### PR TITLE
fix: add release-please marker to plugin.cfg for version sync

### DIFF
--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,8 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-; x-release-please-start-version
-version="1.1.1"
-; x-release-please-end
+version="1.3.0" ; x-release-please-version
 script="plugin.gd"
 godot_version_min="4.5"


### PR DESCRIPTION
## Summary
Added `x-release-please-version` inline marker to plugin.cfg so the Godot plugin version stays in sync with npm releases.

Also updates version from 1.1.1 to 1.3.0 to match current release.

## Test plan
- [x] Verify marker format is valid for release-please generic updater
- [ ] Next release should auto-bump plugin.cfg version

🤖 Generated with [Claude Code](https://claude.com/claude-code)