### PR TITLE
feat: add automatic API documentation generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,28 @@ jobs:
         working-directory: server
       - run: npm publish --access public
         working-directory: server
+
+  update-docs:
+    needs: [release-please, publish]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+        working-directory: server
+      - run: npm run generate-docs
+        working-directory: server
+      - name: Commit and push docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          git diff --staged --quiet || git commit -m "docs: auto-generate API reference [skip ci]"
+          git push

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# godot-mcp Documentation
+
+MCP (Model Context Protocol) server for Godot Engine integration.
+
+## Overview
+
+This server provides **33 tools** and **3 resources** for AI-assisted Godot development.
+
+## Quick Links
+
+- [Tools Reference](tools/README.md) - All available MCP tools
+- [Resources Reference](resources.md) - MCP resources for reading project data
+
+## Tool Categories
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| [Scene](tools/scene.md) | 4 | Scene management tools |
+| [Node](tools/node.md) | 5 | Node manipulation tools |
+| [Script](tools/script.md) | 5 | GDScript management tools |
+| [Editor](tools/editor.md) | 6 | Editor control and debugging tools |
+| [Project](tools/project.md) | 4 | Project information tools |
+| [Screenshot](tools/screenshot.md) | 2 | Screenshot capture tools |
+| [Animation](tools/animation.md) | 3 | Animation query, playback, and editing tools |
+| [TileMap/GridMap](tools/tilemap.md) | 4 | TileMap and GridMap editing tools |
+
+## Installation
+
+```bash
+npx @anthropic-ai/create-mcp@latest init godot-mcp
+```
+
+Or add to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
+
+## Requirements
+
+- Godot 4.5+ (required for Logger class)
+- godot-mcp addon installed and enabled in your Godot project
+
+---
+
+*This documentation is auto-generated from tool definitions.*

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,34 @@
+# Resources Reference
+
+MCP resources provide read-only access to Godot project data.
+
+## Current Scene
+
+**URI:** `godot://scene/current`
+
+**MIME Type:** `application/json`
+
+The currently open scene in the Godot editor
+
+---
+
+## Scene Tree
+
+**URI:** `godot://scene/tree`
+
+**MIME Type:** `application/json`
+
+Full hierarchy of the current scene
+
+---
+
+## Current Script
+
+**URI:** `godot://script/current`
+
+**MIME Type:** `text/x-gdscript`
+
+The currently open script in the Godot editor
+
+---
+

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,77 @@
+# Tools Reference
+
+This documentation is auto-generated from the tool definitions.
+
+## [Scene](scene.md)
+
+Scene management tools
+
+- `get_scene_tree` - Get the full hierarchy of nodes in the currently open scene
+- `open_scene` - Open a scene file in the editor
+- `save_scene` - Save the currently open scene
+- `create_scene` - Create a new scene with a root node
+
+## [Node](node.md)
+
+Node manipulation tools
+
+- `get_node_properties` - Get all properties of a node at the specified path
+- `create_node` - Create a new node as a child of an existing node
+- `update_node` - Update properties of an existing node
+- `delete_node` - Delete a node from the scene
+- `reparent_node` - Move a node to a new parent
+
+## [Script](script.md)
+
+GDScript management tools
+
+- `get_script` - Get the content of a GDScript file
+- `create_script` - Create a new GDScript file
+- `edit_script` - Replace the content of an existing GDScript file
+- `attach_script` - Attach an existing script to a node
+- `detach_script` - Remove the script from a node
+
+## [Editor](editor.md)
+
+Editor control and debugging tools
+
+- `get_editor_state` - Get the current state of the Godot editor
+- `get_selected_nodes` - Get the currently selected nodes in the editor
+- `select_node` - Select a node in the editor
+- `run_project` - Run the current Godot project
+- `stop_project` - Stop the running Godot project
+- `get_debug_output` - Get debug output/print statements from the running project
+
+## [Project](project.md)
+
+Project information tools
+
+- `get_project_info` - Get information about the current Godot project
+- `list_project_files` - List files in the project by type
+- `search_files` - Search for files by name pattern
+- `get_project_settings` - Get project settings
+
+## [Screenshot](screenshot.md)
+
+Screenshot capture tools
+
+- `capture_game_screenshot` - Capture a screenshot of the running game viewport. The project must be running.
+- `capture_editor_screenshot` - Capture a screenshot of the editor 2D or 3D viewport
+
+## [Animation](animation.md)
+
+Animation query, playback, and editing tools
+
+- `animation_query` - Query animation data. Actions: list_players (find AnimationPlayers), get_info (player state), get_details (animation tracks/length), get_keyframes (track keyframes)
+- `animation_playback` - Control animation playback. Actions: play, stop, pause, seek, queue, clear_queue
+- `animation_edit` - Edit animations. Actions: create, delete, rename, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
+
+## [TileMap/GridMap](tilemap.md)
+
+TileMap and GridMap editing tools
+
+- `tilemap_query` - Query TileMapLayer data. Actions: list_layers, get_info, get_tileset_info, get_used_cells, get_cell, get_cells_in_region, convert_coords
+- `tilemap_edit` - Edit TileMapLayer cells. Actions: set_cell, erase_cell, clear_layer, set_cells_batch
+- `gridmap_query` - Query GridMap data. Actions: list, get_info, get_meshlib_info, get_used_cells, get_cell, get_cells_by_item
+- `gridmap_edit` - Edit GridMap cells. Actions: set_cell, clear_cell, clear, set_cells_batch
+

