### PR TITLE
feat: add TileMapLayer and GridMap editing support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ Core implementation complete, published to npm as [@satelliteoflove/godot-mcp](h
 - [x] Resource assignment (scripts, materials, PackedScenes)
 - [x] Animation support (AnimationPlayer read/write)
 - [x] Screenshot capture for visual AI context
-- [ ] TileMap/GridMap editing
+- [x] TileMap/GridMap editing (TileMapLayer and GridMap read/write)
 
 ### Quality
 - [ ] Comprehensive unit tests (see [#1](https://github.com/satelliteoflove/godot-mcp/issues/1))

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -16,6 +16,7 @@ func setup(_plugin: EditorPlugin) -> void:
 	_register_handler(MCPDebugCommands.new())
 	_register_handler(MCPScreenshotCommands.new())
 	_register_handler(MCPAnimationCommands.new())
+	_register_handler(MCPTilemapCommands.new())
 
 
 func _register_handler(handler: MCPBaseCommand) -> void:

--- a/godot/addons/godot_mcp/commands/tilemap_commands.gd
+++ b/godot/addons/godot_mcp/commands/tilemap_commands.gd
@@ -1,0 +1,657 @@
+@tool
+extends MCPBaseCommand
+class_name MCPTilemapCommands
+
+
+func get_commands() -> Dictionary:
+	return {
+		"list_tilemap_layers": list_tilemap_layers,
+		"get_tilemap_layer_info": get_tilemap_layer_info,
+		"get_tileset_info": get_tileset_info,
+		"get_used_cells": get_used_cells,
+		"get_cell": get_cell,
+		"set_cell": set_cell,
+		"erase_cell": erase_cell,
+		"clear_layer": clear_layer,
+		"get_cells_in_region": get_cells_in_region,
+		"set_cells_batch": set_cells_batch,
+		"convert_coords": convert_coords,
+		"list_gridmaps": list_gridmaps,
+		"get_gridmap_info": get_gridmap_info,
+		"get_meshlib_info": get_meshlib_info,
+		"get_gridmap_used_cells": get_gridmap_used_cells,
+		"get_gridmap_cell": get_gridmap_cell,
+		"set_gridmap_cell": set_gridmap_cell,
+		"clear_gridmap_cell": clear_gridmap_cell,
+		"clear_gridmap": clear_gridmap,
+		"get_cells_by_item": get_cells_by_item,
+		"set_gridmap_cells_batch": set_gridmap_cells_batch,
+	}
+
+
+func _get_tilemap_layer(node_path: String) -> TileMapLayer:
+	var node := _get_node(node_path)
+	if not node:
+		return null
+	if not node is TileMapLayer:
+		return null
+	return node as TileMapLayer
+
+
+func _get_gridmap(node_path: String) -> GridMap:
+	var node := _get_node(node_path)
+	if not node:
+		return null
+	if not node is GridMap:
+		return null
+	return node as GridMap
+
+
+func _find_tilemap_layers(node: Node, result: Array) -> void:
+	if node is TileMapLayer:
+		result.append({
+			"path": str(node.get_path()),
+			"name": node.name
+		})
+	for child in node.get_children():
+		_find_tilemap_layers(child, result)
+
+
+func _find_gridmaps(node: Node, result: Array) -> void:
+	if node is GridMap:
+		result.append({
+			"path": str(node.get_path()),
+			"name": node.name
+		})
+	for child in node.get_children():
+		_find_gridmaps(child, result)
+
+
+func _serialize_vector2i(v: Vector2i) -> Dictionary:
+	return {"x": v.x, "y": v.y}
+
+
+func _serialize_vector3i(v: Vector3i) -> Dictionary:
+	return {"x": v.x, "y": v.y, "z": v.z}
+
+
+func _deserialize_vector2i(d: Dictionary) -> Vector2i:
+	return Vector2i(int(d.get("x", 0)), int(d.get("y", 0)))
+
+
+func _deserialize_vector3i(d: Dictionary) -> Vector3i:
+	return Vector3i(int(d.get("x", 0)), int(d.get("y", 0)), int(d.get("z", 0)))
+
+
+func list_tilemap_layers(params: Dictionary) -> Dictionary:
+	var root_path: String = params.get("root_path", "")
+	var root: Node
+
+	if root_path.is_empty():
+		root = EditorInterface.get_edited_scene_root()
+	else:
+		root = _get_node(root_path)
+
+	if not root:
+		return _error("NODE_NOT_FOUND", "Root node not found")
+
+	var layers := []
+	_find_tilemap_layers(root, layers)
+
+	return _success({"tilemap_layers": layers})
+
+
+func get_tilemap_layer_info(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var tileset_path := ""
+	if layer.tile_set:
+		tileset_path = layer.tile_set.resource_path
+
+	return _success({
+		"name": layer.name,
+		"enabled": layer.enabled,
+		"tileset_path": tileset_path,
+		"cell_quadrant_size": layer.rendering_quadrant_size,
+		"collision_enabled": layer.collision_enabled,
+		"used_cells_count": layer.get_used_cells().size()
+	})
+
+
+func get_tileset_info(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	if not layer.tile_set:
+		return _error("NO_TILESET", "TileMapLayer has no TileSet assigned")
+
+	var tileset := layer.tile_set
+	var sources := []
+
+	for i in range(tileset.get_source_count()):
+		var source_id := tileset.get_source_id(i)
+		var source := tileset.get_source(source_id)
+		var source_info := {
+			"source_id": source_id,
+			"source_type": "unknown"
+		}
+
+		if source is TileSetAtlasSource:
+			var atlas := source as TileSetAtlasSource
+			source_info["source_type"] = "atlas"
+			source_info["texture_path"] = atlas.texture.resource_path if atlas.texture else ""
+			source_info["texture_region_size"] = _serialize_vector2i(atlas.texture_region_size)
+			source_info["tile_count"] = atlas.get_tiles_count()
+		elif source is TileSetScenesCollectionSource:
+			source_info["source_type"] = "scenes_collection"
+			var scenes_source := source as TileSetScenesCollectionSource
+			source_info["scene_count"] = scenes_source.get_scene_tiles_count()
+
+		sources.append(source_info)
+
+	return _success({
+		"tileset_path": tileset.resource_path,
+		"tile_size": _serialize_vector2i(tileset.tile_size),
+		"source_count": tileset.get_source_count(),
+		"sources": sources
+	})
+
+
+func get_used_cells(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var cells := layer.get_used_cells()
+	var result := []
+	for cell in cells:
+		result.append(_serialize_vector2i(cell))
+
+	return _success({"cells": result, "count": result.size()})
+
+
+func get_cell(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("coords"):
+		return _error("INVALID_PARAMS", "coords is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var coords := _deserialize_vector2i(params["coords"])
+	var source_id := layer.get_cell_source_id(coords)
+	var atlas_coords := layer.get_cell_atlas_coords(coords)
+	var alt_tile := layer.get_cell_alternative_tile(coords)
+
+	if source_id == -1:
+		return _success({
+			"coords": _serialize_vector2i(coords),
+			"empty": true
+		})
+
+	return _success({
+		"coords": _serialize_vector2i(coords),
+		"empty": false,
+		"source_id": source_id,
+		"atlas_coords": _serialize_vector2i(atlas_coords),
+		"alternative_tile": alt_tile
+	})
+
+
+func set_cell(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("coords"):
+		return _error("INVALID_PARAMS", "coords is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var coords := _deserialize_vector2i(params["coords"])
+	var source_id: int = params.get("source_id", 0)
+	var atlas_coords := Vector2i(0, 0)
+	if params.has("atlas_coords"):
+		atlas_coords = _deserialize_vector2i(params["atlas_coords"])
+	var alt_tile: int = params.get("alternative_tile", 0)
+
+	layer.set_cell(coords, source_id, atlas_coords, alt_tile)
+
+	return _success({
+		"coords": _serialize_vector2i(coords),
+		"source_id": source_id,
+		"atlas_coords": _serialize_vector2i(atlas_coords),
+		"alternative_tile": alt_tile
+	})
+
+
+func erase_cell(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("coords"):
+		return _error("INVALID_PARAMS", "coords is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var coords := _deserialize_vector2i(params["coords"])
+	layer.erase_cell(coords)
+
+	return _success({"erased": _serialize_vector2i(coords)})
+
+
+func clear_layer(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var count := layer.get_used_cells().size()
+	layer.clear()
+
+	return _success({"cleared": true, "cells_removed": count})
+
+
+func get_cells_in_region(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("min_coords"):
+		return _error("INVALID_PARAMS", "min_coords is required")
+	if not params.has("max_coords"):
+		return _error("INVALID_PARAMS", "max_coords is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var min_coords := _deserialize_vector2i(params["min_coords"])
+	var max_coords := _deserialize_vector2i(params["max_coords"])
+
+	var cells := []
+	for cell in layer.get_used_cells():
+		if cell.x >= min_coords.x and cell.x <= max_coords.x and cell.y >= min_coords.y and cell.y <= max_coords.y:
+			var source_id := layer.get_cell_source_id(cell)
+			var atlas_coords := layer.get_cell_atlas_coords(cell)
+			var alt_tile := layer.get_cell_alternative_tile(cell)
+			cells.append({
+				"coords": _serialize_vector2i(cell),
+				"source_id": source_id,
+				"atlas_coords": _serialize_vector2i(atlas_coords),
+				"alternative_tile": alt_tile
+			})
+
+	return _success({"cells": cells, "count": cells.size()})
+
+
+func set_cells_batch(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("cells"):
+		return _error("INVALID_PARAMS", "cells is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	var cells_data: Array = params["cells"]
+	var count := 0
+
+	for cell_data in cells_data:
+		if not cell_data.has("coords"):
+			continue
+		var coords := _deserialize_vector2i(cell_data["coords"])
+		var source_id: int = cell_data.get("source_id", 0)
+		var atlas_coords := Vector2i(0, 0)
+		if cell_data.has("atlas_coords"):
+			atlas_coords = _deserialize_vector2i(cell_data["atlas_coords"])
+		var alt_tile: int = cell_data.get("alternative_tile", 0)
+
+		layer.set_cell(coords, source_id, atlas_coords, alt_tile)
+		count += 1
+
+	return _success({"cells_set": count})
+
+
+func convert_coords(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var layer := _get_tilemap_layer(node_path)
+	if not layer:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
+
+	if params.has("local_position"):
+		var local_pos_data: Dictionary = params["local_position"]
+		var local_pos := Vector2(local_pos_data.get("x", 0.0), local_pos_data.get("y", 0.0))
+		var map_coords := layer.local_to_map(local_pos)
+		return _success({
+			"direction": "local_to_map",
+			"local_position": {"x": local_pos.x, "y": local_pos.y},
+			"map_coords": _serialize_vector2i(map_coords)
+		})
+	elif params.has("map_coords"):
+		var map_coords := _deserialize_vector2i(params["map_coords"])
+		var local_pos := layer.map_to_local(map_coords)
+		return _success({
+			"direction": "map_to_local",
+			"map_coords": _serialize_vector2i(map_coords),
+			"local_position": {"x": local_pos.x, "y": local_pos.y}
+		})
+	else:
+		return _error("INVALID_PARAMS", "Either local_position or map_coords is required")
+
+
+func list_gridmaps(params: Dictionary) -> Dictionary:
+	var root_path: String = params.get("root_path", "")
+	var root: Node
+
+	if root_path.is_empty():
+		root = EditorInterface.get_edited_scene_root()
+	else:
+		root = _get_node(root_path)
+
+	if not root:
+		return _error("NODE_NOT_FOUND", "Root node not found")
+
+	var gridmaps := []
+	_find_gridmaps(root, gridmaps)
+
+	return _success({"gridmaps": gridmaps})
+
+
+func get_gridmap_info(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var meshlib_path := ""
+	if gridmap.mesh_library:
+		meshlib_path = gridmap.mesh_library.resource_path
+
+	return _success({
+		"name": gridmap.name,
+		"mesh_library_path": meshlib_path,
+		"cell_size": _serialize_value(gridmap.cell_size),
+		"cell_center_x": gridmap.cell_center_x,
+		"cell_center_y": gridmap.cell_center_y,
+		"cell_center_z": gridmap.cell_center_z,
+		"used_cells_count": gridmap.get_used_cells().size()
+	})
+
+
+func get_meshlib_info(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	if not gridmap.mesh_library:
+		return _error("NO_MESH_LIBRARY", "GridMap has no MeshLibrary assigned")
+
+	var meshlib := gridmap.mesh_library
+	var items := []
+
+	for i in range(meshlib.get_item_list().size()):
+		var item_id: int = meshlib.get_item_list()[i]
+		var item_name := meshlib.get_item_name(item_id)
+		var mesh := meshlib.get_item_mesh(item_id)
+		var mesh_path := mesh.resource_path if mesh else ""
+
+		items.append({
+			"index": item_id,
+			"name": item_name,
+			"mesh_path": mesh_path
+		})
+
+	return _success({
+		"mesh_library_path": meshlib.resource_path,
+		"item_count": meshlib.get_item_list().size(),
+		"items": items
+	})
+
+
+func get_gridmap_used_cells(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var cells := gridmap.get_used_cells()
+	var result := []
+	for cell in cells:
+		result.append(_serialize_vector3i(cell))
+
+	return _success({"cells": result, "count": result.size()})
+
+
+func get_gridmap_cell(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("coords"):
+		return _error("INVALID_PARAMS", "coords is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var coords := _deserialize_vector3i(params["coords"])
+	var item := gridmap.get_cell_item(coords)
+	var orientation := gridmap.get_cell_item_orientation(coords)
+
+	if item == GridMap.INVALID_CELL_ITEM:
+		return _success({
+			"coords": _serialize_vector3i(coords),
+			"empty": true
+		})
+
+	var item_name := ""
+	if gridmap.mesh_library:
+		item_name = gridmap.mesh_library.get_item_name(item)
+
+	return _success({
+		"coords": _serialize_vector3i(coords),
+		"empty": false,
+		"item": item,
+		"item_name": item_name,
+		"orientation": orientation
+	})
+
+
+func set_gridmap_cell(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("coords"):
+		return _error("INVALID_PARAMS", "coords is required")
+	if not params.has("item"):
+		return _error("INVALID_PARAMS", "item is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var coords := _deserialize_vector3i(params["coords"])
+	var item: int = params["item"]
+	var orientation: int = params.get("orientation", 0)
+
+	gridmap.set_cell_item(coords, item, orientation)
+
+	return _success({
+		"coords": _serialize_vector3i(coords),
+		"item": item,
+		"orientation": orientation
+	})
+
+
+func clear_gridmap_cell(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("coords"):
+		return _error("INVALID_PARAMS", "coords is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var coords := _deserialize_vector3i(params["coords"])
+	gridmap.set_cell_item(coords, GridMap.INVALID_CELL_ITEM)
+
+	return _success({"cleared": _serialize_vector3i(coords)})
+
+
+func clear_gridmap(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var count := gridmap.get_used_cells().size()
+	gridmap.clear()
+
+	return _success({"cleared": true, "cells_removed": count})
+
+
+func get_cells_by_item(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("item"):
+		return _error("INVALID_PARAMS", "item is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var item: int = params["item"]
+	var cells := gridmap.get_used_cells_by_item(item)
+	var result := []
+	for cell in cells:
+		result.append(_serialize_vector3i(cell))
+
+	return _success({"item": item, "cells": result, "count": result.size()})
+
+
+func set_gridmap_cells_batch(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+	if not params.has("cells"):
+		return _error("INVALID_PARAMS", "cells is required")
+
+	var gridmap := _get_gridmap(node_path)
+	if not gridmap:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
+
+	var cells_data: Array = params["cells"]
+	var count := 0
+
+	for cell_data in cells_data:
+		if not cell_data.has("coords") or not cell_data.has("item"):
+			continue
+		var coords := _deserialize_vector3i(cell_data["coords"])
+		var item: int = cell_data["item"]
+		var orientation: int = cell_data.get("orientation", 0)
+
+		gridmap.set_cell_item(coords, item, orientation)
+		count += 1
+
+	return _success({"cells_set": count})

--- a/godot/addons/godot_mcp/commands/tilemap_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/tilemap_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://0hpst23ps31k

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,8 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-# x-release-please-start-version
-version="0.1.2"
-# x-release-please-end
+version="0.1.3"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -6,6 +6,7 @@ import { editorTools } from './editor.js';
 import { projectTools } from './project.js';
 import { screenshotTools } from './screenshot.js';
 import { animationTools } from './animation.js';
+import { tilemapTools } from './tilemap.js';
 
 export function registerAllTools(): void {
   registry.registerTools(sceneTools);
@@ -15,6 +16,7 @@ export function registerAllTools(): void {
   registry.registerTools(projectTools);
   registry.registerTools(screenshotTools);
   registry.registerTools(animationTools);
+  registry.registerTools(tilemapTools);
 }
 
 export { sceneTools } from './scene.js';
@@ -24,3 +26,4 @@ export { editorTools } from './editor.js';
 export { projectTools } from './project.js';
 export { screenshotTools } from './screenshot.js';
 export { animationTools } from './animation.js';
+export { tilemapTools } from './tilemap.js';

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -1,0 +1,478 @@
+import { z } from 'zod';
+import { defineTool } from '../core/define-tool.js';
+import type { AnyToolDefinition } from '../core/types.js';
+
+const Vector2iSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+});
+
+const Vector3iSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  z: z.number().int(),
+});
+
+export const listTilemapLayers = defineTool({
+  name: 'list_tilemap_layers',
+  description: 'Find all TileMapLayer nodes in the scene',
+  schema: z.object({
+    root_path: z
+      .string()
+      .optional()
+      .describe('Starting node path, defaults to scene root'),
+  }),
+  async execute({ root_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      tilemap_layers: Array<{ path: string; name: string }>;
+    }>('list_tilemap_layers', { root_path });
+
+    if (result.tilemap_layers.length === 0) {
+      return 'No TileMapLayer nodes found in scene';
+    }
+    return `Found ${result.tilemap_layers.length} TileMapLayer(s):\n${result.tilemap_layers.map((l) => `  - ${l.path}`).join('\n')}`;
+  },
+});
+
+export const getTilemapLayerInfo = defineTool({
+  name: 'get_tilemap_layer_info',
+  description: 'Get TileMapLayer properties (tileset, enabled, etc.)',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      name: string;
+      enabled: boolean;
+      tileset_path: string;
+      cell_quadrant_size: number;
+      collision_enabled: boolean;
+      used_cells_count: number;
+    }>('get_tilemap_layer_info', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getTilesetInfo = defineTool({
+  name: 'get_tileset_info',
+  description: 'Get TileSet sources and atlas information',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      tileset_path: string;
+      tile_size: { x: number; y: number };
+      source_count: number;
+      sources: Array<{
+        source_id: number;
+        source_type: string;
+        texture_path?: string;
+        texture_region_size?: { x: number; y: number };
+        tile_count?: number;
+        scene_count?: number;
+      }>;
+    }>('get_tileset_info', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getUsedCells = defineTool({
+  name: 'get_used_cells',
+  description: 'Get all non-empty cell coordinates in a TileMapLayer',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      cells: Array<{ x: number; y: number }>;
+      count: number;
+    }>('get_used_cells', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getCell = defineTool({
+  name: 'get_cell',
+  description: 'Get cell data (source_id, atlas_coords, alternative_tile)',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+    coords: Vector2iSchema.describe('Cell coordinates'),
+  }),
+  async execute({ node_path, coords }, { godot }) {
+    const result = await godot.sendCommand<{
+      coords: { x: number; y: number };
+      empty: boolean;
+      source_id?: number;
+      atlas_coords?: { x: number; y: number };
+      alternative_tile?: number;
+    }>('get_cell', { node_path, coords });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const setCell = defineTool({
+  name: 'set_cell',
+  description: 'Set a cell with tile data',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+    coords: Vector2iSchema.describe('Cell coordinates'),
+    source_id: z.number().int().optional().describe('TileSet source ID (default 0)'),
+    atlas_coords: Vector2iSchema.optional().describe('Atlas coordinates (default 0,0)'),
+    alternative_tile: z
+      .number()
+      .int()
+      .optional()
+      .describe('Alternative tile ID (default 0)'),
+  }),
+  async execute(
+    { node_path, coords, source_id, atlas_coords, alternative_tile },
+    { godot }
+  ) {
+    const result = await godot.sendCommand<{
+      coords: { x: number; y: number };
+      source_id: number;
+      atlas_coords: { x: number; y: number };
+      alternative_tile: number;
+    }>('set_cell', {
+      node_path,
+      coords,
+      source_id,
+      atlas_coords,
+      alternative_tile,
+    });
+
+    return `Set cell at (${result.coords.x}, ${result.coords.y}) with source ${result.source_id}, atlas (${result.atlas_coords.x}, ${result.atlas_coords.y})`;
+  },
+});
+
+export const eraseCell = defineTool({
+  name: 'erase_cell',
+  description: 'Clear a single cell',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+    coords: Vector2iSchema.describe('Cell coordinates to erase'),
+  }),
+  async execute({ node_path, coords }, { godot }) {
+    const result = await godot.sendCommand<{
+      erased: { x: number; y: number };
+    }>('erase_cell', { node_path, coords });
+
+    return `Erased cell at (${result.erased.x}, ${result.erased.y})`;
+  },
+});
+
+export const clearLayer = defineTool({
+  name: 'clear_layer',
+  description: 'Clear all cells in a TileMapLayer',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      cleared: boolean;
+      cells_removed: number;
+    }>('clear_layer', { node_path });
+
+    return `Cleared layer: ${result.cells_removed} cells removed`;
+  },
+});
+
+export const getCellsInRegion = defineTool({
+  name: 'get_cells_in_region',
+  description: 'Get cells within a rectangular region',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+    min_coords: Vector2iSchema.describe('Minimum corner of region'),
+    max_coords: Vector2iSchema.describe('Maximum corner of region'),
+  }),
+  async execute({ node_path, min_coords, max_coords }, { godot }) {
+    const result = await godot.sendCommand<{
+      cells: Array<{
+        coords: { x: number; y: number };
+        source_id: number;
+        atlas_coords: { x: number; y: number };
+        alternative_tile: number;
+      }>;
+      count: number;
+    }>('get_cells_in_region', { node_path, min_coords, max_coords });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const setCellsBatch = defineTool({
+  name: 'set_cells_batch',
+  description: 'Set multiple cells at once',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+    cells: z
+      .array(
+        z.object({
+          coords: Vector2iSchema,
+          source_id: z.number().int().optional(),
+          atlas_coords: Vector2iSchema.optional(),
+          alternative_tile: z.number().int().optional(),
+        })
+      )
+      .describe('Array of cells to set'),
+  }),
+  async execute({ node_path, cells }, { godot }) {
+    const result = await godot.sendCommand<{ cells_set: number }>(
+      'set_cells_batch',
+      { node_path, cells }
+    );
+
+    return `Set ${result.cells_set} cells`;
+  },
+});
+
+export const convertCoords = defineTool({
+  name: 'convert_coords',
+  description: 'Convert between local and map coordinates',
+  schema: z.object({
+    node_path: z.string().describe('Path to TileMapLayer node'),
+    local_position: z
+      .object({ x: z.number(), y: z.number() })
+      .optional()
+      .describe('Local position to convert to map coords'),
+    map_coords: Vector2iSchema.optional().describe(
+      'Map coordinates to convert to local position'
+    ),
+  }),
+  async execute({ node_path, local_position, map_coords }, { godot }) {
+    const result = await godot.sendCommand<{
+      direction: string;
+      local_position?: { x: number; y: number };
+      map_coords?: { x: number; y: number };
+    }>('convert_coords', { node_path, local_position, map_coords });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const listGridmaps = defineTool({
+  name: 'list_gridmaps',
+  description: 'Find all GridMap nodes in the scene',
+  schema: z.object({
+    root_path: z
+      .string()
+      .optional()
+      .describe('Starting node path, defaults to scene root'),
+  }),
+  async execute({ root_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      gridmaps: Array<{ path: string; name: string }>;
+    }>('list_gridmaps', { root_path });
+
+    if (result.gridmaps.length === 0) {
+      return 'No GridMap nodes found in scene';
+    }
+    return `Found ${result.gridmaps.length} GridMap(s):\n${result.gridmaps.map((g) => `  - ${g.path}`).join('\n')}`;
+  },
+});
+
+export const getGridmapInfo = defineTool({
+  name: 'get_gridmap_info',
+  description: 'Get GridMap properties (mesh_library, cell_size, etc.)',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      name: string;
+      mesh_library_path: string;
+      cell_size: { x: number; y: number; z: number };
+      cell_center_x: boolean;
+      cell_center_y: boolean;
+      cell_center_z: boolean;
+      used_cells_count: number;
+    }>('get_gridmap_info', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getMeshlibInfo = defineTool({
+  name: 'get_meshlib_info',
+  description: 'Get MeshLibrary item names and indices',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      mesh_library_path: string;
+      item_count: number;
+      items: Array<{
+        index: number;
+        name: string;
+        mesh_path: string;
+      }>;
+    }>('get_meshlib_info', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getGridmapUsedCells = defineTool({
+  name: 'get_gridmap_used_cells',
+  description: 'Get all non-empty cell coordinates in a GridMap',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      cells: Array<{ x: number; y: number; z: number }>;
+      count: number;
+    }>('get_gridmap_used_cells', { node_path });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const getGridmapCell = defineTool({
+  name: 'get_gridmap_cell',
+  description: 'Get cell data (item index, orientation)',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+    coords: Vector3iSchema.describe('Cell coordinates'),
+  }),
+  async execute({ node_path, coords }, { godot }) {
+    const result = await godot.sendCommand<{
+      coords: { x: number; y: number; z: number };
+      empty: boolean;
+      item?: number;
+      item_name?: string;
+      orientation?: number;
+    }>('get_gridmap_cell', { node_path, coords });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const setGridmapCell = defineTool({
+  name: 'set_gridmap_cell',
+  description: 'Set a cell with an item',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+    coords: Vector3iSchema.describe('Cell coordinates'),
+    item: z.number().int().describe('MeshLibrary item index'),
+    orientation: z
+      .number()
+      .int()
+      .optional()
+      .describe('Orientation (0-23, default 0)'),
+  }),
+  async execute({ node_path, coords, item, orientation }, { godot }) {
+    const result = await godot.sendCommand<{
+      coords: { x: number; y: number; z: number };
+      item: number;
+      orientation: number;
+    }>('set_gridmap_cell', { node_path, coords, item, orientation });
+
+    return `Set cell at (${result.coords.x}, ${result.coords.y}, ${result.coords.z}) with item ${result.item}, orientation ${result.orientation}`;
+  },
+});
+
+export const clearGridmapCell = defineTool({
+  name: 'clear_gridmap_cell',
+  description: 'Clear a single cell',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+    coords: Vector3iSchema.describe('Cell coordinates to clear'),
+  }),
+  async execute({ node_path, coords }, { godot }) {
+    const result = await godot.sendCommand<{
+      cleared: { x: number; y: number; z: number };
+    }>('clear_gridmap_cell', { node_path, coords });
+
+    return `Cleared cell at (${result.cleared.x}, ${result.cleared.y}, ${result.cleared.z})`;
+  },
+});
+
+export const clearGridmap = defineTool({
+  name: 'clear_gridmap',
+  description: 'Clear all cells in a GridMap',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+  }),
+  async execute({ node_path }, { godot }) {
+    const result = await godot.sendCommand<{
+      cleared: boolean;
+      cells_removed: number;
+    }>('clear_gridmap', { node_path });
+
+    return `Cleared GridMap: ${result.cells_removed} cells removed`;
+  },
+});
+
+export const getCellsByItem = defineTool({
+  name: 'get_cells_by_item',
+  description: 'Get all cells containing a specific item',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+    item: z.number().int().describe('MeshLibrary item index to search for'),
+  }),
+  async execute({ node_path, item }, { godot }) {
+    const result = await godot.sendCommand<{
+      item: number;
+      cells: Array<{ x: number; y: number; z: number }>;
+      count: number;
+    }>('get_cells_by_item', { node_path, item });
+
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+export const setGridmapCellsBatch = defineTool({
+  name: 'set_gridmap_cells_batch',
+  description: 'Set multiple cells at once',
+  schema: z.object({
+    node_path: z.string().describe('Path to GridMap node'),
+    cells: z
+      .array(
+        z.object({
+          coords: Vector3iSchema,
+          item: z.number().int(),
+          orientation: z.number().int().optional(),
+        })
+      )
+      .describe('Array of cells to set'),
+  }),
+  async execute({ node_path, cells }, { godot }) {
+    const result = await godot.sendCommand<{ cells_set: number }>(
+      'set_gridmap_cells_batch',
+      { node_path, cells }
+    );
+
+    return `Set ${result.cells_set} cells`;
+  },
+});
+
+export const tilemapTools = [
+  listTilemapLayers,
+  getTilemapLayerInfo,
+  getTilesetInfo,
+  getUsedCells,
+  getCell,
+  setCell,
+  eraseCell,
+  clearLayer,
+  getCellsInRegion,
+  setCellsBatch,
+  convertCoords,
+  listGridmaps,
+  getGridmapInfo,
+  getMeshlibInfo,
+  getGridmapUsedCells,
+  getGridmapCell,
+  setGridmapCell,
+  clearGridmapCell,
+  clearGridmap,
+  getCellsByItem,
+  setGridmapCellsBatch,
+] as AnyToolDefinition[];


### PR DESCRIPTION
## Summary

- Add 21 MCP tools for full read/write access to 2D TileMapLayers and 3D GridMaps
- **TileMapLayer (11 tools)**: list, info, tileset info, get/set/erase cells, batch operations, coordinate conversion
- **GridMap (10 tools)**: list, info, meshlib info, get/set/clear cells, batch operations, filter by item
- Fix plugin.cfg format (removed release-please comments that broke Godot's INI parser)

## Test Plan

### TileMapLayer Tests (all verified)
- [x] list_tilemap_layers finds layers in scene
- [x] get_tilemap_layer_info returns correct properties
- [x] get_used_cells returns occupied coordinates
- [x] get_cell returns correct tile data
- [x] set_cell places tile correctly
- [x] erase_cell removes tile
- [x] clear_layer removes all tiles
- [x] get_cells_in_region returns correct subset
- [x] set_cells_batch places multiple tiles
- [x] convert_coords works (returns 0,0 without tileset assigned)

### GridMap Tests (all verified)
- [x] list_gridmaps finds GridMap nodes
- [x] get_gridmap_info returns correct properties
- [x] get_gridmap_used_cells returns occupied coords
- [x] get_gridmap_cell returns item/orientation
- [x] set_gridmap_cell places item with orientation
- [x] clear_gridmap_cell removes item
- [x] clear_gridmap removes all items
- [x] get_cells_by_item filters correctly
- [x] set_gridmap_cells_batch places multiple items

🤖 Generated with [Claude Code](https://claude.com/claude-code)