### PR TITLE
fix: use dynamic import for MCP server to fix npx stdin issue

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { parseArgs } from 'node:util';
-import { main } from './index.js';
 import { installAddon } from './installer/install.js';
 import { getServerVersion } from './version.js';
 
@@ -58,6 +57,8 @@ if (values['install-addon']) {
   }
 } else {
   // Only start the MCP server if no CLI command was specified
+  // Dynamic import avoids loading MCP SDK for CLI commands (fixes npx stdin issue)
+  const { main } = await import('./index.js');
   main().catch((error) => {
     console.error('[godot-mcp] Fatal error:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary

Fixes an issue where `npx @satelliteoflove/godot-mcp --install-addon` (and other CLI commands) would start the MCP server and spam connection errors instead of running the requested command.

## The Problem

When running via `npx` with interactive stdin (TTY), the MCP SDK's `StdioServerTransport` interferes with normal CLI operation. Even though the CLI code correctly checks for flags before calling `main()`, the static import of `index.js` at the top of `cli.ts` loads the MCP SDK during module initialization.

## The Fix

Use dynamic `import()` for the `main` function so `index.js` (and the MCP SDK) only loads when actually starting the server:

```typescript
// Before (static import - always loads MCP SDK)
import { main } from './index.js';

// After (dynamic import - only loads when needed)
const { main } = await import('./index.js');
```

CLI commands (`--help`, `--version`, `--install-addon`) now exit before any MCP-related code is loaded.

## Testing

- `node dist/cli.js --help` - works correctly
- `node dist/cli.js --version` - works correctly  
- `node dist/cli.js --install-addon /path` - works correctly
- `node dist/cli.js` (no args) - starts server correctly
- All 184 unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)