### PR TITLE
fix: improve find_nodes reliability and DRY cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # godot-mcp
 
-MCP server for Godot Engine 4.5+, enabling AI assistants to interact with your Godot projects.
+An MCP server that gives Claude direct visibility into your Godot editor and running game. Instead of copy-pasting debug output or describing what you're seeing, Claude can observe it directly.
 
-## Features
+## Core Capabilities
 
-- **8 MCP tools** across 7 categories
-- **3 MCP resources** for reading scene trees, scripts, and project files
-- Screenshot capture from editor viewports and running games
-- Full animation support (query, playback, editing)
-- TileMapLayer and GridMap editing
-- Resource inspection for SpriteFrames, TileSets, Materials, and Textures
-- Debug output capture from running games
+- Live editor state - what scene is open, what's selected, which panel you're in
+- Runtime debug output from the running game
+- Viewport awareness - where the camera is pointed (2D and 3D)
+- Screenshots of the editor or running game
+- Scene tree and node properties at runtime
+
+## Design Goals
+
+- **Observation over automation** - help Claude understand what's happening so it can help you solve problems
+- **Minimal token footprint** - more room for actual conversation
+- **Friction-free maintenance** - version mismatch detection and one-command updates
 
 ## Quick Start
 

--- a/godot/addons/godot_mcp/commands/scene3d_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene3d_commands.gd
@@ -10,13 +10,6 @@ func get_commands() -> Dictionary:
 	}
 
 
-func _require_scene_open() -> Dictionary:
-	var root := EditorInterface.get_edited_scene_root()
-	if not root:
-		return _error("NO_SCENE", "No scene is currently open")
-	return {}
-
-
 func get_spatial_info(params: Dictionary) -> Dictionary:
 	var scene_check := _require_scene_open()
 	if not scene_check.is_empty():

--- a/godot/addons/godot_mcp/core/base_command.gd
+++ b/godot/addons/godot_mcp/core/base_command.gd
@@ -27,3 +27,32 @@ func _get_node(path: String) -> Node:
 
 func _serialize_value(value: Variant) -> Variant:
 	return MCPUtils.serialize_value(value)
+
+
+func _require_scene_open() -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if not root:
+		return _error("NO_SCENE", "No scene is currently open")
+	return {}
+
+
+func _require_typed_node(path: String, type: String, type_error_code: String = "WRONG_TYPE") -> Variant:
+	var node := _get_node(path)
+	if not node:
+		return _error("NODE_NOT_FOUND", "Node not found: %s" % path)
+	if not node.is_class(type):
+		return _error(type_error_code, "Expected %s, got %s" % [type, node.get_class()])
+	return node
+
+
+func _find_nodes_of_type(root: Node, type: String) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	_find_nodes_recursive(root, type, result)
+	return result
+
+
+func _find_nodes_recursive(node: Node, type: String, result: Array[Dictionary]) -> void:
+	if node.is_class(type):
+		result.append({"path": str(node.get_path()), "name": node.name})
+	for child in node.get_children():
+		_find_nodes_recursive(child, type, result)

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -56,7 +56,12 @@ func _session_stopped() -> void:
 
 
 func has_active_session() -> bool:
-	return _active_session_id >= 0
+	if _active_session_id < 0:
+		return false
+	if not EditorInterface.is_playing_scene():
+		_active_session_id = -1
+		return false
+	return true
 
 
 func request_screenshot(max_width: int = 1920) -> void:

--- a/godot/addons/godot_mcp/core/mcp_utils.gd
+++ b/godot/addons/godot_mcp/core/mcp_utils.gd
@@ -47,7 +47,11 @@ static func serialize_value(value: Variant) -> Variant:
 	match typeof(value):
 		TYPE_VECTOR2:
 			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR2I:
+			return {"x": value.x, "y": value.y}
 		TYPE_VECTOR3:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_VECTOR3I:
 			return {"x": value.x, "y": value.y, "z": value.z}
 		TYPE_COLOR:
 			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}

--- a/server/README.md
+++ b/server/README.md
@@ -1,62 +1,94 @@
-# @satelliteoflove/godot-mcp
+# godot-mcp
 
