### PR TITLE
feat: add AnimationPlayer support with full read/write capability

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,7 +4,13 @@
       "release-type": "node",
       "package-name": "@satelliteoflove/godot-mcp",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "godot/addons/godot_mcp/plugin.cfg"
+        }
+      ]
     }
   }
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,8 +40,8 @@ Core implementation complete, published to npm as [@satelliteoflove/godot-mcp](h
 ## TODO
 
 ### P2 - Nice to Have
-- [ ] Resource assignment (scripts, materials, PackedScenes) - fix the bug from upstream
-- [ ] Animation support (AnimationPlayer read/write)
+- [x] Resource assignment (scripts, materials, PackedScenes)
+- [x] Animation support (AnimationPlayer read/write)
 - [x] Screenshot capture for visual AI context
 - [ ] TileMap/GridMap editing
 

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -15,6 +15,7 @@ func setup(_plugin: EditorPlugin) -> void:
 	_register_handler(MCPFileCommands.new())
 	_register_handler(MCPDebugCommands.new())
 	_register_handler(MCPScreenshotCommands.new())
+	_register_handler(MCPAnimationCommands.new())
 
 
 func _register_handler(handler: MCPBaseCommand) -> void:

--- a/godot/addons/godot_mcp/commands/animation_commands.gd
+++ b/godot/addons/godot_mcp/commands/animation_commands.gd
@@ -1,0 +1,734 @@
+@tool
+extends MCPBaseCommand
+class_name MCPAnimationCommands
+
+
+const TRACK_TYPE_MAP := {
+	"value": Animation.TYPE_VALUE,
+	"position_3d": Animation.TYPE_POSITION_3D,
+	"rotation_3d": Animation.TYPE_ROTATION_3D,
+	"scale_3d": Animation.TYPE_SCALE_3D,
+	"blend_shape": Animation.TYPE_BLEND_SHAPE,
+	"method": Animation.TYPE_METHOD,
+	"bezier": Animation.TYPE_BEZIER,
+	"audio": Animation.TYPE_AUDIO,
+	"animation": Animation.TYPE_ANIMATION
+}
+
+const LOOP_MODE_MAP := {
+	"none": Animation.LOOP_NONE,
+	"linear": Animation.LOOP_LINEAR,
+	"pingpong": Animation.LOOP_PINGPONG
+}
+
+
+func get_commands() -> Dictionary:
+	return {
+		"list_animation_players": list_animation_players,
+		"get_animation_player_info": get_animation_player_info,
+		"get_animation_details": get_animation_details,
+		"get_track_keyframes": get_track_keyframes,
+		"play_animation": play_animation,
+		"stop_animation": stop_animation,
+		"pause_animation": pause_animation,
+		"seek_animation": seek_animation,
+		"queue_animation": queue_animation,
+		"clear_animation_queue": clear_animation_queue,
+		"create_animation": create_animation,
+		"delete_animation": delete_animation,
+		"rename_animation": rename_animation,
+		"update_animation_properties": update_animation_properties,
+		"add_animation_track": add_animation_track,
+		"remove_animation_track": remove_animation_track,
+		"add_keyframe": add_keyframe,
+		"remove_keyframe": remove_keyframe,
+		"update_keyframe": update_keyframe
+	}
+
+
+func _get_animation_player(node_path: String) -> AnimationPlayer:
+	var node := _get_node(node_path)
+	if not node:
+		return null
+	if not node is AnimationPlayer:
+		return null
+	return node as AnimationPlayer
+
+
+func _get_animation(player: AnimationPlayer, anim_name: String) -> Animation:
+	if not player.has_animation(anim_name):
+		return null
+	return player.get_animation(anim_name)
+
+
+func _track_type_to_string(track_type: int) -> String:
+	for key in TRACK_TYPE_MAP:
+		if TRACK_TYPE_MAP[key] == track_type:
+			return key
+	return "unknown"
+
+
+func _loop_mode_to_string(loop_mode: int) -> String:
+	for key in LOOP_MODE_MAP:
+		if LOOP_MODE_MAP[key] == loop_mode:
+			return key
+	return "none"
+
+
+func _find_animation_players(node: Node, result: Array) -> void:
+	if node is AnimationPlayer:
+		result.append({
+			"path": str(node.get_path()),
+			"name": node.name
+		})
+	for child in node.get_children():
+		_find_animation_players(child, result)
+
+
+func list_animation_players(params: Dictionary) -> Dictionary:
+	var root_path: String = params.get("root_path", "")
+	var root: Node
+
+	if root_path.is_empty():
+		root = EditorInterface.get_edited_scene_root()
+	else:
+		root = _get_node(root_path)
+
+	if not root:
+		return _error("NODE_NOT_FOUND", "Root node not found")
+
+	var players := []
+	_find_animation_players(root, players)
+
+	return _success({"animation_players": players})
+
+
+func get_animation_player_info(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer: %s" % node_path)
+
+	var libraries := {}
+	for lib_name in player.get_animation_library_list():
+		var lib := player.get_animation_library(lib_name)
+		libraries[lib_name] = Array(lib.get_animation_list())
+
+	return _success({
+		"current_animation": player.current_animation,
+		"is_playing": player.is_playing(),
+		"current_position": player.current_animation_position,
+		"speed_scale": player.speed_scale,
+		"libraries": libraries,
+		"animation_count": player.get_animation_list().size()
+	})
+
+
+func get_animation_details(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	var tracks := []
+	for i in range(anim.get_track_count()):
+		tracks.append({
+			"index": i,
+			"type": _track_type_to_string(anim.track_get_type(i)),
+			"path": str(anim.track_get_path(i)),
+			"interpolation": anim.track_get_interpolation_type(i),
+			"keyframe_count": anim.track_get_key_count(i)
+		})
+
+	var lib_name := ""
+	var pure_name := anim_name
+	if "/" in anim_name:
+		var parts := anim_name.split("/", true, 1)
+		lib_name = parts[0]
+		pure_name = parts[1]
+
+	return _success({
+		"name": pure_name,
+		"library": lib_name,
+		"length": anim.length,
+		"loop_mode": _loop_mode_to_string(anim.loop_mode),
+		"step": anim.step,
+		"track_count": anim.get_track_count(),
+		"tracks": tracks
+	})
+
+
+func get_track_keyframes(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var track_index: int = params.get("track_index", -1)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+	if track_index < 0:
+		return _error("INVALID_PARAMS", "track_index is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	if track_index >= anim.get_track_count():
+		return _error("TRACK_NOT_FOUND", "Track index out of range: %d" % track_index)
+
+	var keyframes := []
+	var track_type := anim.track_get_type(track_index)
+
+	for i in range(anim.track_get_key_count(track_index)):
+		var kf := {
+			"time": anim.track_get_key_time(track_index, i),
+			"transition": anim.track_get_key_transition(track_index, i)
+		}
+
+		match track_type:
+			Animation.TYPE_METHOD:
+				kf["method"] = anim.method_track_get_name(track_index, i)
+				kf["args"] = anim.method_track_get_params(track_index, i)
+			Animation.TYPE_BEZIER:
+				kf["value"] = anim.bezier_track_get_key_value(track_index, i)
+				kf["in_handle"] = _serialize_value(anim.bezier_track_get_key_in_handle(track_index, i))
+				kf["out_handle"] = _serialize_value(anim.bezier_track_get_key_out_handle(track_index, i))
+			_:
+				kf["value"] = _serialize_value(anim.track_get_key_value(track_index, i))
+
+		keyframes.append(kf)
+
+	return _success({
+		"track_path": str(anim.track_get_path(track_index)),
+		"track_type": _track_type_to_string(track_type),
+		"keyframes": keyframes
+	})
+
+
+func play_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var custom_blend: float = params.get("custom_blend", -1.0)
+	var custom_speed: float = params.get("custom_speed", 1.0)
+	var from_end: bool = params.get("from_end", false)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	if not player.has_animation(anim_name):
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	player.play(anim_name, custom_blend, custom_speed, from_end)
+
+	return _success({"playing": anim_name, "from_position": player.current_animation_position})
+
+
+func stop_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var keep_state: bool = params.get("keep_state", false)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	player.stop(keep_state)
+
+	return _success({"stopped": true})
+
+
+func pause_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var paused: bool = params.get("paused", true)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("paused"):
+		return _error("INVALID_PARAMS", "paused is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	player.set_paused(paused)
+
+	return _success({"paused": paused})
+
+
+func seek_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var seconds: float = params.get("seconds", 0.0)
+	var update: bool = params.get("update", true)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("seconds"):
+		return _error("INVALID_PARAMS", "seconds is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	player.seek(seconds, update)
+
+	return _success({"position": player.current_animation_position})
+
+
+func queue_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	if not player.has_animation(anim_name):
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	player.queue(anim_name)
+
+	return _success({"queued": anim_name, "queue_length": player.get_queue().size()})
+
+
+func clear_animation_queue(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	player.clear_queue()
+
+	return _success({"cleared": true})
+
+
+func create_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var lib_name: String = params.get("library_name", "")
+	var length: float = params.get("length", 1.0)
+	var loop_mode: String = params.get("loop_mode", "none")
+	var step: float = params.get("step", 0.1)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var lib: AnimationLibrary
+	if player.has_animation_library(lib_name):
+		lib = player.get_animation_library(lib_name)
+	else:
+		lib = AnimationLibrary.new()
+		player.add_animation_library(lib_name, lib)
+
+	if lib.has_animation(anim_name):
+		return _error("ANIMATION_EXISTS", "Animation already exists: %s" % anim_name)
+
+	var anim := Animation.new()
+	anim.length = length
+	if LOOP_MODE_MAP.has(loop_mode):
+		anim.loop_mode = LOOP_MODE_MAP[loop_mode]
+	anim.step = step
+
+	var err := lib.add_animation(anim_name, anim)
+	if err != OK:
+		return _error("CREATE_FAILED", "Failed to create animation: %s" % error_string(err))
+
+	return _success({"created": anim_name, "library": lib_name})
+
+
+func delete_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var lib_name: String = params.get("library_name", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	if not player.has_animation_library(lib_name):
+		return _error("LIBRARY_NOT_FOUND", "Animation library not found: %s" % lib_name)
+
+	var lib := player.get_animation_library(lib_name)
+	if not lib.has_animation(anim_name):
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	lib.remove_animation(anim_name)
+
+	return _success({"deleted": anim_name})
+
+
+func rename_animation(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var old_name: String = params.get("old_name", "")
+	var new_name: String = params.get("new_name", "")
+	var lib_name: String = params.get("library_name", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if old_name.is_empty():
+		return _error("INVALID_PARAMS", "old_name is required")
+	if new_name.is_empty():
+		return _error("INVALID_PARAMS", "new_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	if not player.has_animation_library(lib_name):
+		return _error("LIBRARY_NOT_FOUND", "Animation library not found: %s" % lib_name)
+
+	var lib := player.get_animation_library(lib_name)
+	if not lib.has_animation(old_name):
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % old_name)
+
+	if lib.has_animation(new_name):
+		return _error("ANIMATION_EXISTS", "Animation already exists: %s" % new_name)
+
+	lib.rename_animation(old_name, new_name)
+
+	return _success({"renamed": {"from": old_name, "to": new_name}})
+
+
+func update_animation_properties(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	var updated := {}
+
+	if params.has("length"):
+		anim.length = params["length"]
+		updated["length"] = anim.length
+
+	if params.has("loop_mode"):
+		var loop_str: String = params["loop_mode"]
+		if LOOP_MODE_MAP.has(loop_str):
+			anim.loop_mode = LOOP_MODE_MAP[loop_str]
+			updated["loop_mode"] = loop_str
+
+	if params.has("step"):
+		anim.step = params["step"]
+		updated["step"] = anim.step
+
+	return _success({"updated": anim_name, "properties": updated})
+
+
+func add_animation_track(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var track_type: String = params.get("track_type", "")
+	var track_path: String = params.get("track_path", "")
+	var insert_at: int = params.get("insert_at", -1)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+	if track_type.is_empty():
+		return _error("INVALID_PARAMS", "track_type is required")
+	if track_path.is_empty():
+		return _error("INVALID_PARAMS", "track_path is required")
+
+	if not TRACK_TYPE_MAP.has(track_type):
+		return _error("INVALID_TRACK_TYPE", "Invalid track type: %s. Valid types: %s" % [track_type, ", ".join(TRACK_TYPE_MAP.keys())])
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	var godot_track_type: int = TRACK_TYPE_MAP[track_type]
+	var track_index: int
+
+	if insert_at >= 0:
+		track_index = anim.add_track(godot_track_type, insert_at)
+	else:
+		track_index = anim.add_track(godot_track_type)
+
+	anim.track_set_path(track_index, track_path)
+
+	return _success({
+		"track_index": track_index,
+		"track_path": track_path,
+		"track_type": track_type
+	})
+
+
+func remove_animation_track(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var track_index: int = params.get("track_index", -1)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+	if track_index < 0:
+		return _error("INVALID_PARAMS", "track_index is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	if track_index >= anim.get_track_count():
+		return _error("TRACK_NOT_FOUND", "Track index out of range: %d" % track_index)
+
+	anim.remove_track(track_index)
+
+	return _success({"removed_track": track_index})
+
+
+func add_keyframe(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var track_index: int = params.get("track_index", -1)
+	var time: float = params.get("time", 0.0)
+	var transition: float = params.get("transition", 1.0)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+	if track_index < 0:
+		return _error("INVALID_PARAMS", "track_index is required")
+	if not params.has("time"):
+		return _error("INVALID_PARAMS", "time is required")
+	if not params.has("value"):
+		return _error("INVALID_PARAMS", "value is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	if track_index >= anim.get_track_count():
+		return _error("TRACK_NOT_FOUND", "Track index out of range: %d" % track_index)
+
+	var value = MCPUtils.deserialize_value(params["value"])
+	var track_type := anim.track_get_type(track_index)
+	var key_index: int
+
+	match track_type:
+		Animation.TYPE_BEZIER:
+			key_index = anim.bezier_track_insert_key(track_index, time, value)
+		Animation.TYPE_METHOD:
+			var method_name: String = params.get("method_name", "")
+			var args: Array = params.get("args", [])
+			key_index = anim.method_track_add_key(track_index, time, method_name, args)
+		_:
+			key_index = anim.track_insert_key(track_index, time, value, transition)
+
+	return _success({
+		"keyframe_index": key_index,
+		"time": time,
+		"value": _serialize_value(value)
+	})
+
+
+func remove_keyframe(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var track_index: int = params.get("track_index", -1)
+	var keyframe_index: int = params.get("keyframe_index", -1)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+	if track_index < 0:
+		return _error("INVALID_PARAMS", "track_index is required")
+	if keyframe_index < 0:
+		return _error("INVALID_PARAMS", "keyframe_index is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	if track_index >= anim.get_track_count():
+		return _error("TRACK_NOT_FOUND", "Track index out of range: %d" % track_index)
+
+	if keyframe_index >= anim.track_get_key_count(track_index):
+		return _error("KEYFRAME_NOT_FOUND", "Keyframe index out of range: %d" % keyframe_index)
+
+	anim.track_remove_key(track_index, keyframe_index)
+
+	return _success({"removed_keyframe": keyframe_index, "track_index": track_index})
+
+
+func update_keyframe(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+	var track_index: int = params.get("track_index", -1)
+	var keyframe_index: int = params.get("keyframe_index", -1)
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if anim_name.is_empty():
+		return _error("INVALID_PARAMS", "animation_name is required")
+	if track_index < 0:
+		return _error("INVALID_PARAMS", "track_index is required")
+	if keyframe_index < 0:
+		return _error("INVALID_PARAMS", "keyframe_index is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var anim := _get_animation(player, anim_name)
+	if not anim:
+		return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+
+	if track_index >= anim.get_track_count():
+		return _error("TRACK_NOT_FOUND", "Track index out of range: %d" % track_index)
+
+	if keyframe_index >= anim.track_get_key_count(track_index):
+		return _error("KEYFRAME_NOT_FOUND", "Keyframe index out of range: %d" % keyframe_index)
+
+	var result := {}
+
+	if params.has("time"):
+		var new_time: float = params["time"]
+		var old_value = anim.track_get_key_value(track_index, keyframe_index)
+		var old_transition := anim.track_get_key_transition(track_index, keyframe_index)
+		anim.track_remove_key(track_index, keyframe_index)
+		keyframe_index = anim.track_insert_key(track_index, new_time, old_value, old_transition)
+		result["time"] = new_time
+		result["keyframe_index"] = keyframe_index
+
+	if params.has("value"):
+		var new_value = MCPUtils.deserialize_value(params["value"])
+		anim.track_set_key_value(track_index, keyframe_index, new_value)
+		result["value"] = _serialize_value(new_value)
+
+	if params.has("transition"):
+		var new_transition: float = params["transition"]
+		anim.track_set_key_transition(track_index, keyframe_index, new_transition)
+		result["transition"] = new_transition
+
+	return _success({"updated_keyframe": keyframe_index, "changes": result})

--- a/godot/addons/godot_mcp/commands/animation_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/animation_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://bp2p0xfd1tm1h

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,8 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="0.1.0"
+# x-release-please-start-version
+version="0.1.2"
+# x-release-please-end
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -1,0 +1,517 @@
+import { z } from 'zod';
+import { defineTool } from '../core/define-tool.js';
+import type { AnyToolDefinition } from '../core/types.js';
+
+export const listAnimationPlayers = defineTool({
+  name: 'list_animation_players',
+  description: 'Find all AnimationPlayer nodes in the scene',
+  schema: z.object({
+    root_path: z
+      .string()
+      .optional()
+      .describe('Starting node path, defaults to scene root'),
+  }),
+  async execute({ root_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      animation_players: Array<{ path: string; name: string }>;
+    }>('list_animation_players', { root_path });
+
+    if (result.animation_players.length === 0) {
+      return 'No AnimationPlayer nodes found in scene';
+    }
+    return `Found ${result.animation_players.length} AnimationPlayer(s):\n${result.animation_players.map((p) => `  - ${p.path}`).join('\n')}`;
+  },
+});
+
+export const getAnimationPlayerInfo = defineTool({
+  name: 'get_animation_player_info',
+  description: 'Get AnimationPlayer state and available animations',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      current_animation: string;
+      is_playing: boolean;
+      current_position: number;
+      speed_scale: number;
+      libraries: Record<string, string[]>;
+      animation_count: number;
+    }>('get_animation_player_info', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getAnimationDetails = defineTool({
+  name: 'get_animation_details',
+  description: 'Get detailed information about a specific animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z
+      .string()
+      .describe('Name of animation (format: "library/anim" or just "anim")'),
+  }),
+  async execute({ node_path, animation_name }, { godot }) {
+    const result = await godot.sendCommand<{
+      name: string;
+      library: string;
+      length: number;
+      loop_mode: string;
+      step: number;
+      track_count: number;
+      tracks: Array<{
+        index: number;
+        type: string;
+        path: string;
+        interpolation: number;
+        keyframe_count: number;
+      }>;
+    }>('get_animation_details', { node_path, animation_name });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getTrackKeyframes = defineTool({
+  name: 'get_track_keyframes',
+  description: 'Get all keyframes for a specific track',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation name'),
+    track_index: z.number().describe('Track index'),
+  }),
+  async execute({ node_path, animation_name, track_index }, { godot }) {
+    const result = await godot.sendCommand<{
+      track_path: string;
+      track_type: string;
+      keyframes: Array<{
+        time: number;
+        value?: unknown;
+        transition?: number;
+        method?: string;
+        args?: unknown[];
+        in_handle?: { x: number; y: number };
+        out_handle?: { x: number; y: number };
+      }>;
+    }>('get_track_keyframes', { node_path, animation_name, track_index });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const playAnimation = defineTool({
+  name: 'play_animation',
+  description: 'Play an animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to play'),
+    custom_blend: z
+      .number()
+      .optional()
+      .describe('Custom blend time (-1 for default)'),
+    custom_speed: z
+      .number()
+      .optional()
+      .describe('Custom playback speed (1.0 default)'),
+    from_end: z.boolean().optional().describe('Play from end (for reverse)'),
+  }),
+  async execute(
+    { node_path, animation_name, custom_blend, custom_speed, from_end },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      playing: string;
+      from_position: number;
+    }>('play_animation', {
+      node_path,
+      animation_name,
+      custom_blend,
+      custom_speed,
+      from_end,
+    });
+
+    return `Playing animation: ${result.playing}`;
+  },
+});
+
+export const stopAnimation = defineTool({
+  name: 'stop_animation',
+  description: 'Stop current animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    keep_state: z
+      .boolean()
+      .optional()
+      .describe('Keep current animation state (default false)'),
+  }),
+  async execute({ node_path, keep_state }, { godot }) {
+    await godot.sendCommand('stop_animation', { node_path, keep_state });
+    return 'Animation stopped';
+  },
+});
+
+export const pauseAnimation = defineTool({
+  name: 'pause_animation',
+  description: 'Pause/unpause animation playback',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    paused: z.boolean().describe('True to pause, false to unpause'),
+  }),
+  async execute({ node_path, paused }, { godot }) {
+    await godot.sendCommand('pause_animation', { node_path, paused });
+    return paused ? 'Animation paused' : 'Animation unpaused';
+  },
+});
+
+export const seekAnimation = defineTool({
+  name: 'seek_animation',
+  description: 'Seek to a specific position in the animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    seconds: z.number().describe('Position to seek to'),
+    update: z
+      .boolean()
+      .optional()
+      .describe('Update node immediately (default true)'),
+  }),
+  async execute({ node_path, seconds, update }, { godot }) {
+    const result = await godot.sendCommand<{ position: number }>(
+      'seek_animation',
+      { node_path, seconds, update }
+    );
+    return `Seeked to position: ${result.position}`;
+  },
+});
+
+export const queueAnimation = defineTool({
+  name: 'queue_animation',
+  description: 'Queue an animation to play after current one finishes',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to queue'),
+  }),
+  async execute({ node_path, animation_name }, { godot }) {
+    const result = await godot.sendCommand<{
+      queued: string;
+      queue_length: number;
+    }>('queue_animation', { node_path, animation_name });
+    return `Queued animation: ${result.queued} (queue length: ${result.queue_length})`;
+  },
+});
+
+export const clearAnimationQueue = defineTool({
+  name: 'clear_animation_queue',
+  description: 'Clear the animation queue',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+  }),
+  async execute({ node_path }, { godot }) {
+    await godot.sendCommand('clear_animation_queue', { node_path });
+    return 'Animation queue cleared';
+  },
+});
+
+export const createAnimation = defineTool({
+  name: 'create_animation',
+  description: 'Create a new animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Name for new animation'),
+    library_name: z
+      .string()
+      .optional()
+      .describe('Library to add to (default "")'),
+    length: z
+      .number()
+      .optional()
+      .describe('Animation length in seconds (default 1.0)'),
+    loop_mode: z
+      .enum(['none', 'linear', 'pingpong'])
+      .optional()
+      .describe('Loop mode (default "none")'),
+    step: z.number().optional().describe('Step value for keyframe snapping'),
+  }),
+  async execute(
+    { node_path, animation_name, library_name, length, loop_mode, step },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{ created: string; library: string }>(
+      'create_animation',
+      { node_path, animation_name, library_name, length, loop_mode, step }
+    );
+    return `Created animation: ${result.created}${result.library ? ` in library: ${result.library}` : ''}`;
+  },
+});
+
+export const deleteAnimation = defineTool({
+  name: 'delete_animation',
+  description: 'Delete an animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to delete'),
+    library_name: z
+      .string()
+      .optional()
+      .describe('Library containing animation'),
+  }),
+  async execute({ node_path, animation_name, library_name }, { godot }) {
+    const result = await godot.sendCommand<{ deleted: string }>(
+      'delete_animation',
+      { node_path, animation_name, library_name }
+    );
+    return `Deleted animation: ${result.deleted}`;
+  },
+});
+
+export const renameAnimation = defineTool({
+  name: 'rename_animation',
+  description: 'Rename an animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    old_name: z.string().describe('Current animation name'),
+    new_name: z.string().describe('New animation name'),
+    library_name: z
+      .string()
+      .optional()
+      .describe('Library containing animation'),
+  }),
+  async execute({ node_path, old_name, new_name, library_name }, { godot }) {
+    const result = await godot.sendCommand<{
+      renamed: { from: string; to: string };
+    }>('rename_animation', { node_path, old_name, new_name, library_name });
+    return `Renamed animation: ${result.renamed.from} -> ${result.renamed.to}`;
+  },
+});
+
+export const updateAnimationProperties = defineTool({
+  name: 'update_animation_properties',
+  description: 'Update animation properties (length, loop mode, step)',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to update'),
+    length: z.number().optional().describe('New length'),
+    loop_mode: z
+      .enum(['none', 'linear', 'pingpong'])
+      .optional()
+      .describe('New loop mode'),
+    step: z.number().optional().describe('New step value'),
+  }),
+  async execute(
+    { node_path, animation_name, length, loop_mode, step },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      updated: string;
+      properties: Record<string, unknown>;
+    }>('update_animation_properties', {
+      node_path,
+      animation_name,
+      length,
+      loop_mode,
+      step,
+    });
+    return `Updated animation: ${result.updated}\nProperties: ${JSON.stringify(result.properties)}`;
+  },
+});
+
+export const addAnimationTrack = defineTool({
+  name: 'add_animation_track',
+  description: 'Add a new track to an animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to modify'),
+    track_type: z
+      .enum([
+        'value',
+        'position_3d',
+        'rotation_3d',
+        'scale_3d',
+        'blend_shape',
+        'method',
+        'bezier',
+        'audio',
+        'animation',
+      ])
+      .describe('Type of track'),
+    track_path: z
+      .string()
+      .describe('Node path and property (e.g., "Sprite2D:frame")'),
+    insert_at: z
+      .number()
+      .optional()
+      .describe('Track index to insert at (-1 for end)'),
+  }),
+  async execute(
+    { node_path, animation_name, track_type, track_path, insert_at },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      track_index: number;
+      track_path: string;
+      track_type: string;
+    }>('add_animation_track', {
+      node_path,
+      animation_name,
+      track_type,
+      track_path,
+      insert_at,
+    });
+    return `Added track ${result.track_index}: ${result.track_type} -> ${result.track_path}`;
+  },
+});
+
+export const removeAnimationTrack = defineTool({
+  name: 'remove_animation_track',
+  description: 'Remove a track from an animation',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to modify'),
+    track_index: z.number().describe('Index of track to remove'),
+  }),
+  async execute({ node_path, animation_name, track_index }, { godot }) {
+    const result = await godot.sendCommand<{ removed_track: number }>(
+      'remove_animation_track',
+      { node_path, animation_name, track_index }
+    );
+    return `Removed track: ${result.removed_track}`;
+  },
+});
+
+export const addKeyframe = defineTool({
+  name: 'add_keyframe',
+  description: 'Add a keyframe to a track',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to modify'),
+    track_index: z.number().describe('Track index'),
+    time: z.number().describe('Keyframe time in seconds'),
+    value: z.unknown().describe('Keyframe value (type depends on track type)'),
+    transition: z
+      .number()
+      .optional()
+      .describe('Transition curve (1.0 = linear)'),
+    method_name: z
+      .string()
+      .optional()
+      .describe('Method name (for method tracks)'),
+    args: z.array(z.unknown()).optional().describe('Method arguments'),
+  }),
+  async execute(
+    {
+      node_path,
+      animation_name,
+      track_index,
+      time,
+      value,
+      transition,
+      method_name,
+      args,
+    },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      keyframe_index: number;
+      time: number;
+      value: unknown;
+    }>('add_keyframe', {
+      node_path,
+      animation_name,
+      track_index,
+      time,
+      value,
+      transition,
+      method_name,
+      args,
+    });
+    return `Added keyframe ${result.keyframe_index} at ${result.time}s`;
+  },
+});
+
+export const removeKeyframe = defineTool({
+  name: 'remove_keyframe',
+  description: 'Remove a keyframe from a track',
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to modify'),
+    track_index: z.number().describe('Track index'),
+    keyframe_index: z.number().describe('Index of keyframe to remove'),
+  }),
+  async execute(
+    { node_path, animation_name, track_index, keyframe_index },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      removed_keyframe: number;
+      track_index: number;
+    }>('remove_keyframe', {
+      node_path,
+      animation_name,
+      track_index,
+      keyframe_index,
+    });
+    return `Removed keyframe ${result.removed_keyframe} from track ${result.track_index}`;
+  },
+});
+
+export const updateKeyframe = defineTool({
+  name: 'update_keyframe',
+  description: "Update an existing keyframe's value or time",
+  schema: z.object({
+    node_path: z.string().describe('Path to AnimationPlayer'),
+    animation_name: z.string().describe('Animation to modify'),
+    track_index: z.number().describe('Track index'),
+    keyframe_index: z.number().describe('Keyframe index'),
+    time: z.number().optional().describe('New time'),
+    value: z.unknown().optional().describe('New value'),
+    transition: z.number().optional().describe('New transition curve'),
+  }),
+  async execute(
+    {
+      node_path,
+      animation_name,
+      track_index,
+      keyframe_index,
+      time,
+      value,
+      transition,
+    },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      updated_keyframe: number;
+      changes: Record<string, unknown>;
+    }>('update_keyframe', {
+      node_path,
+      animation_name,
+      track_index,
+      keyframe_index,
+      time,
+      value,
+      transition,
+    });
+    return `Updated keyframe ${result.updated_keyframe}: ${JSON.stringify(result.changes)}`;
+  },
+});
+
+export const animationTools = [
+  listAnimationPlayers,
+  getAnimationPlayerInfo,
+  getAnimationDetails,
+  getTrackKeyframes,
+  playAnimation,
+  stopAnimation,
+  pauseAnimation,
+  seekAnimation,
+  queueAnimation,
+  clearAnimationQueue,
+  createAnimation,
+  deleteAnimation,
+  renameAnimation,
+  updateAnimationProperties,
+  addAnimationTrack,
+  removeAnimationTrack,
+  addKeyframe,
+  removeKeyframe,
+  updateKeyframe,
+] as AnyToolDefinition[];

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -5,6 +5,7 @@ import { scriptTools } from './script.js';
 import { editorTools } from './editor.js';
 import { projectTools } from './project.js';
 import { screenshotTools } from './screenshot.js';
