### PR TITLE
feat: add scene3d tool for 3D spatial queries

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -18,6 +18,7 @@ func setup(plugin: EditorPlugin) -> void:
 	_register_handler(MCPAnimationCommands.new(), plugin)
 	_register_handler(MCPTilemapCommands.new(), plugin)
 	_register_handler(MCPResourceCommands.new(), plugin)
+	_register_handler(MCPScene3DCommands.new(), plugin)
 
 
 func _register_handler(handler: MCPBaseCommand, plugin: EditorPlugin) -> void:

--- a/godot/addons/godot_mcp/commands/scene3d_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene3d_commands.gd
@@ -1,0 +1,169 @@
+@tool
+extends MCPBaseCommand
+class_name MCPScene3DCommands
+
+
+func get_commands() -> Dictionary:
+	return {
+		"get_spatial_info": get_spatial_info,
+		"get_scene_bounds": get_scene_bounds,
+	}
+
+
+func _require_scene_open() -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if not root:
+		return _error("NO_SCENE", "No scene is currently open")
+	return {}
+
+
+func get_spatial_info(params: Dictionary) -> Dictionary:
+	var scene_check := _require_scene_open()
+	if not scene_check.is_empty():
+		return scene_check
+
+	var node_path: String = params.get("node_path", "")
+	var include_children: bool = params.get("include_children", false)
+	var type_filter: String = params.get("type_filter", "")
+	var max_results: int = params.get("max_results", 0)
+	var within_aabb: Dictionary = params.get("within_aabb", {})
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var node := _get_node(node_path)
+	if not node:
+		return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+
+	if not node is Node3D:
+		return _error("NOT_NODE3D", "Node is not a Node3D: %s" % node_path)
+
+	var filter_aabb: AABB = AABB()
+	var use_aabb_filter := false
+	if not within_aabb.is_empty():
+		var pos: Dictionary = within_aabb.get("position", {})
+		var size: Dictionary = within_aabb.get("size", {})
+		if pos.has("x") and size.has("x"):
+			filter_aabb = AABB(
+				Vector3(pos.get("x", 0), pos.get("y", 0), pos.get("z", 0)),
+				Vector3(size.get("x", 0), size.get("y", 0), size.get("z", 0))
+			)
+			use_aabb_filter = true
+
+	var nodes: Array[Dictionary] = []
+	var state := {"max": max_results, "count": 0, "stopped": false}
+	_collect_spatial_info(node, nodes, type_filter, include_children, use_aabb_filter, filter_aabb, state)
+
+	var result := {"nodes": nodes, "count": nodes.size()}
+	if state.stopped:
+		result["truncated"] = true
+		result["max_results"] = max_results
+	return _success(result)
+
+
+func _collect_spatial_info(node: Node, results: Array[Dictionary], type_filter: String, include_children: bool, use_aabb_filter: bool, filter_aabb: AABB, state: Dictionary) -> void:
+	if state.max > 0 and state.count >= state.max:
+		state.stopped = true
+		return
+
+	if node is Node3D:
+		var node3d := node as Node3D
+		var type_matches := type_filter.is_empty() or node.is_class(type_filter)
+		var aabb_matches := true
+		if use_aabb_filter:
+			aabb_matches = filter_aabb.has_point(node3d.global_position)
+		if type_matches and aabb_matches:
+			results.append(_get_node3d_info(node3d))
+			state.count += 1
+
+	if include_children and not state.stopped:
+		for child in node.get_children():
+			_collect_spatial_info(child, results, type_filter, true, use_aabb_filter, filter_aabb, state)
+			if state.stopped:
+				break
+
+
+func _get_node3d_info(node: Node3D) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var relative_path := scene_root.get_path_to(node)
+	var usable_path := "/root/" + scene_root.name
+	if relative_path != NodePath("."):
+		usable_path += "/" + str(relative_path)
+
+	var gpos: Vector3 = node.global_position
+	var grot: Vector3 = node.global_rotation
+	var gscale: Vector3 = node.global_transform.basis.get_scale()
+
+	var info := {
+		"path": usable_path,
+		"type": node.get_class(),
+		"global_position": {"x": gpos.x, "y": gpos.y, "z": gpos.z},
+		"global_rotation": {"x": grot.x, "y": grot.y, "z": grot.z},
+		"global_scale": {"x": gscale.x, "y": gscale.y, "z": gscale.z},
+		"visible": node.visible,
+	}
+
+	if node is VisualInstance3D:
+		var aabb := (node as VisualInstance3D).get_aabb()
+		var global_aabb := node.global_transform * aabb
+		info["aabb"] = _serialize_aabb(aabb)
+		info["global_aabb"] = _serialize_aabb(global_aabb)
+
+	return info
+
+
+func _serialize_aabb(aabb: AABB) -> Dictionary:
+	return {
+		"position": _serialize_value(aabb.position),
+		"size": _serialize_value(aabb.size),
+		"end": _serialize_value(aabb.end),
+	}
+
+
+func get_scene_bounds(params: Dictionary) -> Dictionary:
+	var scene_check := _require_scene_open()
+	if not scene_check.is_empty():
+		return scene_check
+
+	var root_path: String = params.get("root_path", "")
+	var scene_root := EditorInterface.get_edited_scene_root()
+
+	var search_root: Node = scene_root
+	if not root_path.is_empty():
+		search_root = _get_node(root_path)
+		if not search_root:
+			return _error("NODE_NOT_FOUND", "Root node not found: %s" % root_path)
+
+	var state := {"aabb": AABB(), "count": 0, "first": true}
+	_collect_bounds(search_root, state)
+
+	if state.count == 0:
+		return _error("NO_GEOMETRY", "No VisualInstance3D nodes found under: %s" % (root_path if not root_path.is_empty() else "scene root"))
+
+	var usable_path := "/root/" + scene_root.name
+	if search_root != scene_root:
+		var relative_path := scene_root.get_path_to(search_root)
+		usable_path += "/" + str(relative_path)
+
+	return _success({
+		"root_path": usable_path,
+		"node_count": state.count,
+		"combined_aabb": _serialize_aabb(state.aabb),
+	})
+
+
+func _collect_bounds(node: Node, state: Dictionary) -> void:
+	if node is VisualInstance3D:
+		var visual := node as VisualInstance3D
+		var local_aabb := visual.get_aabb()
+		var global_aabb := visual.global_transform * local_aabb
+
+		if state.first:
+			state.aabb = global_aabb
+			state.first = false
+		else:
+			state.aabb = state.aabb.merge(global_aabb)
+		state.count += 1
+
+	for child in node.get_children():
+		_collect_bounds(child, state)

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -6,6 +6,7 @@ import { projectTools } from './project.js';
 import { animationTools } from './animation.js';
 import { tilemapTools } from './tilemap.js';
 import { resourceTools } from './resource.js';
