### PR TITLE
fix: include godot/ path in release-please triggers

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,6 +5,7 @@
       "package-name": "@satelliteoflove/godot-mcp",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "include-paths": ["godot"],
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary
Added `include-paths: ["godot"]` to release-please config so that commits touching the GDScript addon trigger npm releases.

This ensures server and addon versions stay in sync automatically.

## What changes
- Commits to `server/` trigger releases (existing behavior)
- Commits to `godot/` now also trigger releases (new)
- Both update `plugin.cfg` version via the existing `extra-files` config

## Test plan
- [x] Config syntax is valid JSON
- [ ] Next commit to `godot/` should create a release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)