### PR TITLE
fix: improve edge case error handling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Core implementation complete, published to npm as [@satelliteoflove/godot-mcp](h
 ### Testing
 - [x] Verify MCP server <-> Godot WebSocket connection
 - [x] Test all tools with real Godot project
-- [ ] Edge cases: no scene open, invalid paths, etc.
+- [x] Edge cases: no scene open, invalid paths, etc.
 
 ## TODO
 

--- a/godot/addons/godot_mcp/commands/node_commands.gd
+++ b/godot/addons/godot_mcp/commands/node_commands.gd
@@ -13,6 +13,13 @@ func get_commands() -> Dictionary:
 	}
 
 
+func _require_scene_open() -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if not root:
+		return _error("NO_SCENE", "No scene is currently open")
+	return {}
+
+
 func get_node_properties(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("node_path", "")
 	if node_path.is_empty():
@@ -36,6 +43,10 @@ func get_node_properties(params: Dictionary) -> Dictionary:
 
 
 func create_node(params: Dictionary) -> Dictionary:
+	var scene_check := _require_scene_open()
+	if not scene_check.is_empty():
+		return scene_check
+
 	var parent_path: String = params.get("parent_path", "")
 	var node_type: String = params.get("node_type", "")
 	var node_name: String = params.get("node_name", "")
@@ -94,6 +105,10 @@ func update_node(params: Dictionary) -> Dictionary:
 
 
 func delete_node(params: Dictionary) -> Dictionary:
+	var scene_check := _require_scene_open()
+	if not scene_check.is_empty():
+		return scene_check
+
 	var node_path: String = params.get("node_path", "")
 	if node_path.is_empty():
 		return _error("INVALID_PARAMS", "node_path is required")
@@ -113,6 +128,10 @@ func delete_node(params: Dictionary) -> Dictionary:
 
 
 func reparent_node(params: Dictionary) -> Dictionary:
+	var scene_check := _require_scene_open()
+	if not scene_check.is_empty():
+		return scene_check
+
 	var node_path: String = params.get("node_path", "")
 	var new_parent_path: String = params.get("new_parent_path", "")
 


### PR DESCRIPTION
## Summary

- Fix null reference crashes when node operations called with no scene open
- Improve TypeScript response handling and env var validation

## Changes

### GDScript (`node_commands.gd`)
- Add `_require_scene_open()` helper function
- Protect `create_node`, `delete_node`, `reparent_node` from null scene root
- Returns clear `NO_SCENE` error instead of crashing

### TypeScript (`websocket.ts`)
- Fix malformed response handling - reject pending requests immediately instead of waiting for 30s timeout
- Add `parsePortEnv()` and `parseHostEnv()` validation helpers
- Invalid `GODOT_PORT` values now log warning and use default

## Test Plan

### Edge Cases Verified
- [x] `delete_node` on root returns `CANNOT_DELETE_ROOT`
- [x] `reparent_node` on root returns `CANNOT_REPARENT_ROOT`
- [x] Invalid node type returns `INVALID_TYPE`

### Valid Operations Verified
- [x] `create_node` creates child with proper owner
- [x] `reparent_node` moves node correctly
- [x] `delete_node` removes non-root node

🤖 Generated with [Claude Code](https://claude.com/claude-code)