+import { scene3dTools } from './scene3d.js';
 
 export function registerAllTools(): void {
   registry.registerTools(sceneTools);
@@ -15,6 +16,7 @@ export function registerAllTools(): void {
   registry.registerTools(animationTools);
   registry.registerTools(tilemapTools);
   registry.registerTools(resourceTools);
+  registry.registerTools(scene3dTools);
 }
 
 export { sceneTools } from './scene.js';
@@ -24,3 +26,4 @@ export { projectTools } from './project.js';
 export { animationTools } from './animation.js';
 export { tilemapTools } from './tilemap.js';
 export { resourceTools } from './resource.js';
+export { scene3dTools } from './scene3d.js';

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+import { defineTool } from '../core/define-tool.js';
+import type { AnyToolDefinition } from '../core/types.js';
+
+interface Vector3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface AABB {
+  position: Vector3;
+  size: Vector3;
+  end: Vector3;
+}
+
+interface SpatialNodeInfo {
+  path: string;
+  type: string;
+  global_position: Vector3;
+  global_rotation: Vector3;
+  global_scale: Vector3;
+  visible: boolean;
+  aabb?: AABB;
+  global_aabb?: AABB;
+}
+
+const Vector3Schema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+});
+
+const AABBInputSchema = z.object({
+  position: Vector3Schema.describe('Min corner of the AABB'),
+  size: Vector3Schema.describe('Size of the AABB'),
+});
+
+const Scene3DSchema = z
+  .object({
+    action: z
+      .enum(['get_spatial_info', 'get_bounds'])
+      .describe('Action: get_spatial_info (node spatial data), get_bounds (combined AABB)'),
+    node_path: z
+      .string()
+      .optional()
+      .describe('Path to the Node3D (required for get_spatial_info)'),
+    root_path: z
+      .string()
+      .optional()
+      .describe('Path to search root (get_bounds only, defaults to scene root)'),
+    include_children: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Include child nodes (get_spatial_info only)'),
+    type_filter: z
+      .string()
+      .optional()
+      .describe('Filter by node type, e.g. "MeshInstance3D" (get_spatial_info only)'),
+    max_results: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Limit number of results (get_spatial_info only). Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed.'
+      ),
+    within_aabb: AABBInputSchema.optional().describe(
+      'Only include nodes whose global position is within this AABB (get_spatial_info only)'
+    ),
+  })
+  .refine(
+    (data) => {
+      switch (data.action) {
+        case 'get_spatial_info':
+          return !!data.node_path;
+        case 'get_bounds':
+          return true;
+        default:
+          return false;
+      }
+    },
+    {
+      message:
+        'Missing required fields for action. get_spatial_info requires node_path.',
+    }
+  );
+
+type Scene3DArgs = z.infer<typeof Scene3DSchema>;
+
+function formatVector3(v: Vector3): string {
+  return `(${v.x.toFixed(3)}, ${v.y.toFixed(3)}, ${v.z.toFixed(3)})`;
+}
+
+function formatAABB(aabb: AABB): string {
+  return `pos: ${formatVector3(aabb.position)}, size: ${formatVector3(aabb.size)}`;
+}
+
+export const scene3d = defineTool({
+  name: 'scene3d',
+  description:
+    'Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.',
+  schema: Scene3DSchema,
+  async execute(args: Scene3DArgs, { godot }) {
+    switch (args.action) {
+      case 'get_spatial_info': {
+        const DEFAULT_LIMIT = 50;
+        let effectiveLimit = args.max_results;
+        if (effectiveLimit === undefined && args.include_children) {
+          effectiveLimit = DEFAULT_LIMIT;
+        }
+
+        const result = await godot.sendCommand<{
+          nodes: SpatialNodeInfo[];
+          count: number;
+          truncated?: boolean;
+          max_results?: number;
+        }>('get_spatial_info', {
+          node_path: args.node_path,
+          include_children: args.include_children,
+          type_filter: args.type_filter,
+          max_results: effectiveLimit,
+          within_aabb: args.within_aabb,
+        });
+
+        if (result.count === 0) {
+          return 'No matching Node3D nodes found';
+        }
+
+        const lines = result.nodes.map((n) => {
+          let line = `${n.path} (${n.type})\n`;
+          line += `  position: ${formatVector3(n.global_position)}\n`;
+          line += `  rotation: ${formatVector3(n.global_rotation)} rad\n`;
+          line += `  scale: ${formatVector3(n.global_scale)}\n`;
+          line += `  visible: ${n.visible}`;
+          if (n.global_aabb) {
+            line += `\n  global_aabb: ${formatAABB(n.global_aabb)}`;
+          }
+          return line;
+        });
+
+        let output = `Found ${result.count} Node3D node(s):\n\n${lines.join('\n\n')}`;
+        if (result.truncated) {
+          const limitNote =
+            args.max_results === undefined
+              ? ` Set max_results higher (e.g., 100 or 500) to see more.`
+              : '';
+          output += `\n\n(Results truncated at ${result.max_results}.${limitNote})`;
+        }
+        return output;
+      }
+
+      case 'get_bounds': {
+        const result = await godot.sendCommand<{
+          root_path: string;
+          node_count: number;
+          combined_aabb: AABB;
+        }>('get_scene_bounds', {
+          root_path: args.root_path,
+        });
+
+        return (
+          `Scene bounds for ${result.root_path}:\n` +
+          `  Visual nodes: ${result.node_count}\n` +
+          `  Combined AABB: ${formatAABB(result.combined_aabb)}\n` +
+          `  Min: ${formatVector3(result.combined_aabb.position)}\n` +
+          `  Max: ${formatVector3(result.combined_aabb.end)}`
+        );
+      }
+    }
+  },
+});
+
+export const scene3dTools = [scene3d] as AnyToolDefinition[];


