### PR TITLE
feat: add source parameter to get_debug_output for editor vs game output

### DIFF
--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -20,6 +20,7 @@ Control the Godot editor: get state (includes viewport/camera info), manage sele
 | `node_path` | string | select | Path to node |
 | `scene_path` | string | No | Scene to run (run only, optional) |
 | `clear` | boolean | get_debug_output | Clear output buffer after reading |
+| `source` | `editor`, `game` | No | Output source: "editor" for editor panel messages (script errors, loading failures), "game" for running game output. If omitted, returns game output when running, else editor output. |
 | `viewport` | `2d`, `3d` | screenshot_editor | Which editor viewport to capture |
 | `max_width` | number | screenshot_game, screenshot_editor | Maximum width in pixels for screenshot |
 | `center_x` | number | set_viewport_2d | X coordinate to center the 2D viewport on |

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -190,7 +190,7 @@ describe('editor tool', () => {
 
   describe('action: get_debug_output', () => {
     it('sends get_debug_output command', async () => {
-      mock.mockResponse({ output: 'Debug message' });
+      mock.mockResponse({ output: 'Debug message', source: 'game' });
       const ctx = createToolContext(mock);
 
       await editor.execute({ action: 'get_debug_output' }, ctx);
@@ -199,7 +199,7 @@ describe('editor tool', () => {
     });
 
     it('passes clear parameter', async () => {
-      mock.mockResponse({ output: 'Debug message' });
+      mock.mockResponse({ output: 'Debug message', source: 'game' });
       const ctx = createToolContext(mock);
 
       await editor.execute({ action: 'get_debug_output', clear: true }, ctx);
@@ -207,7 +207,36 @@ describe('editor tool', () => {
       expect(mock.calls[0].params.clear).toBe(true);
     });
 
-    it('returns formatted output', async () => {
+    it('passes source parameter', async () => {
+      mock.mockResponse({ output: 'Editor error', source: 'editor' });
+      const ctx = createToolContext(mock);
+
+      await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
+
+      expect(mock.calls[0].params.source).toBe('editor');
+    });
+
+    it('returns formatted output with Editor label for editor source', async () => {
+      mock.mockResponse({ output: 'Script parse error', source: 'editor' });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
+
+      expect(result).toContain('Editor output:');
+      expect(result).toContain('Script parse error');
+    });
+
+    it('returns formatted output with Game label for game source', async () => {
+      mock.mockResponse({ output: 'Player spawned', source: 'game' });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_debug_output', source: 'game' }, ctx);
+
+      expect(result).toContain('Game output:');
+      expect(result).toContain('Player spawned');
+    });
+
+    it('returns formatted output with Debug label when no source', async () => {
       mock.mockResponse({ output: 'Error: Something went wrong' });
       const ctx = createToolContext(mock);
 
@@ -217,7 +246,16 @@ describe('editor tool', () => {
       expect(result).toContain('Error: Something went wrong');
     });
 
-    it('returns message when no output', async () => {
+    it('returns message when no output with source label', async () => {
+      mock.mockResponse({ output: '', source: 'editor' });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
+
+      expect(result).toBe('No editor output');
+    });
+
+    it('returns message when no output without source', async () => {
       mock.mockResponse({ output: '' });
       const ctx = createToolContext(mock);
 


### PR DESCRIPTION
## Summary
- Adds `source` parameter to `get_debug_output` action to explicitly request editor or game output
- `source: "editor"` - returns editor Output panel messages (script errors, scene loading failures)
- `source: "game"` - returns game runtime output only (errors if game not running)
- No source - preserves backwards-compatible behavior (game if running, else editor)

## Problem
When building scenes via MCP, if a scene fails to load, the game crashes immediately with no debug output captured. The error is only visible in the editor's Output panel, but `get_debug_output` would try to fetch game output (which doesn't exist).

## Solution
Allow explicit control over which output source to retrieve, so AI assistants can request editor-side errors when debugging loading failures.

## Test plan
- [x] `get_debug_output` with no source - backwards compatible behavior
- [x] `get_debug_output` with `source: "editor"` - returns editor output
- [x] `get_debug_output` with `source: "game"` - returns game output (or error if not running)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)