### PR TITLE
feat: add signal connection support to node tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Open your Godot project (with addon enabled), restart your AI assistant, and sta
 | Tool | Description |
 |------|-------------|
 | `scene` | Manage scenes: open, save, or create scenes |
-| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts |
+| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals |
 | `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom |
 | `project` | Get project information and settings |
 | `animation` | Query, control, and edit animations |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -12,7 +12,7 @@ Scene management tools
 
 Node manipulation and script attachment tools
 
-- `node` - Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts
+- `node` - Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
 
 ## [Editor](editor.md)
 

--- a/docs/tools/node.md
+++ b/docs/tools/node.md
@@ -10,13 +10,13 @@ Node manipulation and script attachment tools
 
 ## node
 
-Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts
+Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | `get_properties`, `find`, `create`, `update`, `delete`, `reparent`, `attach_script`, `detach_script` | Yes | Action: get_properties, find, create, update, delete, reparent, attach_script, detach_script |
+| `action` | `get_properties`, `find`, `create`, `update`, `delete`, `reparent`, `attach_script`, `detach_script`, `connect_signal` | Yes | Action: get_properties, find, create, update, delete, reparent, attach_script, detach_script, connect_signal |
 | `node_path` | string | get_properties, update, delete, reparent, attach_script, detach_script | Path to the node |
 | `name_pattern` | string | find | Glob pattern to match node names, e.g. "*Spawner*", "Turret?" |
 | `type` | string | find | Filter by node type, e.g. "CharacterBody2D", "Area2D" |
@@ -28,6 +28,9 @@ Manage scene nodes: get properties, find, create, update, delete, reparent, atta
 | `properties` | Record<string, unknown> | create, update | Properties to set |
 | `new_parent_path` | string | reparent | Path to the new parent node |
 | `script_path` | string | attach_script | Path to the script file |
+| `signal_name` | string | connect_signal | Name of the signal to connect, e.g. "pressed", "body_entered" |
+| `target_path` | string | connect_signal | Path to the target node that will receive the signal |
+| `method_name` | string | connect_signal | Name of the method to call on the target node |
 
 ### Actions
 
@@ -63,6 +66,10 @@ Parameters: `node_path`*, `script_path`*
 
 Parameters: `node_path`*
 
+#### `connect_signal`
+
+Parameters: `signal_name`*, `target_path`*, `method_name`*
+
 ### Examples
 
 ```json
@@ -93,7 +100,7 @@ Parameters: `node_path`*
 }
 ```
 
-*5 more actions available: `update`, `delete`, `reparent`, `attach_script`, `detach_script`*
+*6 more actions available: `update`, `delete`, `reparent`, `attach_script`, `detach_script`, `connect_signal`*
 
 ---
 

--- a/server/README.md
+++ b/server/README.md
@@ -72,7 +72,7 @@ Open your Godot project (with addon enabled), restart your AI assistant, and sta
 | Tool | Description |
 |------|-------------|
 | `scene` | Manage scenes: open, save, or create scenes |
-| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts |
+| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals |
 | `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom |
 | `project` | Get project information and settings |
 | `animation` | Query, control, and edit animations |

--- a/server/src/__tests__/tools/node.test.ts
+++ b/server/src/__tests__/tools/node.test.ts
@@ -337,4 +337,69 @@ describe('node tool', () => {
       expect(node.schema.safeParse({ action: 'detach_script', node_path: '/root/Test' }).success).toBe(true);
     });
   });
+
+  describe('action: connect_signal', () => {
+    it('sends connect_signal command with all params', async () => {
+      mock.mockResponse({});
+      const ctx = createToolContext(mock);
+
+      await node.execute({
+        action: 'connect_signal',
+        node_path: '/root/Main/Button',
+        signal_name: 'pressed',
+        target_path: '/root/Main',
+        method_name: '_on_button_pressed',
+      }, ctx);
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].command).toBe('connect_signal');
+      expect(mock.calls[0].params).toEqual({
+        node_path: '/root/Main/Button',
+        signal_name: 'pressed',
+        target_path: '/root/Main',
+        method_name: '_on_button_pressed',
+      });
+    });
+
+    it('returns confirmation message', async () => {
+      mock.mockResponse({});
+      const ctx = createToolContext(mock);
+
+      const result = await node.execute({
+        action: 'connect_signal',
+        node_path: '/root/Main/Area2D',
+        signal_name: 'body_entered',
+        target_path: '/root/Main/Player',
+        method_name: '_on_area_entered',
+      }, ctx);
+
+      expect(result).toBe('Connected /root/Main/Area2D.body_entered to /root/Main/Player._on_area_entered()');
+    });
+
+    it('requires all signal connection params', () => {
+      expect(node.schema.safeParse({ action: 'connect_signal' }).success).toBe(false);
+      expect(node.schema.safeParse({
+        action: 'connect_signal',
+        node_path: '/root/Button',
+      }).success).toBe(false);
+      expect(node.schema.safeParse({
+        action: 'connect_signal',
+        node_path: '/root/Button',
+        signal_name: 'pressed',
+      }).success).toBe(false);
+      expect(node.schema.safeParse({
+        action: 'connect_signal',
+        node_path: '/root/Button',
+        signal_name: 'pressed',
+        target_path: '/root/Main',
+      }).success).toBe(false);
+      expect(node.schema.safeParse({
+        action: 'connect_signal',
+        node_path: '/root/Button',
+        signal_name: 'pressed',
+        target_path: '/root/Main',
+        method_name: '_on_pressed',
+      }).success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Adds a `connect_signal` action to the node tool for connecting signals between nodes via MCP.

## Features
- Connect any signal from a source node to a method on a target node
- Uses `CONNECT_PERSIST` flag so connections persist when scene is saved
- Validates signal exists on source node
- Prevents duplicate connections

## Example
```json
{
  "action": "connect_signal",
  "node_path": "/root/MainMenu/Button",
  "signal_name": "pressed",
  "target_path": "/root/MainMenu",
  "method_name": "_on_button_pressed"
}
```

## Test plan
- [x] Connect signal via MCP
- [x] Verify connection works at runtime
- [x] Save scene and verify `[connection]` entry persists in .tscn file
- [x] Reload scene and verify connection still works

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)