-MCP server for Godot Engine 4.5+, enabling AI assistants to interact with your Godot projects.
+An MCP server that gives Claude direct visibility into your Godot editor and running game. Instead of copy-pasting debug output or describing what you're seeing, Claude can observe it directly.
 
-## Features
+## Core Capabilities
 
-- **8 MCP tools** across 7 categories
-- **3 MCP resources** for reading scene trees, scripts, and project files
-- Screenshot capture from editor viewports and running games
-- Full animation support (query, playback, editing)
-- TileMapLayer and GridMap editing
-- Resource inspection for SpriteFrames, TileSets, Materials, and Textures
-- Debug output capture from running games
+- Live editor state - what scene is open, what's selected, which panel you're in
+- Runtime debug output from the running game
+- Viewport awareness - where the camera is pointed (2D and 3D)
+- Screenshots of the editor or running game
+- Scene tree and node properties at runtime
 
-## Installation
+## Design Goals
+
+- **Observation over automation** - help Claude understand what's happening so it can help you solve problems
+- **Minimal token footprint** - more room for actual conversation
+- **Friction-free maintenance** - version mismatch detection and one-command updates
+
+## Quick Start
+
+### 1. Configure Your AI Assistant
+
+**Claude Desktop** - Add to config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
+
+**Claude Code** - Add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
+
+### 2. Install the Godot Addon
 
 ```bash
-npx @satelliteoflove/godot-mcp
+npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 ```
 
-## Setup
+Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
 
-1. Configure your MCP client (see below)
-2. Install the addon: `npx @satelliteoflove/godot-mcp --install-addon /path/to/project`
-3. Enable it in Godot: Project Settings > Plugins > Godot MCP
+### 3. Start Using
 
-### Claude Desktop
+Open your Godot project (with addon enabled), restart your AI assistant, and start building.
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+**Version Sync:** The MCP server auto-updates via npx. If the addon version falls behind, use `project` tool with `addon_status` action to check compatibility, then re-run the install command to update.
 
-```json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `scene` | Manage scenes: open, save, or create scenes |
+| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts |
+| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom |
+| `project` | Get project information and settings |
+| `animation` | Query, control, and edit animations |
+| `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |
+| `gridmap` | Query and edit GridMap data: list gridmaps, get info, get/set cells |
+| `resource` | Manage Godot resources: inspect Resource files by path |
+
+See [docs/](docs/) for detailed API reference, including the [Claude Code Setup Guide](docs/claude-code-setup.md).
+
+## Architecture
+
+```
+[AI Assistant] <--stdio--> [MCP Server] <--WebSocket--> [Godot Addon]
 ```
 
-### Claude Code
+## Development
 