--- a/docs/tools/animation.md
+++ b/docs/tools/animation.md
@@ -1,0 +1,79 @@
+# Animation Tools
+
+Animation query, playback, and editing tools
+
+## Tools
+
+- [animation_query](#animation_query)
+- [animation_playback](#animation_playback)
+- [animation_edit](#animation_edit)
+
+---
+
+## animation_query
+
+Query animation data. Actions: list_players (find AnimationPlayers), get_info (player state), get_details (animation tracks/length), get_keyframes (track keyframes)
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `list_players`, `get_info`, `get_details`, `get_keyframes` | Yes | Action: list_players, get_info, get_details, get_keyframes |
+| `root_path` | string | No | Starting node path (list_players only) |
+| `node_path` | string | No | Path to AnimationPlayer (required except list_players) |
+| `animation_name` | string | No | Animation name (get_details, get_keyframes) |
+| `track_index` | number | No | Track index (get_keyframes only) |
+
+---
+
+## animation_playback
+
+Control animation playback. Actions: play, stop, pause, seek, queue, clear_queue
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | enum (6 values) | Yes | Action: play, stop, pause, seek, queue, clear_queue |
+| `node_path` | string | Yes | Path to AnimationPlayer |
+| `animation_name` | string | No | Animation name (play, queue) |
+| `custom_blend` | number | No | Custom blend time, -1 for default (play) |
+| `custom_speed` | number | No | Playback speed, 1.0 default (play) |
+| `from_end` | boolean | No | Play from end for reverse (play) |
+| `keep_state` | boolean | No | Keep current animation state (stop) |
+| `paused` | boolean | No | True to pause, false to unpause (pause) |
+| `seconds` | number | No | Position to seek to (seek) |
+| `update` | boolean | No | Update node immediately, default true (seek) |
+
+---
+
+## animation_edit
+
+Edit animations. Actions: create, delete, rename, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | enum (9 values) | Yes | Action: create, delete, rename, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe |
+| `node_path` | string | Yes | Path to AnimationPlayer |
+| `animation_name` | string | No | Animation name (most actions) |
+| `library_name` | string | No | Library name (create, delete, rename) |
+| `length` | number | No | Animation length in seconds (create, update_props) |
+| `loop_mode` | `none`, `linear`, `pingpong` | No | Loop mode: none, linear, pingpong (create, update_props) |
+| `step` | number | No | Step value for keyframe snapping (create, update_props) |
+| `old_name` | string | No | Current animation name (rename) |
+| `new_name` | string | No | New animation name (rename) |
+| `track_type` | enum (9 values) | No | Type of track (add_track) |
+| `track_path` | string | No | Node path and property, e.g. "Sprite2D:frame" (add_track) |
+| `insert_at` | number | No | Track index to insert at, -1 for end (add_track) |
+| `track_index` | number | No | Track index (remove_track, add/remove/update_keyframe) |
+| `time` | number | No | Keyframe time in seconds (add_keyframe, update_keyframe) |
+| `value` | unknown | No | Keyframe value (add_keyframe, update_keyframe) |
+| `transition` | number | No | Transition curve, 1.0 = linear (add_keyframe, update_keyframe) |
+| `method_name` | string | No | Method name for method tracks (add_keyframe) |
+| `args` | array | No | Method arguments (add_keyframe) |
+| `keyframe_index` | number | No | Keyframe index (remove_keyframe, update_keyframe) |
+
+---
+

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -1,0 +1,81 @@
+# Editor Tools
+
+Editor control and debugging tools
+
+## Tools
+
+- [get_editor_state](#get_editor_state)
+- [get_selected_nodes](#get_selected_nodes)
+- [select_node](#select_node)
+- [run_project](#run_project)
+- [stop_project](#stop_project)
+- [get_debug_output](#get_debug_output)
+
+---
+
+## get_editor_state
+
+Get the current state of the Godot editor
+
+### Parameters
+
+*No parameters required.*
+
+---
+
+## get_selected_nodes
+
+Get the currently selected nodes in the editor
+
+### Parameters
+
+*No parameters required.*
+
+---
+
+## select_node
+
+Select a node in the editor
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node to select |
+
+---
+
+## run_project
+
+Run the current Godot project
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | No | Optional specific scene to run (defaults to main scene) |
+
+---
+
+## stop_project
+
+Stop the running Godot project
+
+### Parameters
+
+*No parameters required.*
+
+---
+
+## get_debug_output
+
+Get debug output/print statements from the running project
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `clear` | boolean | No | Whether to clear the output buffer after reading |
+
+---
+

--- a/docs/tools/node.md
+++ b/docs/tools/node.md
@@ -1,0 +1,79 @@
+# Node Tools
+
+Node manipulation tools
+
+## Tools
+
+- [get_node_properties](#get_node_properties)
+- [create_node](#create_node)
+- [update_node](#update_node)
+- [delete_node](#delete_node)
+- [reparent_node](#reparent_node)
+
+---
+
+## get_node_properties
+
+Get all properties of a node at the specified path
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node (e.g., "/root/Main/Player") |
+
+---
+
+## create_node
+
+Create a new node as a child of an existing node
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `parent_path` | string | Yes | Path to the parent node |
+| `node_type` | string | Yes | Type of node to create (e.g., "Sprite2D", "CharacterBody2D") |
+| `node_name` | string | Yes | Name for the new node |
+| `properties` | object | No | Optional properties to set on the node |
+
+---
+
+## update_node
+
+Update properties of an existing node
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node to update |
+| `properties` | object | Yes | Properties to update (key-value pairs) |
+
+---
+
+## delete_node
+
+Delete a node from the scene
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node to delete |
+
+---
+
+## reparent_node
+
+Move a node to a new parent
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node to move |
+| `new_parent_path` | string | Yes | Path to the new parent node |
+
+---
+

--- a/docs/tools/project.md
+++ b/docs/tools/project.md
@@ -1,0 +1,62 @@
+# Project Tools
+
+Project information tools
+
+## Tools
+
+- [get_project_info](#get_project_info)
+- [list_project_files](#list_project_files)
+- [search_files](#search_files)
+- [get_project_settings](#get_project_settings)
+
+---
+
+## get_project_info
+
+Get information about the current Godot project
+
+### Parameters
+
+*No parameters required.*
+
+---
+
+## list_project_files
+
+List files in the project by type
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_type` | enum (6 values) | Yes | Type of files to list |
+| `directory` | string | No | Optional directory to search in (defaults to "res://") |
+| `recursive` | boolean | No | Whether to search recursively (defaults to true) |
+
+---
+
+## search_files
+
+Search for files by name pattern
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `pattern` | string | Yes | Search pattern (supports * wildcard) |
+| `directory` | string | No | Optional directory to search in |
+
+---
+
+## get_project_settings
+
+Get project settings
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `category` | string | No | Optional settings category to filter by |
+
+---
+

--- a/docs/tools/scene.md
+++ b/docs/tools/scene.md
@@ -1,0 +1,61 @@
+# Scene Tools
+
+Scene management tools
+
+## Tools
+
+- [get_scene_tree](#get_scene_tree)
+- [open_scene](#open_scene)
+- [save_scene](#save_scene)
+- [create_scene](#create_scene)
+
+---
+
+## get_scene_tree
+
+Get the full hierarchy of nodes in the currently open scene
+
+### Parameters
+
+*No parameters required.*
+
+---
+
+## open_scene
+
+Open a scene file in the editor
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | Yes | Path to the scene file (e.g., "res://scenes/main.tscn") |
+
+---
+
+## save_scene
+
+Save the currently open scene
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | No | Optional path to save as (defaults to current scene path) |
+
+---
+
+## create_scene
+
+Create a new scene with a root node
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_type` | string | Yes | Type of the root node (e.g., "Node2D", "Node3D", "Control") |
+| `root_name` | string | No | Name of the root node |
+| `scene_path` | string | Yes | Path to save the scene (e.g., "res://scenes/new_scene.tscn") |
+
+---
+

--- a/docs/tools/screenshot.md
+++ b/docs/tools/screenshot.md
@@ -1,0 +1,36 @@
+# Screenshot Tools
+
+Screenshot capture tools
+
+## Tools
+
+- [capture_game_screenshot](#capture_game_screenshot)
+- [capture_editor_screenshot](#capture_editor_screenshot)
+
+---
+
+## capture_game_screenshot
+
+Capture a screenshot of the running game viewport. The project must be running.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `max_width` | number | No | Maximum width in pixels (image will be scaled down if larger) |
+
+---
+
+## capture_editor_screenshot
+
+Capture a screenshot of the editor 2D or 3D viewport
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `viewport` | `2d`, `3d` | No | Which viewport to capture (defaults to the currently active one) |
+| `max_width` | number | No | Maximum width in pixels (image will be scaled down if larger) |
+
+---
+

--- a/docs/tools/script.md
+++ b/docs/tools/script.md
@@ -1,0 +1,78 @@
+# Script Tools
+
+GDScript management tools
+
+## Tools
+
+- [get_script](#get_script)
+- [create_script](#create_script)
+- [edit_script](#edit_script)
+- [attach_script](#attach_script)
+- [detach_script](#detach_script)
+
+---
+
+## get_script
+
+Get the content of a GDScript file
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `script_path` | string | Yes | Path to the script file (e.g., "res://scripts/player.gd") |
+
+---
+
+## create_script
+
+Create a new GDScript file
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `script_path` | string | Yes | Path for the new script (e.g., "res://scripts/enemy.gd") |
+| `content` | string | Yes | Content of the script |
+| `attach_to` | string | No | Optional node path to attach the script to |
+
+---
+
+## edit_script
+
+Replace the content of an existing GDScript file
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `script_path` | string | Yes | Path to the script file |
+| `content` | string | Yes | New content for the script |
+
+---
+
+## attach_script
+
+Attach an existing script to a node
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `script_path` | string | Yes | Path to the script file |
+
+---
+
+## detach_script
+
+Remove the script from a node
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+
+---
+

--- a/docs/tools/tilemap.md
+++ b/docs/tools/tilemap.md
@@ -1,0 +1,83 @@
+# TileMap/GridMap Tools
+
+TileMap and GridMap editing tools
+
+## Tools
+
+- [tilemap_query](#tilemap_query)
+- [tilemap_edit](#tilemap_edit)
+- [gridmap_query](#gridmap_query)
+- [gridmap_edit](#gridmap_edit)
+
+---
+
+## tilemap_query
+
+Query TileMapLayer data. Actions: list_layers, get_info, get_tileset_info, get_used_cells, get_cell, get_cells_in_region, convert_coords
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | enum (7 values) | Yes | Action: list_layers, get_info, get_tileset_info, get_used_cells, get_cell, get_cells_in_region, convert_coords |
+| `root_path` | string | No | Starting node path (list_layers only) |
+| `node_path` | string | No | Path to TileMapLayer (required except list_layers) |
+| `coords` | object | No | Cell coordinates (get_cell) |
+| `min_coords` | object | No | Minimum corner of region (get_cells_in_region) |
+| `max_coords` | object | No | Maximum corner of region (get_cells_in_region) |
+| `local_position` | object | No | Local position to convert to map coords (convert_coords) |
+| `map_coords` | object | No | Map coordinates to convert to local position (convert_coords) |
+
+---
+
+## tilemap_edit
+
+Edit TileMapLayer cells. Actions: set_cell, erase_cell, clear_layer, set_cells_batch
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `set_cell`, `erase_cell`, `clear_layer`, `set_cells_batch` | Yes | Action: set_cell, erase_cell, clear_layer, set_cells_batch |
+| `node_path` | string | Yes | Path to TileMapLayer node |
+| `coords` | object | No | Cell coordinates (set_cell, erase_cell) |
+| `source_id` | integer | No | TileSet source ID, default 0 (set_cell) |
+| `atlas_coords` | object | No | Atlas coordinates, default 0,0 (set_cell) |
+| `alternative_tile` | integer | No | Alternative tile ID, default 0 (set_cell) |
+| `cells` | object[] | No | Array of cells to set (set_cells_batch) |
+
+---
+
+## gridmap_query
+
+Query GridMap data. Actions: list, get_info, get_meshlib_info, get_used_cells, get_cell, get_cells_by_item
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | enum (6 values) | Yes | Action: list, get_info, get_meshlib_info, get_used_cells, get_cell, get_cells_by_item |
+| `root_path` | string | No | Starting node path (list only) |
+| `node_path` | string | No | Path to GridMap (required except list) |
+| `coords` | object | No | Cell coordinates (get_cell) |
+| `item` | integer | No | MeshLibrary item index (get_cells_by_item) |
+
+---
+
+## gridmap_edit
+
+Edit GridMap cells. Actions: set_cell, clear_cell, clear, set_cells_batch
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `set_cell`, `clear_cell`, `clear`, `set_cells_batch` | Yes | Action: set_cell, clear_cell, clear, set_cells_batch |
+| `node_path` | string | Yes | Path to GridMap node |
+| `coords` | object | No | Cell coordinates (set_cell, clear_cell) |
+| `item` | integer | No | MeshLibrary item index (set_cell) |
+| `orientation` | integer | No | Orientation 0-23, default 0 (set_cell) |
+| `cells` | object[] | No | Array of cells to set (set_cells_batch) |
+
+---
+

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "godot-mcp",
+  "name": "@satelliteoflove/godot-mcp",
   "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "godot-mcp",
+      "name": "@satelliteoflove/godot-mcp",
       "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
@@ -14,9 +14,13 @@
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.23.0"
       },
+      "bin": {
+        "godot-mcp": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/ws": "^8.5.0",
+        "tsx": "^4.7.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
       },
@@ -313,6 +317,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -330,6 +351,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -345,6 +383,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1521,6 +1576,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1950,6 +2018,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.54.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
@@ -2249,6 +2327,459 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
       }
     },
     "node_modules/type-is": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,8 @@
     "start": "node dist/index.js",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "generate-docs": "tsx scripts/generate-docs.ts"
   },
   "keywords": [
     "godot",
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
+    "tsx": "^4.7.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
   },

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -1,0 +1,229 @@
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { sceneTools } from '../src/tools/scene.js';
+import { nodeTools } from '../src/tools/node.js';
+import { scriptTools } from '../src/tools/script.js';
+import { editorTools } from '../src/tools/editor.js';
+import { projectTools } from '../src/tools/project.js';
+import { screenshotTools } from '../src/tools/screenshot.js';
+import { animationTools } from '../src/tools/animation.js';
+import { tilemapTools } from '../src/tools/tilemap.js';
+import { sceneResources } from '../src/resources/scene.js';
+import { scriptResources } from '../src/resources/script.js';
+import { toInputSchema } from '../src/core/schema.js';
+import type { AnyToolDefinition, ResourceDefinition } from '../src/core/types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_DIR = join(__dirname, '../../docs');
+
+interface ToolCategory {
+  name: string;
+  filename: string;
+  description: string;
+  tools: AnyToolDefinition[];
+}
+
+const categories: ToolCategory[] = [
+  { name: 'Scene', filename: 'scene', description: 'Scene management tools', tools: sceneTools },
+  { name: 'Node', filename: 'node', description: 'Node manipulation tools', tools: nodeTools },
+  { name: 'Script', filename: 'script', description: 'GDScript management tools', tools: scriptTools },
+  { name: 'Editor', filename: 'editor', description: 'Editor control and debugging tools', tools: editorTools },
+  { name: 'Project', filename: 'project', description: 'Project information tools', tools: projectTools },
+  { name: 'Screenshot', filename: 'screenshot', description: 'Screenshot capture tools', tools: screenshotTools },
+  { name: 'Animation', filename: 'animation', description: 'Animation query, playback, and editing tools', tools: animationTools },
+  { name: 'TileMap/GridMap', filename: 'tilemap', description: 'TileMap and GridMap editing tools', tools: tilemapTools },
+];
+
+const allResources: ResourceDefinition[] = [...sceneResources, ...scriptResources];
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function escapeMarkdown(text: string): string {
+  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function getTypeString(prop: Record<string, unknown>): string {
+  if (prop.enum) {
+    const values = prop.enum as string[];
+    if (values.length <= 4) {
+      return values.map(v => `\`${v}\``).join(', ');
+    }
+    return `enum (${values.length} values)`;
+  }
+  if (prop.type === 'array') {
+    const items = prop.items as Record<string, unknown> | undefined;
+    if (items?.type) {
+      return `${items.type}[]`;
+    }
+    return 'array';
+  }
+  if (prop.type === 'object' && prop.additionalProperties) {
+    return 'object';
+  }
+  return String(prop.type || 'unknown');
+}
+
+function generateParamsTable(schema: Record<string, unknown>): string {
+  const properties = schema.properties as Record<string, Record<string, unknown>> | undefined;
+  const required = (schema.required as string[]) || [];
+
+  if (!properties || Object.keys(properties).length === 0) {
+    return '*No parameters required.*\n';
+  }
+
+  let table = '| Parameter | Type | Required | Description |\n';
+  table += '|-----------|------|----------|-------------|\n';
+
+  for (const [name, prop] of Object.entries(properties)) {
+    const isRequired = required.includes(name);
+    const typeStr = getTypeString(prop);
+    const desc = escapeMarkdown(String(prop.description || ''));
+    table += `| \`${name}\` | ${typeStr} | ${isRequired ? 'Yes' : 'No'} | ${desc} |\n`;
+  }
+
+  return table;
+}
+
+function generateToolMarkdown(tool: AnyToolDefinition): string {
+  const schema = toInputSchema(tool.schema);
+  let md = `## ${tool.name}\n\n`;
+  md += `${tool.description}\n\n`;
+  md += `### Parameters\n\n`;
+  md += generateParamsTable(schema);
+  md += '\n';
+  return md;
+}
+
+function generateCategoryFile(category: ToolCategory): string {
+  let md = `# ${category.name} Tools\n\n`;
+  md += `${category.description}\n\n`;
+  md += `## Tools\n\n`;
+
+  for (const tool of category.tools) {
+    md += `- [${tool.name}](#${tool.name.replace(/_/g, '_')})\n`;
+  }
+
+  md += '\n---\n\n';
+
+  for (const tool of category.tools) {
+    md += generateToolMarkdown(tool);
+    md += '---\n\n';
+  }
+
+  return md;
+}
+
+function generateToolsIndex(): string {
+  let md = `# Tools Reference\n\n`;
+  md += `This documentation is auto-generated from the tool definitions.\n\n`;
+
+  for (const category of categories) {
+    md += `## [${category.name}](${category.filename}.md)\n\n`;
+    md += `${category.description}\n\n`;
+    for (const tool of category.tools) {
+      md += `- \`${tool.name}\` - ${tool.description}\n`;
+    }
+    md += '\n';
+  }
+
+  return md;
+}
+
+function generateResourcesDoc(): string {
+  let md = `# Resources Reference\n\n`;
+  md += `MCP resources provide read-only access to Godot project data.\n\n`;
+
+  for (const resource of allResources) {
+    md += `## ${resource.name}\n\n`;
+    md += `**URI:** \`${resource.uri}\`\n\n`;
+    md += `**MIME Type:** \`${resource.mimeType}\`\n\n`;
+    md += `${resource.description}\n\n`;
+    md += '---\n\n';
+  }
+
+  return md;
+}
+
+function generateMainReadme(): string {
+  const totalTools = categories.reduce((sum, cat) => sum + cat.tools.length, 0);
+
+  return `# godot-mcp Documentation
+
+MCP (Model Context Protocol) server for Godot Engine integration.
+
+## Overview
+
+This server provides **${totalTools} tools** and **${allResources.length} resources** for AI-assisted Godot development.
+
+## Quick Links
+
+- [Tools Reference](tools/README.md) - All available MCP tools
+- [Resources Reference](resources.md) - MCP resources for reading project data
+
+## Tool Categories
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+${categories.map(c => `| [${c.name}](tools/${c.filename}.md) | ${c.tools.length} | ${c.description} |`).join('\n')}
+
+## Installation
+
+\`\`\`bash
+npx @anthropic-ai/create-mcp@latest init godot-mcp
+\`\`\`
+
+Or add to your MCP configuration:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+\`\`\`
+
+## Requirements
+
+- Godot 4.5+ (required for Logger class)
+- godot-mcp addon installed and enabled in your Godot project
+
+---
+
+*This documentation is auto-generated from tool definitions.*
+`;
+}
+
+function main(): void {
+  console.log('Generating documentation...');
+
+  ensureDir(DOCS_DIR);
+  ensureDir(join(DOCS_DIR, 'tools'));
+
+  writeFileSync(join(DOCS_DIR, 'README.md'), generateMainReadme());
+  console.log('  Created docs/README.md');
+
+  writeFileSync(join(DOCS_DIR, 'tools', 'README.md'), generateToolsIndex());
+  console.log('  Created docs/tools/README.md');
+
+  for (const category of categories) {
+    const content = generateCategoryFile(category);
+    writeFileSync(join(DOCS_DIR, 'tools', `${category.filename}.md`), content);
+    console.log(`  Created docs/tools/${category.filename}.md`);
+  }
+
+  writeFileSync(join(DOCS_DIR, 'resources.md'), generateResourcesDoc());
+  console.log('  Created docs/resources.md');
+
+  console.log(`\nGenerated documentation for ${categories.reduce((sum, c) => sum + c.tools.length, 0)} tools and ${allResources.length} resources.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `generate-docs.ts` script that reads tool/resource registry and generates markdown documentation
- Add `tsx` devDependency and `generate-docs` npm script
- Add `update-docs` CI job that runs after releases to auto-commit generated docs
- Generate initial docs covering 33 tools and 3 resources

The documentation is auto-generated from the Zod schemas already defined for each tool, ensuring docs stay in sync with the actual API.

## Test plan

- [x] Run `npm run generate-docs` locally - successfully generates all markdown files
- [x] Verify generated docs have correct parameter tables and descriptions
- [ ] CI will auto-update docs on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)