### PR TITLE
fix: prevent CLI commands from spawning unwanted WebSocket connections

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -56,9 +56,10 @@ if (values['install-addon']) {
     console.error('Error:', result.message);
     process.exit(1);
   }
+} else {
+  // Only start the MCP server if no CLI command was specified
+  main().catch((error) => {
+    console.error('[godot-mcp] Fatal error:', error);
+    process.exit(1);
+  });
 }
-
-main().catch((error) => {
-  console.error('[godot-mcp] Fatal error:', error);
-  process.exit(1);
-});


### PR DESCRIPTION
## Summary

CLI commands like `--install-addon` were unintentionally starting WebSocket connections to Godot because `main()` was called unconditionally at the end of cli.ts.

## The Problem

```typescript
if (values['install-addon']) {
  // ... install logic with process.exit() ...
}

main().catch(...);  // Called even when --install-addon is set!
```

## The Fix

Wrap `main()` in an else clause so it only runs when no CLI command is specified.

## Testing

```bash
node dist/cli.js --install-addon /path/to/project
```

Before: Shows WebSocket connection/reconnection messages
After: Clean install output, exits immediately

🤖 Generated with [Claude Code](https://claude.ai/code)