### PR TITLE
fix: reset release-please state with last-release-sha

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "last-release-sha": "4f828fd35b888437df60aa4149c8f224a2795372",
   "packages": {
     "server": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
Fix release-please confusion by adding `last-release-sha` to the config.

## Problem
Release-please keeps creating v3.0.0 PRs because it lost track of the actual release state after manual version bumps.

## Solution
Added `last-release-sha` pointing to the v2.0.2 commit (4f828fd). This tells release-please to start looking for changes from that commit instead of trying to figure it out from the (confused) PR history.

From the [release-please manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md):
> With this setting you can manually set the commit sha release-please will use from which to gather commits for the current release.

## Important
**After the next successful release PR is merged, the `last-release-sha` line must be removed from the config.** It's a one-time fix, not a permanent setting.

## Test plan
- [x] Config JSON is valid
- [ ] After merge, release workflow should not create incorrect 3.0.0 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)