### PR TITLE
fix: update README and add missing scene3d to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,24 @@ An MCP server that gives Claude direct visibility into your Godot editor and run
 
 ## Core Capabilities
 
-- Live editor state - what scene is open, what's selected, which panel you're in
-- Runtime debug output from the running game
-- Viewport awareness - where the camera is pointed (2D and 3D)
-- Screenshots of the editor or running game
-- Scene tree and node properties at runtime
+**Observe** - Claude sees what you see
+- Live editor state, selection, and open scenes
+- Screenshots from editor viewports or running game
+- Debug output and performance metrics from runtime
+- Camera position and viewport in 2D and 3D
 
-## Design Goals
+**Inspect** - Deep access to your project
+- Scene tree traversal with node properties
+- 3D spatial data: transforms, bounding boxes, visibility
+- Resource introspection: SpriteFrames, TileSets, Materials
+- Project settings and input mappings
 
-- **Observation over automation** - help Claude understand what's happening so it can help you solve problems
-- **Minimal token footprint** - more room for actual conversation
-- **Friction-free maintenance** - version mismatch detection and one-command updates
+**Modify** - Direct manipulation when needed
+- Create, update, delete, and reparent nodes
+- Attach and detach scripts
+- Edit TileMapLayers and GridMaps cell-by-cell
+- Control animation playback and edit tracks/keyframes
+- Run and stop the game from the editor
 
 ## Quick Start
 
@@ -58,7 +65,7 @@ Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
 
 Open your Godot project (with addon enabled), restart your AI assistant, and start building.
 
-**Version Sync:** The MCP server auto-updates via npx. If the addon version falls behind, use `project` tool with `addon_status` action to check compatibility, then re-run the install command to update.
+**Version Sync:** The MCP server auto-updates via npx. Version mismatches are detected automatically on connection. If prompted, re-run the install command to update the addon.
 
 ## Tools
 
@@ -72,6 +79,7 @@ Open your Godot project (with addon enabled), restart your AI assistant, and sta
 | `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |
 | `gridmap` | Query and edit GridMap data: list gridmaps, get info, get/set cells |
 | `resource` | Manage Godot resources: inspect Resource files by path |
+| `scene3d` | Get spatial information for 3D nodes: global transforms, bounding boxes, visibility |
 
 See [docs/](docs/) for detailed API reference, including the [Claude Code Setup Guide](docs/claude-code-setup.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) server for Godot Engine integration.
 
 ## Overview
 
-This server provides **8 tools** and **3 resources** for AI-assisted Godot development.
+This server provides **9 tools** and **3 resources** for AI-assisted Godot development.
 
 ## Quick Links
 
@@ -23,6 +23,7 @@ This server provides **8 tools** and **3 resources** for AI-assisted Godot devel
 | [Animation](tools/animation.md) | 1 | Animation query, playback, and editing tools |
 | [TileMap/GridMap](tools/tilemap.md) | 2 | TileMap and GridMap editing tools |
 | [Resource](tools/resource.md) | 1 | Resource inspection tools for SpriteFrames, TileSet, Materials, etc. |
+| [Scene3D](tools/scene3d.md) | 1 | 3D spatial information and bounding box tools |
 
 ## Installation
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -45,3 +45,9 @@ Resource inspection tools for SpriteFrames, TileSet, Materials, etc.
 
 - `resource` - Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.
 
+## [Scene3D](scene3d.md)
+
+3D spatial information and bounding box tools
+
+- `scene3d` - Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
+

--- a/docs/tools/scene3d.md
+++ b/docs/tools/scene3d.md
@@ -1,0 +1,57 @@
+# Scene3D Tools
+
+3D spatial information and bounding box tools
+
+## Tools
+
+- [scene3d](#scene3d)
+
+---
+
+## scene3d
+
+Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `get_spatial_info`, `get_bounds` | Yes | Action: get_spatial_info (node spatial data), get_bounds (combined AABB) |
+| `node_path` | string | No | Path to the Node3D (required for get_spatial_info) |
+| `root_path` | string | No | Path to search root (get_bounds only, defaults to scene root) |
+| `include_children` | boolean | get_spatial_info | Include child nodes |
+| `type_filter` | string | get_spatial_info | Filter by node type, e.g. "MeshInstance3D" |
+| `max_results` | integer | get_spatial_info | Limit number of results. Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed. |
+| `within_aabb` | object {position, size} | get_spatial_info | Only include nodes whose global position is within this AABB |
+
+### Actions
+
+#### `get_spatial_info`
+
+Parameters: `include_children`*, `type_filter`*, `max_results`*, `within_aabb`*
+
+#### `get_bounds`
+
+### Examples
+
+```json
+// get_spatial_info
+{
+  "action": "get_spatial_info",
+  "include_children": false,
+  "type_filter": "example",
+  "max_results": null,
+  "within_aabb": {}
+}
+```
+
+```json
+// get_bounds
+{
+  "action": "get_bounds",
+  "root_path": "/root/Main"
+}
+```
+
+---
+

--- a/server/README.md
+++ b/server/README.md
@@ -4,17 +4,24 @@ An MCP server that gives Claude direct visibility into your Godot editor and run
 
 ## Core Capabilities
 
-- Live editor state - what scene is open, what's selected, which panel you're in
-- Runtime debug output from the running game
-- Viewport awareness - where the camera is pointed (2D and 3D)
-- Screenshots of the editor or running game
-- Scene tree and node properties at runtime
+**Observe** - Claude sees what you see
+- Live editor state, selection, and open scenes
+- Screenshots from editor viewports or running game
+- Debug output and performance metrics from runtime
+- Camera position and viewport in 2D and 3D
 
-## Design Goals
+**Inspect** - Deep access to your project
+- Scene tree traversal with node properties
+- 3D spatial data: transforms, bounding boxes, visibility
+- Resource introspection: SpriteFrames, TileSets, Materials
+- Project settings and input mappings
 
-- **Observation over automation** - help Claude understand what's happening so it can help you solve problems
-- **Minimal token footprint** - more room for actual conversation
-- **Friction-free maintenance** - version mismatch detection and one-command updates
+**Modify** - Direct manipulation when needed
+- Create, update, delete, and reparent nodes
+- Attach and detach scripts
+- Edit TileMapLayers and GridMaps cell-by-cell
+- Control animation playback and edit tracks/keyframes
+- Run and stop the game from the editor
 
 ## Quick Start
 
@@ -58,7 +65,7 @@ Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
 
 Open your Godot project (with addon enabled), restart your AI assistant, and start building.
 
-**Version Sync:** The MCP server auto-updates via npx. If the addon version falls behind, use `project` tool with `addon_status` action to check compatibility, then re-run the install command to update.
+**Version Sync:** The MCP server auto-updates via npx. Version mismatches are detected automatically on connection. If prompted, re-run the install command to update the addon.
 
 ## Tools
 
@@ -72,6 +79,7 @@ Open your Godot project (with addon enabled), restart your AI assistant, and sta
 | `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |
 | `gridmap` | Query and edit GridMap data: list gridmaps, get info, get/set cells |
 | `resource` | Manage Godot resources: inspect Resource files by path |
