### PR TITLE
fix: capture game screenshot and debug output via EditorDebugger

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -6,29 +6,31 @@ var _commands: Dictionary = {}
 var _handlers: Array[MCPBaseCommand] = []
 
 
-func setup(_plugin: EditorPlugin) -> void:
-	_register_handler(MCPSceneCommands.new())
-	_register_handler(MCPNodeCommands.new())
-	_register_handler(MCPScriptCommands.new())
-	_register_handler(MCPSelectionCommands.new())
-	_register_handler(MCPProjectCommands.new())
-	_register_handler(MCPFileCommands.new())
-	_register_handler(MCPDebugCommands.new())
-	_register_handler(MCPScreenshotCommands.new())
-	_register_handler(MCPAnimationCommands.new())
-	_register_handler(MCPTilemapCommands.new())
+func setup(plugin: EditorPlugin) -> void:
+	_register_handler(MCPSceneCommands.new(), plugin)
+	_register_handler(MCPNodeCommands.new(), plugin)
+	_register_handler(MCPScriptCommands.new(), plugin)
+	_register_handler(MCPSelectionCommands.new(), plugin)
+	_register_handler(MCPProjectCommands.new(), plugin)
+	_register_handler(MCPFileCommands.new(), plugin)
+	_register_handler(MCPDebugCommands.new(), plugin)
+	_register_handler(MCPScreenshotCommands.new(), plugin)
+	_register_handler(MCPAnimationCommands.new(), plugin)
+	_register_handler(MCPTilemapCommands.new(), plugin)
 
 
-func _register_handler(handler: MCPBaseCommand) -> void:
+func _register_handler(handler: MCPBaseCommand, plugin: EditorPlugin) -> void:
+	handler.setup(plugin)
 	_handlers.append(handler)
 	var cmds := handler.get_commands()
 	for cmd_name in cmds:
 		_commands[cmd_name] = cmds[cmd_name]
 
 
-func handle_command(command: String, params: Dictionary) -> Dictionary:
+func handle_command(command: String, params: Dictionary):
 	if not _commands.has(command):
 		return MCPUtils.error("UNKNOWN_COMMAND", "Unknown command: %s" % command)
 
 	var callable: Callable = _commands[command]
-	return callable.call(params)
+	var result = await callable.call(params)
+	return result

--- a/godot/addons/godot_mcp/commands/debug_commands.gd
+++ b/godot/addons/godot_mcp/commands/debug_commands.gd
@@ -2,6 +2,11 @@
 extends MCPBaseCommand
 class_name MCPDebugCommands
 
