### PR TITLE
fix: improve error handling and validation across MCP server and addon

### DIFF
--- a/godot/addons/godot_mcp/commands/script_commands.gd
+++ b/godot/addons/godot_mcp/commands/script_commands.gd
@@ -68,7 +68,21 @@ func create_script(params: Dictionary) -> Dictionary:
 		return _error("WRITE_FAILED", "Failed to create script: %s" % script_path)
 
 	file.store_string(content)
+	var write_err := file.get_error()
 	file.close()
+
+	if write_err != OK:
+		return _error("WRITE_FAILED", "Failed to write script: %s (error: %s)" % [script_path, error_string(write_err)])
+
+	var verify_file := FileAccess.open(script_path, FileAccess.READ)
+	if not verify_file:
+		return _error("WRITE_VERIFY_FAILED", "Cannot verify script was written: %s" % script_path)
+
+	var written_content := verify_file.get_as_text()
+	verify_file.close()
+
+	if written_content.length() != content.length():
+		return _error("WRITE_VERIFY_FAILED", "Content length mismatch: expected %d, got %d" % [content.length(), written_content.length()])
 
 	EditorInterface.get_resource_filesystem().scan()
 
@@ -97,7 +111,21 @@ func edit_script(params: Dictionary) -> Dictionary:
 		return _error("WRITE_FAILED", "Failed to write script: %s" % script_path)
 
 	file.store_string(content)
+	var write_err := file.get_error()
 	file.close()
+
+	if write_err != OK:
+		return _error("WRITE_FAILED", "Failed to write script: %s (error: %s)" % [script_path, error_string(write_err)])
+
+	var verify_file := FileAccess.open(script_path, FileAccess.READ)
+	if not verify_file:
+		return _error("WRITE_VERIFY_FAILED", "Cannot verify script was written: %s" % script_path)
+
+	var written_content := verify_file.get_as_text()
+	verify_file.close()
+
+	if written_content.length() != content.length():
+		return _error("WRITE_VERIFY_FAILED", "Content length mismatch: expected %d, got %d" % [content.length(), written_content.length()])
 
 	EditorInterface.get_resource_filesystem().scan()
 

--- a/server/addon/commands/script_commands.gd
+++ b/server/addon/commands/script_commands.gd
@@ -68,7 +68,21 @@ func create_script(params: Dictionary) -> Dictionary:
 		return _error("WRITE_FAILED", "Failed to create script: %s" % script_path)
 
 	file.store_string(content)
+	var write_err := file.get_error()
 	file.close()
+
+	if write_err != OK:
+		return _error("WRITE_FAILED", "Failed to write script: %s (error: %s)" % [script_path, error_string(write_err)])
+
+	var verify_file := FileAccess.open(script_path, FileAccess.READ)
+	if not verify_file:
+		return _error("WRITE_VERIFY_FAILED", "Cannot verify script was written: %s" % script_path)
+
+	var written_content := verify_file.get_as_text()
+	verify_file.close()
+
+	if written_content.length() != content.length():
+		return _error("WRITE_VERIFY_FAILED", "Content length mismatch: expected %d, got %d" % [content.length(), written_content.length()])
 
 	EditorInterface.get_resource_filesystem().scan()
 
@@ -97,7 +111,21 @@ func edit_script(params: Dictionary) -> Dictionary:
 		return _error("WRITE_FAILED", "Failed to write script: %s" % script_path)
 
 	file.store_string(content)
+	var write_err := file.get_error()
 	file.close()
+
+	if write_err != OK:
+		return _error("WRITE_FAILED", "Failed to write script: %s (error: %s)" % [script_path, error_string(write_err)])
+
+	var verify_file := FileAccess.open(script_path, FileAccess.READ)
+	if not verify_file:
+		return _error("WRITE_VERIFY_FAILED", "Cannot verify script was written: %s" % script_path)
+
+	var written_content := verify_file.get_as_text()
+	verify_file.close()
+
+	if written_content.length() != content.length():
+		return _error("WRITE_VERIFY_FAILED", "Content length mismatch: expected %d, got %d" % [content.length(), written_content.length()])
 
 	EditorInterface.get_resource_filesystem().scan()
 

--- a/server/src/core/registry.ts
+++ b/server/src/core/registry.ts
@@ -1,6 +1,11 @@
 import type { AnyToolDefinition, ResourceDefinition, ToolContext, ToolResult } from './types.js';
 import { toInputSchema } from './schema.js';
-import { formatError } from '../utils/errors.js';
+import {
+  formatError,
+  GodotCommandError,
+  GodotConnectionError,
+  GodotTimeoutError,
+} from '../utils/errors.js';
 
 class ToolRegistry {
   private tools: Map<string, AnyToolDefinition> = new Map();
@@ -65,6 +70,13 @@ class ToolRegistry {
       const validated = tool.schema.parse(args);
       return await tool.execute(validated, ctx);
     } catch (error) {
+      if (
+        error instanceof GodotCommandError ||
+        error instanceof GodotConnectionError ||
+        error instanceof GodotTimeoutError
+      ) {
+        throw error;
+      }
       throw new Error(formatError(error));
     }
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import { initializeConnection, getGodotConnection } from './connection/websocket
 import { registry } from './core/registry.js';
 import { registerAllTools } from './tools/index.js';
 import { registerAllResources } from './resources/index.js';
+import { GodotCommandError } from './utils/errors.js';
 
 registerAllTools();
 registerAllResources();
@@ -48,7 +49,14 @@ export async function main() {
         content: [result],
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      let message: string;
+      if (error instanceof GodotCommandError) {
+        message = `[${error.code}] ${error.message}`;
+      } else if (error instanceof Error) {
+        message = error.message;
+      } else {
+        message = String(error);
+      }
       return {
         content: [{ type: 'text', text: `Error: ${message}` }],
         isError: true,


### PR DESCRIPTION
## Summary

- Preserve error codes from Godot (e.g., `FILE_NOT_FOUND`) through to MCP responses instead of losing them when re-wrapping errors
- Log reconnection failures for visibility instead of silently swallowing them
- Validate file writes with post-write verification in `create_script` and `edit_script` commands
- Track handshake status and emit `handshake_failed` event for better diagnostics

## Test plan

**Automated (CI):**
- [x] Build passes (`npm run build`)
- [x] Existing tests pass (`npm test`) - 167 tests

**Manual - Error code preservation:**
1. Start Godot with the addon enabled
2. Use an MCP client to call `read_script` with a non-existent path like `res://does_not_exist.gd`
3. Verify the error response contains `[FILE_NOT_FOUND]` prefix, not just a generic message

**Manual - Reconnection logging:**
1. Start the MCP server with Godot running
2. Close Godot (or kill the addon)
3. Check MCP server stderr - should see reconnection attempt logs with failure reasons, not silent retries

**Manual - File write validation (GDScript side):**
1. Use `create_script` to create a new script
2. Verify the script file exists and has correct content
3. (Edge case) If you can simulate a disk-full or permission error, verify `WRITE_FAILED` or `WRITE_VERIFY_FAILED` is returned

**Not directly testable without version mismatch:**
- Handshake failure event emission (would require an outdated addon version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)