### PR TITLE
fix: use scene-relative paths instead of full editor paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ This server provides **10 tools** and **3 resources** for AI-assisted Godot deve
 | [Editor](tools/editor.md) | 1 | Editor control, debugging, and screenshot tools |
 | [Project](tools/project.md) | 1 | Project information tools |
 | [Animation](tools/animation.md) | 1 | Animation query, playback, and editing tools |
-| [TileMap/GridMap](tools/tilemap.md) | 2 | TileMap and GridMap editing tools |
+| [TileMapLayer/GridMap](tools/tilemap.md) | 2 | TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprecated TileMap) |
 | [Resource](tools/resource.md) | 1 | Resource inspection tools for SpriteFrames, TileSet, Materials, etc. |
 | [Scene3D](tools/scene3d.md) | 1 | 3D spatial information and bounding box tools |
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -32,9 +32,9 @@ Animation query, playback, and editing tools
 
 - `animation` - Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
 
-## [TileMap/GridMap](tilemap.md)
+## [TileMapLayer/GridMap](tilemap.md)
 
-TileMap and GridMap editing tools
+TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprecated TileMap)
 
 - `tilemap` - Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates
 - `gridmap` - Query and edit GridMap data: list gridmaps, get info, get/set cells

--- a/docs/tools/tilemap.md
+++ b/docs/tools/tilemap.md
@@ -1,6 +1,6 @@
-# TileMap/GridMap Tools
+# TileMapLayer/GridMap Tools
 
-TileMap and GridMap editing tools
+TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprecated TileMap)
 
 ## Tools
 

--- a/godot/addons/godot_mcp/commands/node_commands.gd
+++ b/godot/addons/godot_mcp/commands/node_commands.gd
@@ -168,9 +168,10 @@ func create_node(params: Dictionary) -> Dictionary:
 			node.set(key, deserialized)
 
 	parent.add_child(node)
-	_set_owner_recursive(node, EditorInterface.get_edited_scene_root())
+	var scene_root := EditorInterface.get_edited_scene_root()
+	_set_owner_recursive(node, scene_root)
 
-	return _success({"node_path": str(node.get_path())})
+	return _success({"node_path": str(scene_root.get_path_to(node))})
 
 
 func _set_owner_recursive(node: Node, owner: Node) -> void:
@@ -250,6 +251,6 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	node.reparent(new_parent)
 
-	return _success({"new_path": str(node.get_path())})
+	return _success({"new_path": str(root.get_path_to(node))})
 
 

--- a/godot/addons/godot_mcp/commands/script_commands.gd
+++ b/godot/addons/godot_mcp/commands/script_commands.gd
@@ -136,7 +136,8 @@ func attach_script(params: Dictionary) -> Dictionary:
 	if node.get_script() != script:
 		return _error("ATTACH_FAILED", "Script attachment did not persist")
 