-Add to `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
+```bash
+cd server
+npm install && npm run build
+npm test
+npm run generate-docs
 ```
-
-## Documentation
-
-See the [GitHub repository](https://github.com/satelliteoflove/godot-mcp) for full documentation.
 
 ## Requirements
 

--- a/server/addon/commands/scene3d_commands.gd
+++ b/server/addon/commands/scene3d_commands.gd
@@ -10,13 +10,6 @@ func get_commands() -> Dictionary:
 	}
 
 
-func _require_scene_open() -> Dictionary:
-	var root := EditorInterface.get_edited_scene_root()
-	if not root:
-		return _error("NO_SCENE", "No scene is currently open")
-	return {}
-
-
 func get_spatial_info(params: Dictionary) -> Dictionary:
 	var scene_check := _require_scene_open()
 	if not scene_check.is_empty():

--- a/server/addon/core/base_command.gd
+++ b/server/addon/core/base_command.gd
@@ -27,3 +27,32 @@ func _get_node(path: String) -> Node:
 
 func _serialize_value(value: Variant) -> Variant:
 	return MCPUtils.serialize_value(value)
+
+
+func _require_scene_open() -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if not root:
+		return _error("NO_SCENE", "No scene is currently open")
+	return {}
+
+
+func _require_typed_node(path: String, type: String, type_error_code: String = "WRONG_TYPE") -> Variant:
+	var node := _get_node(path)
+	if not node:
+		return _error("NODE_NOT_FOUND", "Node not found: %s" % path)
+	if not node.is_class(type):
+		return _error(type_error_code, "Expected %s, got %s" % [type, node.get_class()])
+	return node
+
+
+func _find_nodes_of_type(root: Node, type: String) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	_find_nodes_recursive(root, type, result)
+	return result
+
+
+func _find_nodes_recursive(node: Node, type: String, result: Array[Dictionary]) -> void:
+	if node.is_class(type):
+		result.append({"path": str(node.get_path()), "name": node.name})
+	for child in node.get_children():
+		_find_nodes_recursive(child, type, result)

--- a/server/addon/core/mcp_debugger_plugin.gd
+++ b/server/addon/core/mcp_debugger_plugin.gd
@@ -56,7 +56,12 @@ func _session_stopped() -> void:
 
 
 func has_active_session() -> bool:
-	return _active_session_id >= 0
+	if _active_session_id < 0:
+		return false
+	if not EditorInterface.is_playing_scene():
+		_active_session_id = -1
+		return false
+	return true
 
 
 func request_screenshot(max_width: int = 1920) -> void:

--- a/server/addon/core/mcp_utils.gd
+++ b/server/addon/core/mcp_utils.gd
@@ -47,7 +47,11 @@ static func serialize_value(value: Variant) -> Variant:
 	match typeof(value):
 		TYPE_VECTOR2:
 			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR2I:
+			return {"x": value.x, "y": value.y}
 		TYPE_VECTOR3:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_VECTOR3I:
 			return {"x": value.x, "y": value.y, "z": value.z}
 		TYPE_COLOR:
 			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}

--- a/server/addon/plugin.cfg
+++ b/server/addon/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="2.3.0"
+version="2.4.0"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -467,15 +467,7 @@ Add to your MCP configuration:
 }
 
 function generateRootReadme(): string {
-  const totalTools = categories.reduce((sum, cat) => sum + cat.tools.length, 0);
   const allTools = categories.flatMap(c => c.tools);
-  const capabilities = analyzeCapabilities();
-
-  const featureList = [
-    `**${totalTools} MCP tools** across ${categories.length} categories`,
-    `**${allResources.length} MCP resources** for reading scene trees, scripts, and project files`,
-    ...capabilities,
-  ];
 
   const toolsTable = allTools.map(tool => {
     const desc = tool.description.split('.')[0];
@@ -484,11 +476,21 @@ function generateRootReadme(): string {
 
   return `# godot-mcp
 
-MCP server for Godot Engine 4.5+, enabling AI assistants to interact with your Godot projects.
+An MCP server that gives Claude direct visibility into your Godot editor and running game. Instead of copy-pasting debug output or describing what you're seeing, Claude can observe it directly.
 
-## Features
+## Core Capabilities
 
-${featureList.map(f => `- ${f}`).join('\n')}
+- Live editor state - what scene is open, what's selected, which panel you're in
+- Runtime debug output from the running game
+- Viewport awareness - where the camera is pointed (2D and 3D)
+- Screenshots of the editor or running game
+- Scene tree and node properties at runtime
+
+## Design Goals
+
+- **Observation over automation** - help Claude understand what's happening so it can help you solve problems
+- **Minimal token footprint** - more room for actual conversation
+- **Friction-free maintenance** - version mismatch detection and one-command updates
 
 ## Quick Start
 