### PR DESCRIPTION
## Summary

- Add new `scene3d` MCP tool for querying computed spatial data from 3D scenes
- Two actions: `get_spatial_info` for per-node data, `get_bounds` for combined AABB
- Provides data that cannot be derived from static file parsing (global transforms require matrix multiplication through parent hierarchy)

## Key Features

- **Computed global transforms**: Position, rotation, scale in world space
- **AABB calculation**: Local and global bounding boxes for VisualInstance3D nodes
- **Default limit of 50**: Prevents accidentally large responses when using `include_children=true`
- **Spatial filtering**: `within_aabb` parameter to query specific regions
- **Type filtering**: `type_filter` parameter (e.g., "MeshInstance3D")
- **Efficient aggregation**: `get_bounds` returns O(1) combined AABB regardless of scene size

## Test Plan

- [x] Basic functionality: Query single node
- [x] Include children: Recursive traversal with default limit
- [x] max_results override: Explicit limits work correctly
- [x] within_aabb: Spatial filtering returns only nodes in region
- [x] type_filter: Excludes non-matching node types
- [x] get_bounds: Returns combined AABB of all visual nodes

## Files Changed

| File | Change |
|------|--------|
| `server/src/tools/scene3d.ts` | New TypeScript tool definition |
| `godot/addons/godot_mcp/commands/scene3d_commands.gd` | New GDScript command handler |
| `server/src/tools/index.ts` | Register scene3d tools |
| `godot/addons/godot_mcp/command_router.gd` | Register command handler |

🤖 Generated with [Claude Code](https://claude.com/claude-code)