### PR TITLE
fix: move doc generation into release-please PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,27 +48,3 @@ jobs:
       - run: npm publish --access public
         working-directory: server
 
-  update-docs:
-    needs: [release-please, publish]
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - run: npm ci
-        working-directory: server
-      - run: npm run generate-docs
-        working-directory: server
-      - name: Commit and push docs
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/
-          git diff --staged --quiet || git commit -m "docs: auto-generate API reference [skip ci]"
-          git push

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,32 @@
+name: Update Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+jobs:
+  update-docs:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+        working-directory: server
+      - run: npm run generate-docs
+        working-directory: server
+      - name: Commit docs if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          git diff --staged --quiet || git commit -m "docs: auto-generate API reference"
+          git push


### PR DESCRIPTION
## Summary
- Fixes the release workflow that was failing because it tried to push directly to the protected `main` branch
- Creates a new `update-docs.yml` workflow that triggers on release-please PRs and commits generated docs to the PR branch
- Removes the broken `update-docs` job from `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)