-	return _success({"node_path": str(node.get_path()), "script_path": script_path})
+	var scene_root := EditorInterface.get_edited_scene_root()
+	return _success({"node_path": str(scene_root.get_path_to(node)), "script_path": script_path})
 
 
 func detach_script(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/commands/tilemap_commands.gd
+++ b/godot/addons/godot_mcp/commands/tilemap_commands.gd
@@ -47,24 +47,24 @@ func _get_gridmap(node_path: String) -> GridMap:
 	return node as GridMap
 
 
-func _find_tilemap_layers(node: Node, result: Array) -> void:
+func _find_tilemap_layers(node: Node, result: Array, scene_root: Node) -> void:
 	if node is TileMapLayer:
 		result.append({
-			"path": str(node.get_path()),
+			"path": str(scene_root.get_path_to(node)),
 			"name": node.name
 		})
 	for child in node.get_children():
-		_find_tilemap_layers(child, result)
+		_find_tilemap_layers(child, result, scene_root)
 
 
-func _find_gridmaps(node: Node, result: Array) -> void:
+func _find_gridmaps(node: Node, result: Array, scene_root: Node) -> void:
 	if node is GridMap:
 		result.append({
-			"path": str(node.get_path()),
+			"path": str(scene_root.get_path_to(node)),
 			"name": node.name
 		})
 	for child in node.get_children():
-		_find_gridmaps(child, result)
+		_find_gridmaps(child, result, scene_root)
 
 
 func _serialize_vector2i(v: Vector2i) -> Dictionary:
@@ -85,10 +85,14 @@ func _deserialize_vector3i(d: Dictionary) -> Vector3i:
 
 func list_tilemap_layers(params: Dictionary) -> Dictionary:
 	var root_path: String = params.get("root_path", "")
+	var scene_root := EditorInterface.get_edited_scene_root()
 	var root: Node
 
+	if not scene_root:
+		return _error("NO_SCENE", "No scene is open")
+
 	if root_path.is_empty():
-		root = EditorInterface.get_edited_scene_root()
+		root = scene_root
 	else:
 		root = _get_node(root_path)
 
@@ -96,7 +100,7 @@ func list_tilemap_layers(params: Dictionary) -> Dictionary:
 		return _error("NODE_NOT_FOUND", "Root node not found")
 
 	var layers := []
-	_find_tilemap_layers(root, layers)
+	_find_tilemap_layers(root, layers, scene_root)
 
 	return _success({"tilemap_layers": layers})
 
@@ -400,10 +404,14 @@ func convert_coords(params: Dictionary) -> Dictionary:
 
 func list_gridmaps(params: Dictionary) -> Dictionary:
 	var root_path: String = params.get("root_path", "")
+	var scene_root := EditorInterface.get_edited_scene_root()
 	var root: Node
 
+	if not scene_root:
+		return _error("NO_SCENE", "No scene is open")
+
 	if root_path.is_empty():
-		root = EditorInterface.get_edited_scene_root()
+		root = scene_root
 	else:
 		root = _get_node(root_path)
 
@@ -411,7 +419,7 @@ func list_gridmaps(params: Dictionary) -> Dictionary:
 		return _error("NODE_NOT_FOUND", "Root node not found")
 
 	var gridmaps := []
-	_find_gridmaps(root, gridmaps)
+	_find_gridmaps(root, gridmaps, scene_root)
 
 	return _success({"gridmaps": gridmaps})
 

--- a/godot/addons/godot_mcp/core/base_command.gd
+++ b/godot/addons/godot_mcp/core/base_command.gd
@@ -47,12 +47,14 @@ func _require_typed_node(path: String, type: String, type_error_code: String = "
 
 func _find_nodes_of_type(root: Node, type: String) -> Array[Dictionary]:
 	var result: Array[Dictionary] = []
-	_find_nodes_recursive(root, type, result)
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root:
+		_find_nodes_recursive(root, type, result, scene_root)
 	return result
 
 
-func _find_nodes_recursive(node: Node, type: String, result: Array[Dictionary]) -> void:
+func _find_nodes_recursive(node: Node, type: String, result: Array[Dictionary], scene_root: Node) -> void:
 	if node.is_class(type):
-		result.append({"path": str(node.get_path()), "name": node.name})
+		result.append({"path": str(scene_root.get_path_to(node)), "name": node.name})
 	for child in node.get_children():
-		_find_nodes_recursive(child, type, result)
+		_find_nodes_recursive(child, type, result, scene_root)

--- a/server/addon/commands/node_commands.gd
+++ b/server/addon/commands/node_commands.gd
@@ -168,9 +168,10 @@ func create_node(params: Dictionary) -> Dictionary:
 			node.set(key, deserialized)
 
 	parent.add_child(node)
-	_set_owner_recursive(node, EditorInterface.get_edited_scene_root())
+	var scene_root := EditorInterface.get_edited_scene_root()
+	_set_owner_recursive(node, scene_root)
 
-	return _success({"node_path": str(node.get_path())})
+	return _success({"node_path": str(scene_root.get_path_to(node))})
 
 
 func _set_owner_recursive(node: Node, owner: Node) -> void:
@@ -250,6 +251,6 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	node.reparent(new_parent)
 
-	return _success({"new_path": str(node.get_path())})
+	return _success({"new_path": str(root.get_path_to(node))})
 
 

--- a/server/addon/commands/script_commands.gd
+++ b/server/addon/commands/script_commands.gd
@@ -136,7 +136,8 @@ func attach_script(params: Dictionary) -> Dictionary:
 	if node.get_script() != script:
 		return _error("ATTACH_FAILED", "Script attachment did not persist")
 
-	return _success({"node_path": str(node.get_path()), "script_path": script_path})
+	var scene_root := EditorInterface.get_edited_scene_root()
+	return _success({"node_path": str(scene_root.get_path_to(node)), "script_path": script_path})
 
 
 func detach_script(params: Dictionary) -> Dictionary:

--- a/server/addon/commands/tilemap_commands.gd
+++ b/server/addon/commands/tilemap_commands.gd
@@ -47,24 +47,24 @@ func _get_gridmap(node_path: String) -> GridMap:
 	return node as GridMap
 
 
-func _find_tilemap_layers(node: Node, result: Array) -> void:
+func _find_tilemap_layers(node: Node, result: Array, scene_root: Node) -> void:
 	if node is TileMapLayer:
 		result.append({
-			"path": str(node.get_path()),
+			"path": str(scene_root.get_path_to(node)),
 			"name": node.name
 		})
 	for child in node.get_children():
-		_find_tilemap_layers(child, result)
+		_find_tilemap_layers(child, result, scene_root)
 
 
-func _find_gridmaps(node: Node, result: Array) -> void:
+func _find_gridmaps(node: Node, result: Array, scene_root: Node) -> void:
 	if node is GridMap:
 		result.append({
-			"path": str(node.get_path()),
+			"path": str(scene_root.get_path_to(node)),
 			"name": node.name
 		})
 	for child in node.get_children():
-		_find_gridmaps(child, result)
+		_find_gridmaps(child, result, scene_root)
 
 
 func _serialize_vector2i(v: Vector2i) -> Dictionary:
@@ -85,10 +85,14 @@ func _deserialize_vector3i(d: Dictionary) -> Vector3i:
 
 func list_tilemap_layers(params: Dictionary) -> Dictionary:
 	var root_path: String = params.get("root_path", "")
+	var scene_root := EditorInterface.get_edited_scene_root()
 	var root: Node
 
+	if not scene_root:
+		return _error("NO_SCENE", "No scene is open")
+
 	if root_path.is_empty():
-		root = EditorInterface.get_edited_scene_root()
+		root = scene_root
 	else:
 		root = _get_node(root_path)
 
@@ -96,7 +100,7 @@ func list_tilemap_layers(params: Dictionary) -> Dictionary:
 		return _error("NODE_NOT_FOUND", "Root node not found")
 
 	var layers := []
-	_find_tilemap_layers(root, layers)
+	_find_tilemap_layers(root, layers, scene_root)
 
 	return _success({"tilemap_layers": layers})
 
@@ -400,10 +404,14 @@ func convert_coords(params: Dictionary) -> Dictionary:
 
 func list_gridmaps(params: Dictionary) -> Dictionary:
 	var root_path: String = params.get("root_path", "")
+	var scene_root := EditorInterface.get_edited_scene_root()
 	var root: Node
 
+	if not scene_root:
+		return _error("NO_SCENE", "No scene is open")
+
 	if root_path.is_empty():
-		root = EditorInterface.get_edited_scene_root()
+		root = scene_root
 	else:
 		root = _get_node(root_path)
 
@@ -411,7 +419,7 @@ func list_gridmaps(params: Dictionary) -> Dictionary:
 		return _error("NODE_NOT_FOUND", "Root node not found")
 
 	var gridmaps := []
-	_find_gridmaps(root, gridmaps)
+	_find_gridmaps(root, gridmaps, scene_root)
 
 	return _success({"gridmaps": gridmaps})
 

--- a/server/addon/core/base_command.gd
+++ b/server/addon/core/base_command.gd
@@ -47,12 +47,14 @@ func _require_typed_node(path: String, type: String, type_error_code: String = "
 
 func _find_nodes_of_type(root: Node, type: String) -> Array[Dictionary]:
 	var result: Array[Dictionary] = []
-	_find_nodes_recursive(root, type, result)
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root:
+		_find_nodes_recursive(root, type, result, scene_root)
 	return result
 
 
-func _find_nodes_recursive(node: Node, type: String, result: Array[Dictionary]) -> void:
+func _find_nodes_recursive(node: Node, type: String, result: Array[Dictionary], scene_root: Node) -> void:
 	if node.is_class(type):
-		result.append({"path": str(node.get_path()), "name": node.name})
+		result.append({"path": str(scene_root.get_path_to(node)), "name": node.name})
 	for child in node.get_children():
-		_find_nodes_recursive(child, type, result)
+		_find_nodes_recursive(child, type, result, scene_root)

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -35,7 +35,7 @@ const categories: ToolCategory[] = [
   { name: 'Editor', filename: 'editor', description: 'Editor control, debugging, and screenshot tools', tools: editorTools },
   { name: 'Project', filename: 'project', description: 'Project information tools', tools: projectTools },
   { name: 'Animation', filename: 'animation', description: 'Animation query, playback, and editing tools', tools: animationTools },
-  { name: 'TileMap/GridMap', filename: 'tilemap', description: 'TileMap and GridMap editing tools', tools: tilemapTools },
+  { name: 'TileMapLayer/GridMap', filename: 'tilemap', description: 'TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprecated TileMap)', tools: tilemapTools },
   { name: 'Resource', filename: 'resource', description: 'Resource inspection tools for SpriteFrames, TileSet, Materials, etc.', tools: resourceTools },
   { name: 'Scene3D', filename: 'scene3d', description: '3D spatial information and bounding box tools', tools: scene3dTools },
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },

--- a/server/src/__tests__/tools/node.test.ts
+++ b/server/src/__tests__/tools/node.test.ts
@@ -238,8 +238,8 @@ describe('node tool', () => {
       });
     });
 
-    it('returns confirmation with both paths', async () => {
-      mock.mockResponse({});
+    it('returns confirmation with new path', async () => {
+      mock.mockResponse({ new_path: 'New/Node' });
       const ctx = createToolContext(mock);
 
       const result = await node.execute({
@@ -248,7 +248,7 @@ describe('node tool', () => {
         new_parent_path: '/root/New',
       }, ctx);
 
-      expect(result).toBe('Moved node /root/Old/Node to /root/New');
+      expect(result).toBe('Reparented node to: New/Node');
     });
 
     it('requires both node_path and new_parent_path for reparent', () => {

--- a/server/src/tools/node.ts
+++ b/server/src/tools/node.ts
@@ -150,11 +150,11 @@ export const node = defineTool({
       }
 
       case 'reparent': {
-        await godot.sendCommand('reparent_node', {
+        const result = await godot.sendCommand<{ new_path: string }>('reparent_node', {
           node_path: args.node_path,
           new_parent_path: args.new_parent_path,
         });
-        return `Moved node ${args.node_path} to ${args.new_parent_path}`;
+        return `Reparented node to: ${result.new_path}`;
       }
 
       case 'attach_script': {


### PR DESCRIPTION
## Summary

- Fixed GDScript commands that were returning full editor hierarchy paths (like `/root/@EditorNode@20446/.../Level/Ground`) instead of scene-relative paths
- These incorrect paths could not be reused with other MCP tools, breaking workflows that chain operations
- Updated `reparent` action to display the node's actual new path instead of echoing input parameters

## Files Fixed

**GDScript:**
- `tilemap_commands.gd`: `list_tilemap_layers`, `list_gridmaps`
- `node_commands.gd`: `create_node`, `reparent_node`
- `script_commands.gd`: `attach_script`
- `base_command.gd`: `_find_nodes_of_type`, `_find_nodes_recursive`

**TypeScript:**
- `node.ts`: `reparent` action now uses returned `new_path`

## Root Cause

Using `node.get_path()` in the editor context returns the full path through the editor's internal node hierarchy. The fix uses `scene_root.get_path_to(node)` which returns the correct scene-relative path.

## Test plan

- [x] Verified `tilemap list_layers` returns paths like `Level/Ground` instead of full editor paths
- [x] Verified `node create` returns correct relative paths
- [x] Verified `node reparent` returns the new path from Godot
- [x] All existing tests pass (162/162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)