### PR TITLE
feat: add get_errors and get_stack_trace actions to editor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Open your Godot project (with addon enabled), restart your AI assistant, and sta
 |------|-------------|
 | `scene` | Manage scenes: open, save, or create scenes |
 | `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals |
-| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom |
+| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_errors (structured errors with file:line), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom |
 | `project` | Get project information and settings |
 | `animation` | Query, control, and edit animations |
 | `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -18,7 +18,7 @@ Node manipulation and script attachment tools
 
 Editor control, debugging, and screenshot tools
 
-- `editor` - Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom
+- `editor` - Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_errors (structured errors with file:line), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom
 
 ## [Project](project.md)
 

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -10,13 +10,13 @@ Editor control, debugging, and screenshot tools
 
 ## editor
 
-Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom
+Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_errors (structured errors with file:line), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_debug_output`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_debug_output, get_performance, screenshot_game, screenshot_editor, set_viewport_2d |
+| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_debug_output`, `get_errors`, `get_stack_trace`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_debug_output, get_errors, get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d |
 | `node_path` | string | select | Path to node |
 | `scene_path` | string | No | Scene to run (run only, optional) |
 | `clear` | boolean | get_debug_output | Clear output buffer after reading |
@@ -44,6 +44,10 @@ Parameters: `node_path`*
 #### `get_debug_output`
 
 Parameters: `clear`*
+
+#### `get_errors`
+
+#### `get_stack_trace`
 
 #### `get_performance`
 
@@ -83,7 +87,7 @@ Parameters: `center_x`*, `center_y`*, `zoom`*
 }
 ```
 
-*7 more actions available: `run`, `stop`, `get_debug_output`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d`*
+*9 more actions available: `run`, `stop`, `get_debug_output`, `get_errors`, `get_stack_trace`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d`*
 
 ---
 

--- a/godot/addons/godot_mcp/commands/debug_commands.gd
+++ b/godot/addons/godot_mcp/commands/debug_commands.gd
@@ -17,7 +17,9 @@ func get_commands() -> Dictionary:
 		"run_project": run_project,
 		"stop_project": stop_project,
 		"get_debug_output": get_debug_output,
-		"get_performance_metrics": get_performance_metrics
+		"get_performance_metrics": get_performance_metrics,
+		"get_errors": get_errors,
+		"get_stack_trace": get_stack_trace,
 	}
 
 
@@ -126,3 +128,24 @@ func get_performance_metrics(_params: Dictionary) -> Dictionary:
 func _on_performance_metrics_received(metrics: Dictionary) -> void:
 	_performance_metrics_pending = false
 	_performance_metrics_result = metrics
+
+
+func get_errors(params: Dictionary) -> Dictionary:
+	var clear: bool = params.get("clear", false)
+	var errors := MCPLogger.get_errors()
+	if clear:
+		MCPLogger.clear_errors()
+	return _success({"error_count": errors.size(), "errors": errors})
+
+
+func get_stack_trace(_params: Dictionary) -> Dictionary:
+	var frames := MCPLogger.get_last_stack_trace()
+	var errors := MCPLogger.get_errors()
+	var last_error: Dictionary = errors[-1] if not errors.is_empty() else {}
+	return _success({
+		"error": last_error.get("message", ""),
+		"error_type": last_error.get("type", ""),
+		"file": last_error.get("file", ""),
+		"line": last_error.get("line", 0),
+		"frames": frames,
+	})

--- a/godot/addons/godot_mcp/commands/system_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/system_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://c22fvs7y7mjiu

--- a/godot/addons/godot_mcp/core/mcp_log.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_log.gd.uid
@@ -1,0 +1,1 @@
+uid://bavtmnjx74t1l

--- a/server/README.md
+++ b/server/README.md
@@ -73,7 +73,7 @@ Open your Godot project (with addon enabled), restart your AI assistant, and sta
 |------|-------------|
 | `scene` | Manage scenes: open, save, or create scenes |
 | `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals |
-| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get performance metrics, capture screenshots, set 2D viewport position/zoom |
+| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_errors (structured errors with file:line), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom |
 | `project` | Get project information and settings |
 | `animation` | Query, control, and edit animations |
 | `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -265,6 +265,98 @@ describe('editor tool', () => {
     });
   });
 
+  describe('action: get_errors', () => {
+    it('sends get_errors command', async () => {
+      mock.mockResponse({ error_count: 0, errors: [] });
+      const ctx = createToolContext(mock);
+
+      await editor.execute({ action: 'get_errors' }, ctx);
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].command).toBe('get_errors');
+    });
+
+    it('passes clear parameter', async () => {
+      mock.mockResponse({ error_count: 0, errors: [] });
+      const ctx = createToolContext(mock);
+
+      await editor.execute({ action: 'get_errors', clear: true }, ctx);
+
+      expect(mock.calls[0].params.clear).toBe(true);
+    });
+
+    it('returns "No errors" when error_count is 0', async () => {
+      mock.mockResponse({ error_count: 0, errors: [] });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_errors' }, ctx);
+
+      expect(result).toBe('No errors');
+    });
+
+    it('returns JSON with errors when present', async () => {
+      const errorData = {
+        error_count: 1,
+        errors: [{
+          timestamp: 12345,
+          type: 'Parser Error',
+          message: 'Could not find type "DungeonData"',
+          file: 'res://scenes/dungeon.gd',
+          line: 10,
+          function: '',
+          error_type: 1,
+          frames: [],
+        }],
+      };
+      mock.mockResponse(errorData);
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_errors' }, ctx);
+
+      expect(result).toBe(JSON.stringify(errorData, null, 2));
+    });
+  });
+
+  describe('action: get_stack_trace', () => {
+    it('sends get_stack_trace command', async () => {
+      mock.mockResponse({ error: '', error_type: '', file: '', line: 0, frames: [] });
+      const ctx = createToolContext(mock);
+
+      await editor.execute({ action: 'get_stack_trace' }, ctx);
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].command).toBe('get_stack_trace');
+    });
+
+    it('returns "No stack trace available" when empty', async () => {
+      mock.mockResponse({ error: '', error_type: '', file: '', line: 0, frames: [] });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_stack_trace' }, ctx);
+
+      expect(result).toBe('No stack trace available');
+    });
+
+    it('returns JSON with stack trace when present', async () => {
+      const stackData = {
+        error: 'Null instance access',
+        error_type: 'Runtime Error',
+        file: 'res://player.gd',
+        line: 42,
+        frames: [
+          { file: 'res://player.gd', line: 42, function: '_process' },
+          { file: 'res://main.gd', line: 15, function: '_ready' },
+        ],
+      };
+      mock.mockResponse(stackData);
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'get_stack_trace' }, ctx);
+
+      expect(result).toBe(JSON.stringify(stackData, null, 2));
+    });
+  });
+
   describe('action: get_performance', () => {
     it('sends get_performance_metrics command', async () => {
       mock.mockResponse({ fps: 60 });


### PR DESCRIPTION
## Summary

- Adds `get_errors` action to retrieve structured error data (timestamp, type, message, file, line, stack frames)
- Adds `get_stack_trace` action to get the most recent error's backtrace
- Enhances MCPLogger to store structured error data from Godot's Logger._log_error() callback

Closes #98

## Test plan

- [x] Tested get_errors returns structured error data for parser errors
- [x] Tested get_stack_trace returns backtrace frames
- [x] Tested clear parameter clears errors after reading
- [x] All 198 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)