+| `scene3d` | Get spatial information for 3D nodes: global transforms, bounding boxes, visibility |
 
 See [docs/](docs/) for detailed API reference, including the [Claude Code Setup Guide](docs/claude-code-setup.md).
 

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -9,6 +9,7 @@ import { projectTools } from '../src/tools/project.js';
 import { animationTools } from '../src/tools/animation.js';
 import { tilemapTools } from '../src/tools/tilemap.js';
 import { resourceTools } from '../src/tools/resource.js';
+import { scene3dTools } from '../src/tools/scene3d.js';
 import { sceneResources } from '../src/resources/scene.js';
 import { scriptResources } from '../src/resources/script.js';
 import { toInputSchema } from '../src/core/schema.js';
@@ -35,6 +36,7 @@ const categories: ToolCategory[] = [
   { name: 'Animation', filename: 'animation', description: 'Animation query, playback, and editing tools', tools: animationTools },
   { name: 'TileMap/GridMap', filename: 'tilemap', description: 'TileMap and GridMap editing tools', tools: tilemapTools },
   { name: 'Resource', filename: 'resource', description: 'Resource inspection tools for SpriteFrames, TileSet, Materials, etc.', tools: resourceTools },
+  { name: 'Scene3D', filename: 'scene3d', description: '3D spatial information and bounding box tools', tools: scene3dTools },
 ];
 
 const allResources: ResourceDefinition[] = [...sceneResources, ...scriptResources];
@@ -480,17 +482,24 @@ An MCP server that gives Claude direct visibility into your Godot editor and run
 
 ## Core Capabilities
 
-- Live editor state - what scene is open, what's selected, which panel you're in
-- Runtime debug output from the running game
-- Viewport awareness - where the camera is pointed (2D and 3D)
-- Screenshots of the editor or running game
-- Scene tree and node properties at runtime
+**Observe** - Claude sees what you see
+- Live editor state, selection, and open scenes
+- Screenshots from editor viewports or running game
+- Debug output and performance metrics from runtime
+- Camera position and viewport in 2D and 3D
 
-## Design Goals
+**Inspect** - Deep access to your project
+- Scene tree traversal with node properties
+- 3D spatial data: transforms, bounding boxes, visibility
+- Resource introspection: SpriteFrames, TileSets, Materials
+- Project settings and input mappings
 
-- **Observation over automation** - help Claude understand what's happening so it can help you solve problems
-- **Minimal token footprint** - more room for actual conversation
-- **Friction-free maintenance** - version mismatch detection and one-command updates
+**Modify** - Direct manipulation when needed
+- Create, update, delete, and reparent nodes
+- Attach and detach scripts
+- Edit TileMapLayers and GridMaps cell-by-cell
+- Control animation playback and edit tracks/keyframes
+- Run and stop the game from the editor
 
 ## Quick Start
 
@@ -534,7 +543,7 @@ Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
 
 Open your Godot project (with addon enabled), restart your AI assistant, and start building.
 
-**Version Sync:** The MCP server auto-updates via npx. If the addon version falls behind, use \`project\` tool with \`addon_status\` action to check compatibility, then re-run the install command to update.
+**Version Sync:** The MCP server auto-updates via npx. Version mismatches are detected automatically on connection. If prompted, re-run the install command to update the addon.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- Rewrote Core Capabilities into Observe/Inspect/Modify sections to better represent full MCP capabilities
- Added scene3d tool to doc generator (was missing from categories array)
- Fixed version sync phrasing to clarify that mismatches are detected automatically
- Regenerated all docs

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify docs/tools/scene3d.md is present and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)