@@ -568,80 +570,6 @@ MIT
 `;
 }
 
-function generateNpmReadme(): string {
-  const totalTools = categories.reduce((sum, cat) => sum + cat.tools.length, 0);
-  const capabilities = analyzeCapabilities();
-
-  const featureList = [
-    `**${totalTools} MCP tools** across ${categories.length} categories`,
-    `**${allResources.length} MCP resources** for reading scene trees, scripts, and project files`,
-    ...capabilities,
-  ];
-
-  return `# @satelliteoflove/godot-mcp
-
-MCP server for Godot Engine 4.5+, enabling AI assistants to interact with your Godot projects.
-
-## Features
-
-${featureList.map(f => `- ${f}`).join('\n')}
-
-## Installation
-
-\`\`\`bash
-npx @satelliteoflove/godot-mcp
-\`\`\`
-
-## Setup
-
-1. Configure your MCP client (see below)
-2. Install the addon: \`npx @satelliteoflove/godot-mcp --install-addon /path/to/project\`
-3. Enable it in Godot: Project Settings > Plugins > Godot MCP
-
-### Claude Desktop
-
-Add to \`~/Library/Application Support/Claude/claude_desktop_config.json\` (macOS) or \`%APPDATA%\\Claude\\claude_desktop_config.json\` (Windows):
-
-\`\`\`json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
-\`\`\`
-
-### Claude Code
-
-Add to \`.mcp.json\`:
-
-\`\`\`json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
-\`\`\`
-
-## Documentation
-
-See the [GitHub repository](https://github.com/satelliteoflove/godot-mcp) for full documentation.
-
-## Requirements
-
-- Node.js 20+
-- Godot 4.5+
-
-## License
-
-MIT
-`;
-}
 
 function main(): void {
   console.log('Generating documentation...');
@@ -666,11 +594,12 @@ function main(): void {
   writeFileSync(join(DOCS_DIR, 'resources.md'), generateResourcesDoc());
   console.log('  Created docs/resources.md');
 
-  writeFileSync(ROOT_README, generateRootReadme());
+  const readme = generateRootReadme();
+  writeFileSync(ROOT_README, readme);
   console.log('  Created README.md');
 
-  writeFileSync(NPM_README, generateNpmReadme());
-  console.log('  Created server/README.md');
+  writeFileSync(NPM_README, readme);
+  console.log('  Created server/README.md (copy of root)');
 
   console.log(`\nGenerated documentation for ${categories.reduce((sum, c) => sum + c.tools.length, 0)} tools and ${allResources.length} resources.`);
 }

--- a/server/src/core/types.ts
+++ b/server/src/core/types.ts
@@ -30,3 +30,9 @@ export interface ResourceDefinition {
   mimeType: string;
   handler: (ctx: ToolContext) => Promise<string>;
 }
+
+export interface Vector3 {
+  x: number;
+  y: number;
+  z: number;
+}

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -1,17 +1,11 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
-import type { AnyToolDefinition, ImageContent } from '../core/types.js';
+import type { AnyToolDefinition, ImageContent, Vector3 } from '../core/types.js';
 
 interface ScreenshotResponse {
   image_base64: string;
   width: number;
   height: number;
-}
-
-interface Vector3 {
-  x: number;
-  y: number;
-  z: number;
 }
 
 interface CameraInfo {

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -1,12 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
-import type { AnyToolDefinition } from '../core/types.js';
-
-interface Vector3 {
-  x: number;
-  y: number;
-  z: number;
-}
+import type { AnyToolDefinition, Vector3 } from '../core/types.js';
 
 interface AABB {
   position: Vector3;


### PR DESCRIPTION
## Summary
- Fix `find_nodes` timing out when game not running by checking `EditorInterface.is_playing_scene()`
- Add 5-second timeout to find_nodes game communication (was relying on 30s MCP timeout)
- Fix "signal already connected" error by checking `is_connected` before connecting
- DRY improvements: add helper methods to MCPBaseCommand, consolidate Vector3 type

## Changes

### Bug Fixes
- **find_nodes stale session**: When the game stops, the debugger session ID wasn't being properly cleared, causing find_nodes to try to communicate with a non-existent game. Now checks `EditorInterface.is_playing_scene()` in both `has_active_session()` and directly in `node_commands.gd`
- **find_nodes timeout**: Added 5-second timeout with clear error message instead of waiting for the 30-second MCP server timeout
- **Signal connection**: Check if signal is connected before connecting to avoid "signal already connected" errors

### DRY Improvements
- Add helper methods to `MCPBaseCommand`: `_require_scene_open()`, `_require_typed_node()`, `_find_nodes_of_type()`
- Remove duplicate `_require_scene_open()` from `node_commands.gd` and `scene3d_commands.gd`
- Add `Vector2i`/`Vector3i` to `MCPUtils.serialize_value()`
- Consolidate `Vector3` type into `core/types.ts`
- Consolidate README generation into single function

## Test plan
- [x] Verify `find_nodes` works when game is running
- [x] Verify `find_nodes` falls back to editor scene tree when game is not running
- [x] Verify timeout error message is clear (5 seconds instead of 30)
- [x] All 145 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)