### PR TITLE
chore: fully generate READMEs and improve release logic and usability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs['server--release_created'] }}
+      tag_name: ${{ steps.release.outputs['server--tag_name'] }}
+      version: ${{ steps.release.outputs['server--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -85,4 +87,25 @@ jobs:
         working-directory: server
       - run: npm publish --access public
         working-directory: server
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  upload-addon:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create addon zip
+        run: |
+          cd godot/addons
+          zip -r ../../godot-mcp-addon-${{ needs.release-please.outputs.version }}.zip godot_mcp
+      - name: Upload addon to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.release-please.outputs.tag_name }} \
+            godot-mcp-addon-${{ needs.release-please.outputs.version }}.zip \
+            --clobber

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ MCP server for Godot Engine 4.5+, enabling AI assistants to interact with your G
 
 ### 1. Install the Godot Addon
 
-Copy `godot/addons/godot_mcp` to your project's `addons` directory and enable it in Project Settings > Plugins.
+Download the addon from [GitHub Releases](https://github.com/satelliteoflove/godot-mcp/releases) and extract to your project's `addons` directory. Enable it in Project Settings > Plugins.
 
 ### 2. Configure Your AI Assistant
 

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="1.3.0" ; x-release-please-version
+version="2.0.2" ; x-release-please-version
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/README.md
+++ b/server/README.md
@@ -20,9 +20,10 @@ npx @satelliteoflove/godot-mcp
 
 ## Setup
 
-1. Copy the Godot addon from `godot/addons/godot_mcp` into your project
-2. Enable it in Project Settings > Plugins
-3. Configure your MCP client (see below)
+1. Download the addon from [GitHub Releases](https://github.com/satelliteoflove/godot-mcp/releases)
+2. Extract to your project's `addons` directory
+3. Enable it in Project Settings > Plugins
+4. Configure your MCP client (see below)
 
 ### Claude Desktop
 

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -493,7 +493,7 @@ ${featureList.map(f => `- ${f}`).join('\n')}
 
 ### 1. Install the Godot Addon
 
-Copy \`godot/addons/godot_mcp\` to your project's \`addons\` directory and enable it in Project Settings > Plugins.
+Download the addon from [GitHub Releases](https://github.com/satelliteoflove/godot-mcp/releases) and extract to your project's \`addons\` directory. Enable it in Project Settings > Plugins.
 
 ### 2. Configure Your AI Assistant
 
@@ -587,9 +587,10 @@ npx @satelliteoflove/godot-mcp
 
 ## Setup
 
-1. Copy the Godot addon from \`godot/addons/godot_mcp\` into your project
-2. Enable it in Project Settings > Plugins
-3. Configure your MCP client (see below)
+1. Download the addon from [GitHub Releases](https://github.com/satelliteoflove/godot-mcp/releases)
+2. Extract to your project's \`addons\` directory
+3. Enable it in Project Settings > Plugins
+4. Configure your MCP client (see below)
 
 ### Claude Desktop
 


### PR DESCRIPTION
## Summary
- Remove marker-based partial updates - generate complete READMEs
- Simplify tools section to clean table format (no more category headers with "(1)")
- Remove misleading "bidirectional communication" claim (it's request-response, not push)
- Streamline content and remove redundancy
- **Fix version sync**: plugin.cfg updated from 1.3.0 to 2.0.2
- **Add addon zip to releases**: New workflow job creates and uploads `godot-mcp-addon-vX.Y.Z.zip`
- **Update installation instructions**: Point to GitHub Releases instead of "copy from repo"

## Changes

| Area | Change |
|------|--------|
| README format | Verbose category headers → simple table |
| Features | Removed misleading "bidirectional" claim |
| plugin.cfg | 1.3.0 → 2.0.2 (sync with server) |
| release.yml | Added `upload-addon` job |
| Installation | "Copy from repo" → "Download from Releases" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)