+const DEBUG_OUTPUT_TIMEOUT := 5.0
+
+var _debug_output_result: PackedStringArray = []
+var _debug_output_pending: bool = false
+
 
 func get_commands() -> Dictionary:
 	return {
@@ -31,9 +36,38 @@ func stop_project(_params: Dictionary) -> Dictionary:
 
 func get_debug_output(params: Dictionary) -> Dictionary:
 	var clear: bool = params.get("clear", false)
-	var output := "\n".join(MCPLogger.get_output())
 
-	if clear:
-		MCPLogger.clear()
+	if not EditorInterface.is_playing_scene():
+		var output := "\n".join(MCPLogger.get_output())
+		if clear:
+			MCPLogger.clear()
+		return _success({"output": output})
 
-	return _success({"output": output})
+	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
+	if debugger_plugin == null or not debugger_plugin.has_active_session():
+		var output := "\n".join(MCPLogger.get_output())
+		if clear:
+			MCPLogger.clear()
+		return _success({"output": output})
+
+	_debug_output_pending = true
+	_debug_output_result = PackedStringArray()
+
+	debugger_plugin.debug_output_received.connect(_on_debug_output_received, CONNECT_ONE_SHOT)
+	debugger_plugin.request_debug_output(clear)
+
+	var start_time := Time.get_ticks_msec()
+	while _debug_output_pending:
+		await Engine.get_main_loop().process_frame
+		if (Time.get_ticks_msec() - start_time) / 1000.0 > DEBUG_OUTPUT_TIMEOUT:
+			_debug_output_pending = false
+			if debugger_plugin.debug_output_received.is_connected(_on_debug_output_received):
+				debugger_plugin.debug_output_received.disconnect(_on_debug_output_received)
+			return _success({"output": "\n".join(MCPLogger.get_output())})
+
+	return _success({"output": "\n".join(_debug_output_result)})
+
+
+func _on_debug_output_received(output: PackedStringArray) -> void:
+	_debug_output_pending = false
+	_debug_output_result = output

--- a/godot/addons/godot_mcp/core/base_command.gd
+++ b/godot/addons/godot_mcp/core/base_command.gd
@@ -2,6 +2,12 @@
 class_name MCPBaseCommand
 extends RefCounted
 
+var _plugin: EditorPlugin
+
+
+func setup(plugin: EditorPlugin) -> void:
+	_plugin = plugin
+
 
 func get_commands() -> Dictionary:
 	return {}

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -1,0 +1,88 @@
+@tool
+extends EditorDebuggerPlugin
+class_name MCPDebuggerPlugin
+
+signal screenshot_received(success: bool, image_base64: String, width: int, height: int, error: String)
+signal debug_output_received(output: PackedStringArray)
+
+var _active_session_id: int = -1
+var _pending_screenshot: bool = false
+var _pending_debug_output: bool = false
+
+
+func _has_capture(prefix: String) -> bool:
+	return prefix == "godot_mcp"
+
+
+func _capture(message: String, data: Array, session_id: int) -> bool:
+	match message:
+		"godot_mcp:screenshot_result":
+			_handle_screenshot_result(data)
+			return true
+		"godot_mcp:debug_output_result":
+			_handle_debug_output_result(data)
+			return true
+	return false
+
+
+func _setup_session(session_id: int) -> void:
+	_active_session_id = session_id
+
+
+func _session_stopped() -> void:
+	_active_session_id = -1
+	if _pending_screenshot:
+		_pending_screenshot = false
+		screenshot_received.emit(false, "", 0, 0, "Game session ended")
+	if _pending_debug_output:
+		_pending_debug_output = false
+		debug_output_received.emit(PackedStringArray())
+
+
+func has_active_session() -> bool:
+	return _active_session_id >= 0
+
+
+func request_screenshot(max_width: int = 1920) -> void:
+	if _active_session_id < 0:
+		screenshot_received.emit(false, "", 0, 0, "No active game session")
+		return
+	_pending_screenshot = true
+	var session := get_session(_active_session_id)
+	if session:
+		session.send_message("godot_mcp:take_screenshot", [max_width])
+	else:
+		_pending_screenshot = false
+		screenshot_received.emit(false, "", 0, 0, "Could not get debugger session")
+
+
+func _handle_screenshot_result(data: Array) -> void:
+	_pending_screenshot = false
+	if data.size() < 5:
+		screenshot_received.emit(false, "", 0, 0, "Invalid response data")
+		return
+	var success: bool = data[0]
+	var image_base64: String = data[1]
+	var width: int = data[2]
+	var height: int = data[3]
+	var error: String = data[4]
+	screenshot_received.emit(success, image_base64, width, height, error)
+
+
+func request_debug_output(clear: bool = false) -> void:
+	if _active_session_id < 0:
+		debug_output_received.emit(PackedStringArray())
+		return
+	_pending_debug_output = true
+	var session := get_session(_active_session_id)
+	if session:
+		session.send_message("godot_mcp:get_debug_output", [clear])
+	else:
+		_pending_debug_output = false
+		debug_output_received.emit(PackedStringArray())
+
+
+func _handle_debug_output_result(data: Array) -> void:
+	_pending_debug_output = false
+	var output: PackedStringArray = data[0] if data.size() > 0 else PackedStringArray()
+	debug_output_received.emit(output)

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://cc71xjkq3cjfs

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1,0 +1,111 @@
+extends Node
+class_name MCPGameBridge
+
+const DEFAULT_MAX_WIDTH := 1920
+
+var _logger: _MCPGameLogger
+
+
+func _ready() -> void:
+	if not EngineDebugger.is_active():
+		return
+	_logger = _MCPGameLogger.new()
+	OS.add_logger(_logger)
+	EngineDebugger.register_message_capture("godot_mcp", _on_debugger_message)
+	print("[MCP Game Bridge] Initialized")
+
+
+func _exit_tree() -> void:
+	if EngineDebugger.is_active():
+		EngineDebugger.unregister_message_capture("godot_mcp")
+
+
+func _on_debugger_message(message: String, data: Array) -> bool:
+	match message:
+		"take_screenshot":
+			_take_screenshot_deferred.call_deferred(data)
+			return true
+		"get_debug_output":
+			_handle_get_debug_output(data)
+			return true
+	return false
+
+
+func _take_screenshot_deferred(data: Array) -> void:
+	var max_width: int = data[0] if data.size() > 0 else DEFAULT_MAX_WIDTH
+	await RenderingServer.frame_post_draw
+	_capture_and_send_screenshot(max_width)
+
+
+func _capture_and_send_screenshot(max_width: int) -> void:
+	var viewport := get_viewport()
+	if viewport == null:
+		_send_screenshot_error("NO_VIEWPORT", "Could not get game viewport")
+		return
+	var image := viewport.get_texture().get_image()
+	if image == null:
+		_send_screenshot_error("CAPTURE_FAILED", "Failed to capture image from viewport")
+		return
+	if max_width > 0 and image.get_width() > max_width:
+		var scale_factor := float(max_width) / float(image.get_width())
+		var new_height := int(image.get_height() * scale_factor)
+		image.resize(max_width, new_height, Image.INTERPOLATE_LANCZOS)
+	var png_buffer := image.save_png_to_buffer()
+	var base64 := Marshalls.raw_to_base64(png_buffer)
+	EngineDebugger.send_message("godot_mcp:screenshot_result", [
+		true,
+		base64,
+		image.get_width(),
+		image.get_height(),
+		""
+	])
+
+
+func _send_screenshot_error(code: String, message: String) -> void:
+	EngineDebugger.send_message("godot_mcp:screenshot_result", [
+		false,
+		"",
+		0,
+		0,
+		"%s: %s" % [code, message]
+	])
+
+
+func _handle_get_debug_output(data: Array) -> void:
+	var clear: bool = data[0] if data.size() > 0 else false
+	var output := _logger.get_output() if _logger else PackedStringArray()
+	if clear and _logger:
+		_logger.clear()
+	EngineDebugger.send_message("godot_mcp:debug_output_result", [output])
+
+
+class _MCPGameLogger extends Logger:
+	var _output: PackedStringArray = []
+	var _max_lines := 1000
+	var _mutex := Mutex.new()
+
+	func _log_message(message: String, error: bool) -> void:
+		_mutex.lock()
+		var prefix := "[ERROR] " if error else ""
+		_output.append(prefix + message)
+		if _output.size() > _max_lines:
+			_output.remove_at(0)
+		_mutex.unlock()
+
+	func _log_error(function: String, file: String, line: int, code: String,
+					rationale: String, editor_notify: bool, error_type: int,
+					script_backtraces: Array[ScriptBacktrace]) -> void:
+		_mutex.lock()
+		var msg := "[%s:%d] %s: %s" % [file.get_file(), line, code, rationale]
+		_output.append("[ERROR] " + msg)
+		if _output.size() > _max_lines:
+			_output.remove_at(0)
+		_mutex.unlock()
+
+	func get_output() -> PackedStringArray:
+		return _output
+
+	func clear() -> void:
+		_mutex.lock()
+		_output.clear()
+		_mutex.unlock()

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://hwfido041o7s

--- a/godot/addons/godot_mcp/plugin.gd
+++ b/godot/addons/godot_mcp/plugin.gd
@@ -4,10 +4,15 @@ extends EditorPlugin
 const WebSocketServer := preload("res://addons/godot_mcp/websocket_server.gd")
 const CommandRouter := preload("res://addons/godot_mcp/command_router.gd")
 const StatusPanel := preload("res://addons/godot_mcp/ui/status_panel.tscn")
+const MCPDebuggerPlugin := preload("res://addons/godot_mcp/core/mcp_debugger_plugin.gd")
+
+const GAME_BRIDGE_AUTOLOAD := "MCPGameBridge"
+const GAME_BRIDGE_PATH := "res://addons/godot_mcp/game_bridge/mcp_game_bridge.gd"
 
 var _websocket_server: WebSocketServer
 var _command_router: CommandRouter
 var _status_panel: Control
+var _debugger_plugin: MCPDebuggerPlugin
 
 
 func _enter_tree() -> void:
@@ -24,6 +29,11 @@ func _enter_tree() -> void:
 	add_control_to_bottom_panel(_status_panel, "MCP")
 	_update_status("Waiting for connection...")
 
+	_debugger_plugin = MCPDebuggerPlugin.new()
+	add_debugger_plugin(_debugger_plugin)
+
+	_ensure_game_bridge_autoload()
+
 	_websocket_server.start_server()
 	print("[godot-mcp] Plugin initialized")
 
@@ -37,14 +47,29 @@ func _exit_tree() -> void:
 		_websocket_server.stop_server()
 		_websocket_server.queue_free()
 
+	if _debugger_plugin:
+		remove_debugger_plugin(_debugger_plugin)
+		_debugger_plugin = null
+
 	if _command_router:
 		_command_router.free()
 
 	print("[godot-mcp] Plugin disabled")
 
 
+func _ensure_game_bridge_autoload() -> void:
+	if not ProjectSettings.has_setting("autoload/" + GAME_BRIDGE_AUTOLOAD):
+		ProjectSettings.set_setting("autoload/" + GAME_BRIDGE_AUTOLOAD, GAME_BRIDGE_PATH)
+		ProjectSettings.save()
+		print("[godot-mcp] Added MCPGameBridge autoload")
+
+
+func get_debugger_plugin() -> MCPDebuggerPlugin:
+	return _debugger_plugin
+
+
 func _on_command_received(id: String, command: String, params: Dictionary) -> void:
-	var response := _command_router.handle_command(command, params)
+	var response = await _command_router.handle_command(command, params)
 	response["id"] = id
 	_websocket_server.send_response(response)
 


### PR DESCRIPTION
## Summary

- Fix `capture_game_screenshot` to capture actual game viewport instead of editor
- Fix `get_debug_output` to capture game-side print() statements
- Add EditorDebuggerPlugin-based message passing between editor and game processes

## Problem

Godot 4.4+ runs games as separate processes with embedded window view. This means:
- Editor-side viewport APIs cannot access the game viewport
- Editor-side Logger (MCPLogger) only captures editor process output, not game prints

## Solution

Implement debugger message passing:
- **MCPGameBridge** (game-side autoload): Captures screenshots and logs via game-side Logger, sends back via `EngineDebugger.send_message()`
- **MCPDebuggerPlugin** (editor-side): Receives messages from game, emits signals for command handlers
- Commands now use async/await to wait for debugger responses

## Test plan

- [ ] Run a project with `run_project`
- [ ] Call `capture_game_screenshot` - should show actual game, not editor
- [ ] Call `get_debug_output` - should show game print() statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)