+import { animationTools } from './animation.js';
 
 export function registerAllTools(): void {
   registry.registerTools(sceneTools);
@@ -13,6 +14,7 @@ export function registerAllTools(): void {
   registry.registerTools(editorTools);
   registry.registerTools(projectTools);
   registry.registerTools(screenshotTools);
+  registry.registerTools(animationTools);
 }
 
 export { sceneTools } from './scene.js';
@@ -21,3 +23,4 @@ export { scriptTools } from './script.js';
 export { editorTools } from './editor.js';
 export { projectTools } from './project.js';
 export { screenshotTools } from './screenshot.js';
+export { animationTools } from './animation.js';


### PR DESCRIPTION
## Summary

Adds comprehensive AnimationPlayer support to godot-mcp with 19 new MCP tools:

- **Inspection (4)**: list_animation_players, get_animation_player_info, get_animation_details, get_track_keyframes
- **Playback (6)**: play, stop, pause, seek, queue, clear_animation_queue
- **Animation CRUD (4)**: create, delete, rename, update_animation_properties
- **Track CRUD (5)**: add/remove tracks, add/remove/update keyframes

Also:
- Syncs plugin.cfg version to 0.1.2
- Configures release-please to auto-sync plugin.cfg version on releases

## Files Changed

- `godot/addons/godot_mcp/commands/animation_commands.gd` - New GDScript command handlers
- `server/src/tools/animation.ts` - New TypeScript MCP tool definitions
- `godot/addons/godot_mcp/command_router.gd` - Register animation commands
- `server/src/tools/index.ts` - Register animation tools
- `ROADMAP.md` - Mark animation support complete
- `godot/addons/godot_mcp/plugin.cfg` - Sync version + add release-please annotations
- `.github/release-please-config.json` - Add extra-files for plugin.cfg

## Test Plan

- [x] list_animation_players - Found AnimPlayer node
- [x] get_animation_player_info - Shows state, libraries, is_playing
- [x] create_animation - Created 2s looping animation
- [x] add_animation_track - Added value track for modulate property
- [x] add_keyframe - Added 3 color keyframes (red->green->blue)
- [x] get_animation_details - Shows length, loop_mode, tracks
- [x] get_track_keyframes - Returns all keyframe data with values
- [x] play_animation - Animation plays and loops correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)