### PR TITLE
fix: return generated UID from scene create action

### DIFF
--- a/godot/addons/godot_mcp/commands/scene_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene_commands.gd
@@ -127,5 +127,7 @@ func create_scene(params: Dictionary) -> Dictionary:
 		return _error("SAVE_FAILED", "Failed to save scene: %s" % error_string(err))
 
 	EditorInterface.open_scene_from_path(scene_path)
-	return _success({"path": scene_path})
+
+	var uid := ResourceUID.id_to_text(ResourceLoader.get_resource_uid(scene_path))
+	return _success({"path": scene_path, "uid": uid})
 

--- a/server/src/__tests__/tools/scene.test.ts
+++ b/server/src/__tests__/tools/scene.test.ts
@@ -105,8 +105,8 @@ describe('scene tool', () => {
       expect(mock.calls[0].params.root_name).toBe('Control');
     });
 
-    it('returns confirmation message', async () => {
-      mock.mockResponse({});
+    it('returns confirmation message with UID', async () => {
+      mock.mockResponse({ path: 'res://levels/world.tscn', uid: 'uid://abc123xyz' });
       const ctx = createToolContext(mock);
 
       const result = await scene.execute({
@@ -115,7 +115,7 @@ describe('scene tool', () => {
         scene_path: 'res://levels/world.tscn',
       }, ctx);
 
-      expect(result).toBe('Created scene: res://levels/world.tscn with root node type Node3D');
+      expect(result).toBe('Created scene: res://levels/world.tscn with root node type Node3D\nUID: uid://abc123xyz');
     });
 
     it('requires root_type and scene_path for create', () => {

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -60,12 +60,12 @@ export const scene = defineTool({
       }
 
       case 'create': {
-        await godot.sendCommand('create_scene', {
+        const result = await godot.sendCommand<{ path: string; uid: string }>('create_scene', {
           root_type: args.root_type,
           root_name: args.root_name ?? args.root_type,
           scene_path: args.scene_path,
         });
-        return `Created scene: ${args.scene_path} with root node type ${args.root_type}`;
+        return `Created scene: ${result.path} with root node type ${args.root_type}\nUID: ${result.uid}`;
       }
     }
   },


### PR DESCRIPTION
## Summary
- When creating a scene via the `scene` tool's `create` action, the response now includes the generated UID
- Enables callers to reference scenes by UID (more stable than path) for things like setting main_scene in project.godot

## Changes
- **GDScript**: After saving, open the scene first (to register the UID), then return it in the response
- **TypeScript**: Capture the response and include the UID in the output message

## Test plan
- [x] Create a scene via MCP and verify the UID is returned
- [x] Verify the returned UID matches what's in the .tscn file

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)