### PR TITLE
refactor: consolidate MCP tools and fix Claude Code compatibility

### DIFF
--- a/godot/addons/godot_mcp/commands/animation_commands.gd
+++ b/godot/addons/godot_mcp/commands/animation_commands.gd
@@ -295,7 +295,11 @@ func pause_animation(params: Dictionary) -> Dictionary:
 			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
 		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
 
-	player.set_paused(paused)
+	if paused:
+		player.pause()
+	else:
+		if not player.current_animation.is_empty():
+			player.play()
 
 	return _success({"paused": paused})
 


### PR DESCRIPTION
## Summary

- Consolidate animation, tilemap, and gridmap tools to reduce MCP context consumption
- Fix schema format to use flat object schemas instead of discriminated unions (Claude Code requires `type: "object"` at root, not `anyOf`)
- Fix `pause_animation` to use correct Godot 4.x API

## Changes

### Schema Refactoring
- `animation.ts`: 3 consolidated tools (animation_query, animation_playback, animation_edit) using flat schemas with `.refine()` validation
- `tilemap.ts`: 4 consolidated tools (tilemap_query, tilemap_edit, gridmap_query, gridmap_edit) same pattern
- Added documentation comment in animation.ts explaining the pattern for future contributors

### Bug Fix
- Fixed `pause_animation` in animation_commands.gd - was calling non-existent `player.set_paused()`, now uses `player.pause()` / `player.play()`

## Context Reduction
MCP tools now properly load in Claude Code. Total MCP tool context: ~22.5k tokens for 33 tools.

## Test plan
- [x] All animation_query actions tested (list_players, get_info, get_details, get_keyframes)
- [x] All animation_playback actions tested (play, pause, seek, stop, queue, clear_queue)
- [x] All animation_edit actions tested (create, add_track, add_keyframe, update_keyframe, update_props, remove_keyframe, remove_track, rename, delete)
- [x] All tilemap_query actions tested
- [x] All tilemap_edit actions tested
- [x] All gridmap_query actions tested
- [x] All gridmap_edit actions tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)