### PR TITLE
refactor: clean up test suite, remove low-value tests

### DIFF
--- a/server/src/__tests__/schema.test.ts
+++ b/server/src/__tests__/schema.test.ts
@@ -3,44 +3,26 @@ import { z } from 'zod';
 import { toInputSchema } from '../core/schema.js';
 
 describe('toInputSchema', () => {
-  it('converts simple object schema', () => {
-    const schema = z.object({
-      name: z.string(),
-    });
-
-    const result = toInputSchema(schema);
-
-    expect(result).toHaveProperty('type', 'object');
-    expect(result).toHaveProperty('properties');
-    expect((result as Record<string, unknown>).properties).toHaveProperty('name');
-  });
-
-  it('converts schema with optional fields', () => {
+  it('converts object schema with required/optional fields and descriptions', () => {
     const schema = z.object({
       required_field: z.string(),
       optional_field: z.string().optional(),
-    });
-
-    const result = toInputSchema(schema) as Record<string, unknown>;
-
-    expect(result.required).toContain('required_field');
-    expect(result.required).not.toContain('optional_field');
-  });
-
-  it('converts schema with descriptions', () => {
-    const schema = z.object({
       path: z.string().describe('The file path'),
     });
 
     const result = toInputSchema(schema) as Record<string, unknown>;
-    const properties = result.properties as Record<string, unknown>;
-    const pathProp = properties.path as Record<string, unknown>;
 
-    expect(pathProp.description).toBe('The file path');
+    expect(result.type).toBe('object');
+    expect(result.required).toContain('required_field');
+    expect(result.required).not.toContain('optional_field');
+
+    const props = result.properties as Record<string, Record<string, unknown>>;
+    expect(props.path.description).toBe('The file path');
   });
 
-  it('converts nested object schema', () => {
+  it('converts nested objects and primitive types', () => {
     const schema = z.object({
+      enabled: z.boolean(),
       node: z.object({
         name: z.string(),
         type: z.string(),
@@ -48,40 +30,15 @@ describe('toInputSchema', () => {
     });
 
     const result = toInputSchema(schema) as Record<string, unknown>;
-    const properties = result.properties as Record<string, unknown>;
-    const nodeProp = properties.node as Record<string, unknown>;
+    const props = result.properties as Record<string, Record<string, unknown>>;
 
-    expect(nodeProp.type).toBe('object');
-    expect(nodeProp.properties).toHaveProperty('name');
-    expect(nodeProp.properties).toHaveProperty('type');
-  });
-
-  it('converts boolean schema', () => {
-    const schema = z.object({
-      enabled: z.boolean(),
-    });
-
-    const result = toInputSchema(schema) as Record<string, unknown>;
-    const properties = result.properties as Record<string, unknown>;
-    const enabledProp = properties.enabled as Record<string, unknown>;
-
-    expect(enabledProp.type).toBe('boolean');
+    expect(props.enabled.type).toBe('boolean');
+    expect(props.node.type).toBe('object');
+    expect((props.node.properties as Record<string, unknown>)).toHaveProperty('name');
   });
 
   it('removes $schema property from output', () => {
-    const schema = z.object({ test: z.string() });
-
-    const result = toInputSchema(schema);
-
+    const result = toInputSchema(z.object({ test: z.string() }));
     expect(result).not.toHaveProperty('$schema');
-  });
-
-  it('converts empty object schema', () => {
-    const schema = z.object({});
-
-    const result = toInputSchema(schema) as Record<string, unknown>;
-
-    expect(result.type).toBe('object');
-    expect(result.properties).toEqual({});
   });
 });

--- a/server/src/__tests__/tools/animation.test.ts
+++ b/server/src/__tests__/tools/animation.test.ts
@@ -1,102 +1,62 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
-import { animation, animationTools } from '../../tools/animation.js';
+import { animation } from '../../tools/animation.js';
 
 describe('animation tool', () => {
-  describe('tool definitions', () => {
-    it('exports one tool', () => {
-      expect(animationTools).toHaveLength(1);
-    });
+  let mock: MockGodotConnection;
 
-    it('has animation tool with all action types', () => {
-      expect(animation.name).toBe('animation');
-      expect(animation.description).toContain('Query');
-      expect(animation.description).toContain('Playback');
-      expect(animation.description).toContain('Edit');
-    });
+  beforeEach(() => {
+    mock = createMockGodot();
   });
 
   describe('query actions', () => {
-    let mock: MockGodotConnection;
-
-    beforeEach(() => {
-      mock = createMockGodot();
-    });
-
-    it('list_players sends command and formats empty result', async () => {
-      mock.mockResponse({ animation_players: [] });
+    it('list_players returns formatted list or empty message', async () => {
       const ctx = createToolContext(mock);
 
-      const result = await animation.execute({ action: 'list_players' }, ctx);
+      mock.mockResponse({ animation_players: [] });
+      expect(await animation.execute({ action: 'list_players' }, ctx))
+        .toBe('No AnimationPlayer nodes found in scene');
 
-      expect(mock.calls[0].command).toBe('list_animation_players');
-      expect(result).toBe('No AnimationPlayer nodes found in scene');
-    });
-
-    it('list_players formats found players', async () => {
       mock.mockResponse({
         animation_players: [
           { path: '/root/Player/AnimPlayer', name: 'AnimPlayer' },
           { path: '/root/Enemy/AnimPlayer', name: 'AnimPlayer' },
         ],
       });
-      const ctx = createToolContext(mock);
-
       const result = await animation.execute({ action: 'list_players' }, ctx);
-
       expect(result).toContain('Found 2 AnimationPlayer(s)');
       expect(result).toContain('/root/Player/AnimPlayer');
     });
 
-    it('get_info sends command and returns JSON', async () => {
-      const info = { current_animation: 'idle', is_playing: true, current_position: 0.5 };
-      mock.mockResponse(info);
+    it('get_info/get_details/get_keyframes return JSON', async () => {
       const ctx = createToolContext(mock);
 
-      const result = await animation.execute({
+      const info = { current_animation: 'idle', is_playing: true };
+      mock.mockResponse(info);
+      expect(JSON.parse(await animation.execute({
         action: 'get_info',
         node_path: '/root/AnimPlayer',
-      }, ctx);
+      }, ctx) as string)).toEqual(info);
 
-      expect(mock.calls[0].command).toBe('get_animation_player_info');
-      expect(mock.calls[0].params.node_path).toBe('/root/AnimPlayer');
-      expect(result).toBe(JSON.stringify(info, null, 2));
-    });
-
-    it('get_details sends command with animation name', async () => {
       const details = { name: 'walk', length: 1.5, track_count: 3 };
       mock.mockResponse(details);
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(JSON.parse(await animation.execute({
         action: 'get_details',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
-      }, ctx);
+      }, ctx) as string)).toEqual(details);
 
-      expect(mock.calls[0].command).toBe('get_animation_details');
-      expect(mock.calls[0].params.animation_name).toBe('walk');
-      expect(result).toBe(JSON.stringify(details, null, 2));
-    });
-
-    it('get_keyframes sends command with track index', async () => {
       const keyframes = { track_path: 'Sprite:frame', keyframes: [{ time: 0, value: 0 }] };
       mock.mockResponse(keyframes);
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(JSON.parse(await animation.execute({
         action: 'get_keyframes',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
         track_index: 0,
-      }, ctx);
-
-      expect(mock.calls[0].command).toBe('get_track_keyframes');
-      expect(mock.calls[0].params.track_index).toBe(0);
-      expect(result).toBe(JSON.stringify(keyframes, null, 2));
+      }, ctx) as string)).toEqual(keyframes);
     });
 
-    it('throws on error from Godot', async () => {
+    it('propagates errors from Godot', async () => {
       mock.mockError(new Error('Node not found'));
       const ctx = createToolContext(mock);
 
@@ -108,28 +68,31 @@ describe('animation tool', () => {
   });
 
   describe('playback actions', () => {
-    let mock: MockGodotConnection;
-
-    beforeEach(() => {
-      mock = createMockGodot();
-    });
-
-    it('play sends command and returns confirmation', async () => {
-      mock.mockResponse({ playing: 'run', from_position: 0 });
+    it('play/stop/seek return confirmations', async () => {
       const ctx = createToolContext(mock);
 
-      const result = await animation.execute({
+      mock.mockResponse({ playing: 'run', from_position: 0 });
+      expect(await animation.execute({
         action: 'play',
         node_path: '/root/AnimPlayer',
         animation_name: 'run',
-      }, ctx);
+      }, ctx)).toBe('Playing animation: run');
 
-      expect(mock.calls[0].command).toBe('play_animation');
-      expect(mock.calls[0].params.animation_name).toBe('run');
-      expect(result).toBe('Playing animation: run');
+      mock.mockResponse({});
+      expect(await animation.execute({
+        action: 'stop',
+        node_path: '/root/AnimPlayer',
+      }, ctx)).toBe('Animation stopped');
+
+      mock.mockResponse({ position: 1.5 });
+      expect(await animation.execute({
+        action: 'seek',
+        node_path: '/root/AnimPlayer',
+        seconds: 1.5,
+      }, ctx)).toBe('Seeked to position: 1.5');
     });
 
-    it('play passes optional params', async () => {
+    it('play passes optional speed/blend/from_end params', async () => {
       mock.mockResponse({ playing: 'walk', from_position: 0 });
       const ctx = createToolContext(mock);
 
@@ -146,175 +109,80 @@ describe('animation tool', () => {
       expect(mock.calls[0].params.custom_blend).toBe(0.5);
       expect(mock.calls[0].params.from_end).toBe(true);
     });
-
-    it('stop sends command and returns confirmation', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
-        action: 'stop',
-        node_path: '/root/AnimPlayer',
-      }, ctx);
-
-      expect(mock.calls[0].command).toBe('stop_animation');
-      expect(result).toBe('Animation stopped');
-    });
-
-    it('seek sends command and returns position', async () => {
-      mock.mockResponse({ position: 1.5 });
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
-        action: 'seek',
-        node_path: '/root/AnimPlayer',
-        seconds: 1.5,
-      }, ctx);
-
-      expect(mock.calls[0].command).toBe('seek_animation');
-      expect(mock.calls[0].params.seconds).toBe(1.5);
-      expect(result).toBe('Seeked to position: 1.5');
-    });
   });
 
   describe('edit actions', () => {
-    let mock: MockGodotConnection;
-
-    beforeEach(() => {
-      mock = createMockGodot();
-    });
-
-    it('create sends command and returns confirmation', async () => {
-      mock.mockResponse({ created: 'new_anim', library: '' });
+    it('create/delete return confirmations', async () => {
       const ctx = createToolContext(mock);
 
-      const result = await animation.execute({
+      mock.mockResponse({ created: 'new_anim', library: '' });
+      expect(await animation.execute({
         action: 'create',
         node_path: '/root/AnimPlayer',
         animation_name: 'new_anim',
         length: 2.0,
-      }, ctx);
+      }, ctx)).toBe('Created animation: new_anim');
 
-      expect(mock.calls[0].command).toBe('create_animation');
-      expect(mock.calls[0].params.animation_name).toBe('new_anim');
-      expect(mock.calls[0].params.length).toBe(2.0);
-      expect(result).toBe('Created animation: new_anim');
-    });
-
-    it('create includes library in result when provided', async () => {
       mock.mockResponse({ created: 'walk', library: 'movement' });
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(await animation.execute({
         action: 'create',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
         library_name: 'movement',
-      }, ctx);
+      }, ctx)).toBe('Created animation: walk in library: movement');
 
-      expect(result).toBe('Created animation: walk in library: movement');
-    });
-
-    it('delete sends command and returns confirmation', async () => {
       mock.mockResponse({ deleted: 'old_anim' });
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(await animation.execute({
         action: 'delete',
         node_path: '/root/AnimPlayer',
         animation_name: 'old_anim',
-      }, ctx);
-
-      expect(mock.calls[0].command).toBe('delete_animation');
-      expect(result).toBe('Deleted animation: old_anim');
+      }, ctx)).toBe('Deleted animation: old_anim');
     });
 
-    it('update_props sends command and returns updated properties', async () => {
-      mock.mockResponse({ updated: 'walk', properties: { length: 2.0, loop_mode: 'linear' } });
+    it('track operations return formatted confirmations', async () => {
       const ctx = createToolContext(mock);
 
-      const result = await animation.execute({
-        action: 'update_props',
-        node_path: '/root/AnimPlayer',
-        animation_name: 'walk',
-        length: 2.0,
-        loop_mode: 'linear',
-      }, ctx);
-
-      expect(mock.calls[0].command).toBe('update_animation_properties');
-      expect(result).toContain('Updated animation: walk');
-      expect(result).toContain('"length":2');
-    });
-
-    it('add_track sends command and returns track info', async () => {
       mock.mockResponse({ track_index: 0, track_path: 'Sprite2D:frame', track_type: 'value' });
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(await animation.execute({
         action: 'add_track',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
         track_type: 'value',
         track_path: 'Sprite2D:frame',
-      }, ctx);
+      }, ctx)).toBe('Added track 0: value -> Sprite2D:frame');
 
-      expect(mock.calls[0].command).toBe('add_animation_track');
-      expect(result).toBe('Added track 0: value -> Sprite2D:frame');
-    });
-
-    it('remove_track sends command and returns confirmation', async () => {
       mock.mockResponse({ removed_track: 2 });
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(await animation.execute({
         action: 'remove_track',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
         track_index: 2,
-      }, ctx);
-
-      expect(mock.calls[0].command).toBe('remove_animation_track');
-      expect(result).toBe('Removed track: 2');
+      }, ctx)).toBe('Removed track: 2');
     });
 
-    it('add_keyframe sends command and returns keyframe info', async () => {
-      mock.mockResponse({ keyframe_index: 0, time: 0.5, value: 3 });
+    it('keyframe operations return formatted confirmations', async () => {
       const ctx = createToolContext(mock);
 
-      const result = await animation.execute({
+      mock.mockResponse({ keyframe_index: 0, time: 0.5, value: 3 });
+      expect(await animation.execute({
         action: 'add_keyframe',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
         track_index: 0,
         time: 0.5,
         value: 3,
-      }, ctx);
+      }, ctx)).toBe('Added keyframe 0 at 0.5s');
 
-      expect(mock.calls[0].command).toBe('add_keyframe');
-      expect(mock.calls[0].params.time).toBe(0.5);
-      expect(mock.calls[0].params.value).toBe(3);
-      expect(result).toBe('Added keyframe 0 at 0.5s');
-    });
-
-    it('remove_keyframe sends command and returns confirmation', async () => {
       mock.mockResponse({ removed_keyframe: 1, track_index: 0 });
-      const ctx = createToolContext(mock);
-
-      const result = await animation.execute({
+      expect(await animation.execute({
         action: 'remove_keyframe',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
         track_index: 0,
         keyframe_index: 1,
-      }, ctx);
+      }, ctx)).toBe('Removed keyframe 1 from track 0');
 
-      expect(mock.calls[0].command).toBe('remove_keyframe');
-      expect(result).toBe('Removed keyframe 1 from track 0');
-    });
-
-    it('update_keyframe sends command and returns changes', async () => {
       mock.mockResponse({ updated_keyframe: 0, changes: { time: 0.75, value: 5 } });
-      const ctx = createToolContext(mock);
-
       const result = await animation.execute({
         action: 'update_keyframe',
         node_path: '/root/AnimPlayer',
@@ -324,10 +192,7 @@ describe('animation tool', () => {
         time: 0.75,
         value: 5,
       }, ctx);
-
-      expect(mock.calls[0].command).toBe('update_keyframe');
       expect(result).toContain('Updated keyframe 0');
-      expect(result).toContain('"time":0.75');
     });
   });
 });

--- a/server/src/__tests__/tools/docs.test.ts
+++ b/server/src/__tests__/tools/docs.test.ts
@@ -1,110 +1,73 @@
 import { describe, it, expect } from 'vitest';
 import { createMockGodot, createToolContext } from '../helpers/mock-godot.js';
-import { docs, docsTools } from '../../tools/docs.js';
+import { docs } from '../../tools/docs.js';
 
 describe('godot_docs tool', () => {
-  describe('tool definitions', () => {
-    it('exports one tool', () => {
-      expect(docsTools).toHaveLength(1);
-    });
-
-    it('has correct name and description', () => {
-      expect(docs.name).toBe('godot_docs');
-      expect(docs.description).toContain('Godot Engine documentation');
-    });
-  });
-
   describe('schema validation', () => {
-    it('requires action', () => {
-      expect(docs.schema.safeParse({}).success).toBe(false);
-    });
-
-    it('requires class_name for fetch_class', () => {
-      const result = docs.schema.safeParse({ action: 'fetch_class' });
-      expect(result.success).toBe(true);
-    });
-
-    it('requires path for fetch_page', () => {
-      const result = docs.schema.safeParse({ action: 'fetch_page' });
-      expect(result.success).toBe(true);
-    });
-
-    it('accepts valid version values', () => {
+    it('accepts valid version and section values', () => {
       const versions = ['stable', 'latest', '4.5', '4.4', '4.3', '4.2'];
+      const sections = ['full', 'description', 'properties', 'methods', 'signals'];
+
       for (const version of versions) {
-        const result = docs.schema.safeParse({
+        expect(docs.schema.safeParse({
           action: 'fetch_class',
           class_name: 'Node2D',
           version,
-        });
-        expect(result.success).toBe(true);
+        }).success).toBe(true);
+      }
+
+      for (const section of sections) {
+        expect(docs.schema.safeParse({
+          action: 'fetch_class',
+          class_name: 'Node2D',
+          section,
+        }).success).toBe(true);
       }
     });
 
     it('rejects invalid version', () => {
-      const result = docs.schema.safeParse({
+      expect(docs.schema.safeParse({
         action: 'fetch_class',
         class_name: 'Node2D',
         version: '3.5',
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it('accepts valid section values', () => {
-      const sections = ['full', 'description', 'properties', 'methods', 'signals'];
-      for (const section of sections) {
-        const result = docs.schema.safeParse({
-          action: 'fetch_class',
-          class_name: 'Node2D',
-          section,
-        });
-        expect(result.success).toBe(true);
-      }
+      }).success).toBe(false);
     });
   });
 
-  describe('fetch_class action (live integration)', () => {
-    it('fetches CharacterBody2D class reference', async () => {
+  describe('fetch_class (live integration)', () => {
+    it('fetches class reference with section filtering', async () => {
       const mock = createMockGodot();
       const ctx = createToolContext(mock);
 
-      const result = await docs.execute(
-        { action: 'fetch_class', class_name: 'CharacterBody2D', version: 'stable', section: 'description' },
-        ctx
-      );
+      const fullResult = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'Node2D',
+        version: 'stable',
+        section: 'full',
+      }, ctx) as string;
 
-      expect(result).toContain('CharacterBody2D');
-      expect(result).toContain('Source: https://docs.godotengine.org');
-      expect(result).toContain('Approx tokens:');
-    });
+      const descResult = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'Node2D',
+        version: 'stable',
+        section: 'description',
+      }, ctx) as string;
 
-    it('returns smaller content with section filter', async () => {
-      const mock = createMockGodot();
-      const ctx = createToolContext(mock);
-
-      const fullResult = (await docs.execute(
-        { action: 'fetch_class', class_name: 'Node2D', version: 'stable', section: 'full' },
-        ctx
-      )) as string;
-
-      const descResult = (await docs.execute(
-        { action: 'fetch_class', class_name: 'Node2D', version: 'stable', section: 'description' },
-        ctx
-      )) as string;
-
+      expect(fullResult).toContain('Node2D');
+      expect(fullResult).toContain('Source: https://docs.godotengine.org');
       expect(descResult.length).toBeLessThan(fullResult.length);
-      expect(descResult).toContain('Node2D');
-      expect(descResult).toContain('Description');
     });
 
     it('handles class name case insensitively', async () => {
       const mock = createMockGodot();
       const ctx = createToolContext(mock);
 
-      const result = await docs.execute(
-        { action: 'fetch_class', class_name: 'SPRITE2D', version: 'stable', section: 'description' },
-        ctx
-      );
+      const result = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'SPRITE2D',
+        version: 'stable',
+        section: 'description',
+      }, ctx);
 
       expect(result).toContain('Sprite2D');
     });
@@ -113,42 +76,40 @@ describe('godot_docs tool', () => {
       const mock = createMockGodot();
       const ctx = createToolContext(mock);
 
-      await expect(
-        docs.execute(
-          { action: 'fetch_class', class_name: 'NotARealClass12345', version: 'stable', section: 'full' },
-          ctx
-        )
-      ).rejects.toThrow('not found');
+      await expect(docs.execute({
+        action: 'fetch_class',
+        class_name: 'NotARealClass12345',
+        version: 'stable',
+        section: 'full',
+      }, ctx)).rejects.toThrow('not found');
     });
 
     it('fetches from specific version', async () => {
       const mock = createMockGodot();
       const ctx = createToolContext(mock);
 
-      const result = await docs.execute(
-        { action: 'fetch_class', class_name: 'TileMapLayer', version: '4.5', section: 'description' },
-        ctx
-      );
+      const result = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'TileMapLayer',
+        version: '4.5',
+        section: 'description',
+      }, ctx);
 
-      expect(result).toContain('https://docs.godotengine.org/en/4.5/');
-      expect(result).toContain('TileMapLayer');
+      expect(result).toContain('/en/4.5/');
     });
   });
 
-  describe('fetch_page action (live integration)', () => {
+  describe('fetch_page (live integration)', () => {
     it('fetches tutorial page', async () => {
       const mock = createMockGodot();
       const ctx = createToolContext(mock);
 
-      const result = (await docs.execute(
-        {
-          action: 'fetch_page',
-          path: '/tutorials/2d/2d_movement.html',
-          version: 'stable',
-          section: 'full',
-        },
-        ctx
-      )) as string;
+      const result = await docs.execute({
+        action: 'fetch_page',
+        path: '/tutorials/2d/2d_movement.html',
+        version: 'stable',
+        section: 'full',
+      }, ctx) as string;
 
       expect(result).toContain('Source: https://docs.godotengine.org');
       expect(result.length).toBeGreaterThan(1000);
@@ -156,43 +117,38 @@ describe('godot_docs tool', () => {
   });
 
   describe('version auto-detection', () => {
-    it('uses detected version from Godot connection', async () => {
+    it('uses detected version from Godot, falls back to stable', async () => {
       const mock = createMockGodot();
-      mock.godotVersion = '4.5.1';
       const ctx = createToolContext(mock);
 
-      const result = await docs.execute(
-        { action: 'fetch_class', class_name: 'Node2D', section: 'description' },
-        ctx
-      );
+      mock.godotVersion = '4.5.1';
+      const withVersion = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'Node2D',
+        section: 'description',
+      }, ctx);
+      expect(withVersion).toContain('(auto-detected: 4.5)');
 
-      expect(result).toContain('(auto-detected: 4.5)');
-      expect(result).toContain('/en/4.5/');
-    });
-
-    it('falls back to stable when not connected', async () => {
-      const mock = createMockGodot();
       mock.godotVersion = null;
-      const ctx = createToolContext(mock);
-
-      const result = await docs.execute(
-        { action: 'fetch_class', class_name: 'Node2D', section: 'description' },
-        ctx
-      );
-
-      expect(result).toContain('(auto-detected: stable)');
-      expect(result).toContain('/en/stable/');
+      const noVersion = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'Node2D',
+        section: 'description',
+      }, ctx);
+      expect(noVersion).toContain('(auto-detected: stable)');
     });
 
-    it('uses explicit version over auto-detected', async () => {
+    it('explicit version overrides auto-detected', async () => {
       const mock = createMockGodot();
       mock.godotVersion = '4.5.1';
       const ctx = createToolContext(mock);
 
-      const result = await docs.execute(
-        { action: 'fetch_class', class_name: 'Node2D', version: '4.4', section: 'description' },
-        ctx
-      );
+      const result = await docs.execute({
+        action: 'fetch_class',
+        class_name: 'Node2D',
+        version: '4.4',
+        section: 'description',
+      }, ctx);
 
       expect(result).not.toContain('auto-detected');
       expect(result).toContain('/en/4.4/');

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
-import { editor, editorTools } from '../../tools/editor.js';
+import { editor } from '../../tools/editor.js';
 
 describe('editor tool', () => {
   let mock: MockGodotConnection;
@@ -9,487 +9,173 @@ describe('editor tool', () => {
     mock = createMockGodot();
   });
 
-  describe('tool definitions', () => {
-    it('exports one tool', () => {
-      expect(editorTools).toHaveLength(1);
-    });
-
-    it('has editor tool with expected actions', () => {
-      expect(editor.name).toBe('editor');
-      expect(editor.description).toContain('state');
-      expect(editor.description).toContain('screenshot');
-    });
-  });
-
-  describe('action: get_state', () => {
-    it('sends get_editor_state command', async () => {
-      mock.mockResponse({
-        current_scene: 'res://main.tscn',
-        is_playing: false,
-        godot_version: '4.5',
-        open_scenes: ['res://main.tscn'],
-        main_screen: '2D',
-      });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'get_state' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('get_editor_state');
-    });
-
-    it('returns JSON state with all fields', async () => {
-      const state = {
-        current_scene: 'res://main.tscn',
-        is_playing: true,
-        godot_version: '4.5',
-        open_scenes: ['res://main.tscn', 'res://player.tscn'],
-        main_screen: 'Script',
-      };
-      mock.mockResponse(state);
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_state' }, ctx);
-
-      expect(result).toBe(JSON.stringify(state, null, 2));
-    });
-
-    it('includes open_scenes and main_screen in response', async () => {
-      const state = {
-        current_scene: 'res://main.tscn',
-        is_playing: false,
-        godot_version: '4.5',
-        open_scenes: ['res://main.tscn', 'res://enemy.tscn'],
-        main_screen: '3D',
-      };
-      mock.mockResponse(state);
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_state' }, ctx);
-      const parsed = JSON.parse(result as string);
-
-      expect(parsed.open_scenes).toEqual(['res://main.tscn', 'res://enemy.tscn']);
-      expect(parsed.main_screen).toBe('3D');
-    });
-  });
-
-  describe('action: get_selection', () => {
-    it('sends get_selected_nodes command', async () => {
-      mock.mockResponse({ selected: ['/root/Main/Player'] });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'get_selection' }, ctx);
-
-      expect(mock.calls[0].command).toBe('get_selected_nodes');
-    });
-
-    it('returns formatted list of selected nodes', async () => {
-      mock.mockResponse({ selected: ['/root/Main/Player', '/root/Main/Enemy'] });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_selection' }, ctx);
-
-      expect(result).toContain('Selected nodes:');
-      expect(result).toContain('/root/Main/Player');
-      expect(result).toContain('/root/Main/Enemy');
-    });
-
-    it('returns message when no nodes selected', async () => {
-      mock.mockResponse({ selected: [] });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_selection' }, ctx);
-
-      expect(result).toBe('No nodes selected');
-    });
-  });
-
-  describe('action: select', () => {
-    it('sends select_node command with node_path', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'select', node_path: '/root/Main/Player' }, ctx);
-
-      expect(mock.calls[0].command).toBe('select_node');
-      expect(mock.calls[0].params.node_path).toBe('/root/Main/Player');
-    });
-
-    it('returns confirmation', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'select', node_path: '/root/Main/Enemy' }, ctx);
-
-      expect(result).toBe('Selected node: /root/Main/Enemy');
-    });
-
-    it('requires node_path', () => {
+  describe('schema validation', () => {
+    it('requires node_path for select action', () => {
       expect(editor.schema.safeParse({ action: 'select' }).success).toBe(false);
       expect(editor.schema.safeParse({ action: 'select', node_path: '/root/Test' }).success).toBe(true);
     });
-  });
 
-  describe('action: run', () => {
-    it('sends run_project command', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'run' }, ctx);
-
-      expect(mock.calls[0].command).toBe('run_project');
-    });
-
-    it('passes optional scene_path', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'run', scene_path: 'res://test.tscn' }, ctx);
-
-      expect(mock.calls[0].params.scene_path).toBe('res://test.tscn');
-    });
-
-    it('returns confirmation with scene path when provided', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'run', scene_path: 'res://test.tscn' }, ctx);
-
-      expect(result).toBe('Running scene: res://test.tscn');
-    });
-
-    it('returns confirmation without scene path', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'run' }, ctx);
-
-      expect(result).toBe('Running project');
+    it('requires at least one param for set_viewport_2d', () => {
+      expect(editor.schema.safeParse({ action: 'set_viewport_2d' }).success).toBe(false);
+      expect(editor.schema.safeParse({ action: 'set_viewport_2d', zoom: 2.0 }).success).toBe(true);
     });
   });
 
-  describe('action: stop', () => {
-    it('sends stop_project command', async () => {
-      mock.mockResponse({});
+  describe('get_state', () => {
+    it('returns JSON with editor state including camera and viewport info', async () => {
+      const state = {
+        current_scene: 'res://main.tscn',
+        is_playing: false,
+        godot_version: '4.5',
+        open_scenes: ['res://main.tscn', 'res://player.tscn'],
+        main_screen: '2D',
+        camera: { position: { x: 0, y: 0, z: 10 } },
+        viewport_2d: { center: { x: 0, y: 0 }, zoom: 1.0 },
+      };
+      mock.mockResponse(state);
       const ctx = createToolContext(mock);
 
-      await editor.execute({ action: 'stop' }, ctx);
+      const result = await editor.execute({ action: 'get_state' }, ctx);
 
-      expect(mock.calls[0].command).toBe('stop_project');
-    });
-
-    it('returns confirmation', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'stop' }, ctx);
-
-      expect(result).toBe('Stopped project');
+      expect(JSON.parse(result as string)).toEqual(state);
     });
   });
 
-  describe('action: get_debug_output', () => {
-    it('sends get_debug_output command', async () => {
-      mock.mockResponse({ output: 'Debug message', source: 'game' });
+  describe('get_selection', () => {
+    it('returns formatted list or empty message', async () => {
+      mock.mockResponse({ selected: [] });
+      const ctx = createToolContext(mock);
+      expect(await editor.execute({ action: 'get_selection' }, ctx)).toBe('No nodes selected');
+
+      mock.mockResponse({ selected: ['/root/Main/Player', '/root/Main/Enemy'] });
+      const result = await editor.execute({ action: 'get_selection' }, ctx);
+      expect(result).toContain('Selected nodes:');
+      expect(result).toContain('/root/Main/Player');
+    });
+  });
+
+  describe('run/stop', () => {
+    it('returns appropriate confirmations', async () => {
+      mock.mockResponse({});
       const ctx = createToolContext(mock);
 
-      await editor.execute({ action: 'get_debug_output' }, ctx);
-
-      expect(mock.calls[0].command).toBe('get_debug_output');
+      expect(await editor.execute({ action: 'run' }, ctx)).toBe('Running project');
+      expect(await editor.execute({ action: 'run', scene_path: 'res://test.tscn' }, ctx))
+        .toBe('Running scene: res://test.tscn');
+      expect(await editor.execute({ action: 'stop' }, ctx)).toBe('Stopped project');
     });
+  });
 
-    it('passes clear parameter', async () => {
-      mock.mockResponse({ output: 'Debug message', source: 'game' });
+  describe('get_debug_output', () => {
+    it('returns labeled output based on source', async () => {
       const ctx = createToolContext(mock);
 
-      await editor.execute({ action: 'get_debug_output', clear: true }, ctx);
+      mock.mockResponse({ output: '', source: 'editor' });
+      expect(await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx))
+        .toBe('No editor output');
 
-      expect(mock.calls[0].params.clear).toBe(true);
-    });
-
-    it('passes source parameter', async () => {
-      mock.mockResponse({ output: 'Editor error', source: 'editor' });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
-
-      expect(mock.calls[0].params.source).toBe('editor');
-    });
-
-    it('returns formatted output with Editor label for editor source', async () => {
-      mock.mockResponse({ output: 'Script parse error', source: 'editor' });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
-
-      expect(result).toContain('Editor output:');
-      expect(result).toContain('Script parse error');
-    });
-
-    it('returns formatted output with Game label for game source', async () => {
       mock.mockResponse({ output: 'Player spawned', source: 'game' });
-      const ctx = createToolContext(mock);
-
       const result = await editor.execute({ action: 'get_debug_output', source: 'game' }, ctx);
-
       expect(result).toContain('Game output:');
       expect(result).toContain('Player spawned');
     });
 
-    it('returns formatted output with Debug label when no source', async () => {
-      mock.mockResponse({ output: 'Error: Something went wrong' });
+    it('passes clear parameter to Godot', async () => {
+      mock.mockResponse({ output: 'test', source: 'game' });
       const ctx = createToolContext(mock);
 
-      const result = await editor.execute({ action: 'get_debug_output' }, ctx);
-
-      expect(result).toContain('Debug output:');
-      expect(result).toContain('Error: Something went wrong');
-    });
-
-    it('returns message when no output with source label', async () => {
-      mock.mockResponse({ output: '', source: 'editor' });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
-
-      expect(result).toBe('No editor output');
-    });
-
-    it('returns message when no output without source', async () => {
-      mock.mockResponse({ output: '' });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_debug_output' }, ctx);
-
-      expect(result).toBe('No debug output');
+      await editor.execute({ action: 'get_debug_output', clear: true }, ctx);
+      expect(mock.calls[0].params.clear).toBe(true);
     });
   });
 
-  describe('action: get_errors', () => {
-    it('sends get_errors command', async () => {
-      mock.mockResponse({ error_count: 0, errors: [] });
+  describe('get_errors', () => {
+    it('returns "No errors" when empty, JSON when present', async () => {
       const ctx = createToolContext(mock);
 
-      await editor.execute({ action: 'get_errors' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('get_errors');
-    });
-
-    it('passes clear parameter', async () => {
       mock.mockResponse({ error_count: 0, errors: [] });
-      const ctx = createToolContext(mock);
+      expect(await editor.execute({ action: 'get_errors' }, ctx)).toBe('No errors');
 
-      await editor.execute({ action: 'get_errors', clear: true }, ctx);
-
-      expect(mock.calls[0].params.clear).toBe(true);
-    });
-
-    it('returns "No errors" when error_count is 0', async () => {
-      mock.mockResponse({ error_count: 0, errors: [] });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_errors' }, ctx);
-
-      expect(result).toBe('No errors');
-    });
-
-    it('returns JSON with errors when present', async () => {
       const errorData = {
         error_count: 1,
         errors: [{
           timestamp: 12345,
           type: 'Parser Error',
-          message: 'Could not find type "DungeonData"',
-          file: 'res://scenes/dungeon.gd',
+          message: 'Could not find type',
+          file: 'res://test.gd',
           line: 10,
-          function: '',
-          error_type: 1,
           frames: [],
         }],
       };
       mock.mockResponse(errorData);
-      const ctx = createToolContext(mock);
-
       const result = await editor.execute({ action: 'get_errors' }, ctx);
-
-      expect(result).toBe(JSON.stringify(errorData, null, 2));
+      expect(JSON.parse(result as string)).toEqual(errorData);
     });
   });
 
-  describe('action: get_stack_trace', () => {
-    it('sends get_stack_trace command', async () => {
-      mock.mockResponse({ error: '', error_type: '', file: '', line: 0, frames: [] });
+  describe('get_stack_trace', () => {
+    it('returns "No stack trace available" when empty, JSON when present', async () => {
       const ctx = createToolContext(mock);
 
-      await editor.execute({ action: 'get_stack_trace' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('get_stack_trace');
-    });
-
-    it('returns "No stack trace available" when empty', async () => {
       mock.mockResponse({ error: '', error_type: '', file: '', line: 0, frames: [] });
-      const ctx = createToolContext(mock);
+      expect(await editor.execute({ action: 'get_stack_trace' }, ctx)).toBe('No stack trace available');
 
-      const result = await editor.execute({ action: 'get_stack_trace' }, ctx);
-
-      expect(result).toBe('No stack trace available');
-    });
-
-    it('returns JSON with stack trace when present', async () => {
       const stackData = {
-        error: 'Null instance access',
+        error: 'Null instance',
         error_type: 'Runtime Error',
         file: 'res://player.gd',
         line: 42,
-        frames: [
-          { file: 'res://player.gd', line: 42, function: '_process' },
-          { file: 'res://main.gd', line: 15, function: '_ready' },
-        ],
+        frames: [{ file: 'res://player.gd', line: 42, function: '_process' }],
       };
       mock.mockResponse(stackData);
-      const ctx = createToolContext(mock);
-
       const result = await editor.execute({ action: 'get_stack_trace' }, ctx);
-
-      expect(result).toBe(JSON.stringify(stackData, null, 2));
+      expect(JSON.parse(result as string)).toEqual(stackData);
     });
   });
 
-  describe('action: get_performance', () => {
-    it('sends get_performance_metrics command', async () => {
-      mock.mockResponse({ fps: 60 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'get_performance' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('get_performance_metrics');
-    });
-
-    it('returns JSON formatted response', async () => {
-      const metrics = { fps: 60, frame_time_ms: 16.67 };
-      mock.mockResponse(metrics);
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'get_performance' }, ctx);
-
-      expect(result).toBe(JSON.stringify(metrics, null, 2));
-    });
-  });
-
-  describe('action: screenshot_game', () => {
-    it('sends capture_game_screenshot command', async () => {
-      mock.mockResponse({ image_base64: 'abc123', width: 800, height: 600 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'screenshot_game' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('capture_game_screenshot');
-    });
-
-    it('passes max_width parameter', async () => {
-      mock.mockResponse({ image_base64: 'abc123', width: 640, height: 480 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'screenshot_game', max_width: 640 }, ctx);
-
-      expect(mock.calls[0].params.max_width).toBe(640);
-    });
-
-    it('returns ImageContent with correct structure', async () => {
-      const base64Data = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-      mock.mockResponse({ image_base64: base64Data, width: 1, height: 1 });
+  describe('screenshots', () => {
+    it('returns ImageContent structure', async () => {
+      const base64 = 'iVBORw0KGgoAAAANSUhEUg==';
+      mock.mockResponse({ image_base64: base64, width: 800, height: 600 });
       const ctx = createToolContext(mock);
 
       const result = await editor.execute({ action: 'screenshot_game' }, ctx);
+      expect(result).toEqual({ type: 'image', data: base64, mimeType: 'image/png' });
+    });
 
-      expect(result).toEqual({
-        type: 'image',
-        data: base64Data,
-        mimeType: 'image/png',
-      });
+    it('passes viewport and max_width params for editor screenshot', async () => {
+      mock.mockResponse({ image_base64: 'abc', width: 800, height: 600 });
+      const ctx = createToolContext(mock);
+
+      await editor.execute({ action: 'screenshot_editor', viewport: '2d', max_width: 800 }, ctx);
+      expect(mock.calls[0].params.viewport).toBe('2d');
+      expect(mock.calls[0].params.max_width).toBe(800);
     });
 
     it('propagates errors from Godot', async () => {
       mock.mockError(new Error('Game is not running'));
       const ctx = createToolContext(mock);
 
-      await expect(editor.execute({ action: 'screenshot_game' }, ctx)).rejects.toThrow('Game is not running');
+      await expect(editor.execute({ action: 'screenshot_game' }, ctx))
+        .rejects.toThrow('Game is not running');
     });
   });
 
-  describe('action: screenshot_editor', () => {
-    it('sends capture_editor_screenshot command', async () => {
-      mock.mockResponse({ image_base64: 'xyz789', width: 1920, height: 1080 });
+  describe('set_viewport_2d', () => {
+    it('returns formatted confirmation with actual values', async () => {
+      mock.mockResponse({ center: { x: 100.5, y: 200.5 }, zoom: 2.5 });
       const ctx = createToolContext(mock);
 
-      await editor.execute({ action: 'screenshot_editor' }, ctx);
+      const result = await editor.execute({
+        action: 'set_viewport_2d',
+        center_x: 100,
+        center_y: 200,
+        zoom: 2.5,
+      }, ctx);
 
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('capture_editor_screenshot');
-    });
-
-    it('passes viewport parameter', async () => {
-      mock.mockResponse({ image_base64: 'xyz789', width: 1920, height: 1080 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'screenshot_editor', viewport: '2d' }, ctx);
-
-      expect(mock.calls[0].params.viewport).toBe('2d');
-    });
-
-    it('passes 3d viewport parameter', async () => {
-      mock.mockResponse({ image_base64: 'xyz789', width: 1920, height: 1080 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'screenshot_editor', viewport: '3d' }, ctx);
-
-      expect(mock.calls[0].params.viewport).toBe('3d');
-    });
-
-    it('passes max_width parameter', async () => {
-      mock.mockResponse({ image_base64: 'xyz789', width: 1280, height: 720 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'screenshot_editor', max_width: 1280 }, ctx);
-
-      expect(mock.calls[0].params.max_width).toBe(1280);
-    });
-
-    it('passes both viewport and max_width', async () => {
-      mock.mockResponse({ image_base64: 'xyz789', width: 800, height: 600 });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'screenshot_editor', viewport: '2d', max_width: 800 }, ctx);
-
-      expect(mock.calls[0].params.viewport).toBe('2d');
-      expect(mock.calls[0].params.max_width).toBe(800);
-    });
-
-    it('returns ImageContent with correct structure', async () => {
-      const base64Data = 'editorScreenshotBase64Data';
-      mock.mockResponse({ image_base64: base64Data, width: 1920, height: 1080 });
-      const ctx = createToolContext(mock);
-
-      const result = await editor.execute({ action: 'screenshot_editor' }, ctx);
-
-      expect(result).toEqual({
-        type: 'image',
-        data: base64Data,
-        mimeType: 'image/png',
-      });
-    });
-
-    it('propagates errors from Godot', async () => {
-      mock.mockError(new Error('Editor viewport not available'));
-      const ctx = createToolContext(mock);
-
-      await expect(editor.execute({ action: 'screenshot_editor' }, ctx)).rejects.toThrow(
-        'Editor viewport not available'
-      );
+      expect(result).toContain('100.5');
+      expect(result).toContain('200.5');
+      expect(result).toContain('2.50');
     });
   });
 });

--- a/server/src/__tests__/tools/resource.test.ts
+++ b/server/src/__tests__/tools/resource.test.ts
@@ -2,19 +2,14 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import {
-  createMockGodot,
-  createToolContext,
-  MockGodotConnection,
-} from '../helpers/mock-godot.js';
-import { resource, resourceTools } from '../../tools/resource.js';
+import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { resource } from '../../tools/resource.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = join(__dirname, '../fixtures');
 
 function loadFixture(name: string): unknown {
-  const filepath = join(FIXTURES_DIR, `${name}.json`);
-  return JSON.parse(readFileSync(filepath, 'utf-8'));
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, `${name}.json`), 'utf-8'));
 }
 
 describe('resource tool', () => {
@@ -24,204 +19,113 @@ describe('resource tool', () => {
     mock = createMockGodot();
   });
 
-  describe('tool definitions', () => {
-    it('exports one tool', () => {
-      expect(resourceTools).toHaveLength(1);
-    });
-
-    it('has resource tool with get_info action', () => {
-      expect(resource.name).toBe('resource');
-      expect(resource.description).toContain('Resource');
-    });
-  });
-
   describe('schema validation', () => {
-    it('requires action and resource_path for get_info', () => {
+    it('requires resource_path for get_info', () => {
       expect(resource.schema.safeParse({ action: 'get_info' }).success).toBe(false);
+      expect(resource.schema.safeParse({
+        action: 'get_info',
+        resource_path: 'res://test.tres',
+      }).success).toBe(true);
     });
 
-    it('accepts valid action and resource_path', () => {
-      expect(
-        resource.schema.safeParse({ action: 'get_info', resource_path: 'res://test.tres' }).success
-      ).toBe(true);
-    });
-
-    it('accepts optional max_depth', () => {
-      const result = resource.schema.safeParse({
+    it('accepts optional max_depth and include_internal', () => {
+      expect(resource.schema.safeParse({
         action: 'get_info',
         resource_path: 'res://test.tres',
         max_depth: 2,
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('accepts optional include_internal', () => {
-      const result = resource.schema.safeParse({
-        action: 'get_info',
-        resource_path: 'res://test.tres',
         include_internal: true,
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('rejects invalid max_depth type', () => {
-      const result = resource.schema.safeParse({
-        action: 'get_info',
-        resource_path: 'res://test.tres',
-        max_depth: 'deep',
-      });
-      expect(result.success).toBe(false);
+      }).success).toBe(true);
     });
   });
 
-  describe('action: get_info', () => {
-    it('sends correct command name', async () => {
-      mock.mockResponse({ resource_path: 'res://test.tres', resource_type: 'Resource' });
-      const ctx = createToolContext(mock);
-
-      await resource.execute({ action: 'get_info', resource_path: 'res://test.tres' }, ctx);
-
-      expect(mock.calls[0].command).toBe('get_resource_info');
-    });
-
-    it('applies default max_depth of 1', async () => {
+  describe('get_info', () => {
+    it('applies default max_depth=1 and include_internal=false', async () => {
       mock.mockResponse({ resource_path: 'res://test.tres', resource_type: 'Resource' });
       const ctx = createToolContext(mock);
 
       await resource.execute({ action: 'get_info', resource_path: 'res://test.tres' }, ctx);
 
       expect(mock.calls[0].params.max_depth).toBe(1);
-    });
-
-    it('applies default include_internal of false', async () => {
-      mock.mockResponse({ resource_path: 'res://test.tres', resource_type: 'Resource' });
-      const ctx = createToolContext(mock);
-
-      await resource.execute({ action: 'get_info', resource_path: 'res://test.tres' }, ctx);
-
       expect(mock.calls[0].params.include_internal).toBe(false);
-    });
-
-    it('passes custom max_depth', async () => {
-      mock.mockResponse({ resource_path: 'res://test.tres', resource_type: 'Resource' });
-      const ctx = createToolContext(mock);
-
-      await resource.execute({ action: 'get_info', resource_path: 'res://test.tres', max_depth: 0 }, ctx);
-
-      expect(mock.calls[0].params.max_depth).toBe(0);
     });
 
     it('propagates errors from Godot', async () => {
       mock.mockError(new Error('Resource not found: res://missing.tres'));
       const ctx = createToolContext(mock);
 
-      await expect(
-        resource.execute({ action: 'get_info', resource_path: 'res://missing.tres' }, ctx)
-      ).rejects.toThrow('Resource not found');
+      await expect(resource.execute({
+        action: 'get_info',
+        resource_path: 'res://missing.tres',
+      }, ctx)).rejects.toThrow('Resource not found');
     });
   });
 
-  describe('SpriteFrames response structure (from real Godot data)', () => {
-    it('returns correct structure at max_depth=1', async () => {
-      const fixture = loadFixture('resource-spriteframes');
-      mock.mockResponse(fixture);
+  describe('SpriteFrames fixture (real Godot response structure)', () => {
+    it('parses animation data with frame details at depth 1', async () => {
+      mock.mockResponse(loadFixture('resource-spriteframes'));
       const ctx = createToolContext(mock);
 
-      const result = await resource.execute(
-        { action: 'get_info', resource_path: 'res://player/player_sprites.tres' },
-        ctx
-      );
+      const result = await resource.execute({
+        action: 'get_info',
+        resource_path: 'res://player/player_sprites.tres',
+      }, ctx);
       const parsed = JSON.parse(result as string);
 
       expect(parsed.resource_type).toBe('SpriteFrames');
-      expect(parsed.type_specific).toBeDefined();
-      expect(parsed.type_specific.animations).toBeInstanceOf(Array);
-      expect(parsed.type_specific.animations.length).toBe(5);
-    });
+      expect(parsed.type_specific.animations).toHaveLength(5);
 
-    it('includes frame details with AtlasTexture regions at depth 1', async () => {
-      const fixture = loadFixture('resource-spriteframes');
-      mock.mockResponse(fixture);
-      const ctx = createToolContext(mock);
-
-      const result = await resource.execute(
-        { action: 'get_info', resource_path: 'res://player/player_sprites.tres' },
-        ctx
-      );
-      const parsed = JSON.parse(result as string);
-
-      const runAnim = parsed.type_specific.animations.find(
-        (a: { name: string }) => a.name === 'run'
-      );
-      expect(runAnim).toBeDefined();
+      const runAnim = parsed.type_specific.animations.find((a: { name: string }) => a.name === 'run');
       expect(runAnim.frame_count).toBe(8);
       expect(runAnim.fps).toBe(12);
-      expect(runAnim.loop).toBe(true);
-      expect(runAnim.frames).toHaveLength(8);
-
-      const firstFrame = runAnim.frames[0];
-      expect(firstFrame.texture_type).toBe('AtlasTexture');
-      expect(firstFrame.atlas_source).toBe('res://sprites/player/hero.png');
-      expect(firstFrame.region).toEqual({ x: 26, y: 314, width: 44, height: 46 });
+      expect(runAnim.frames[0].texture_type).toBe('AtlasTexture');
+      expect(runAnim.frames[0].region).toEqual({ x: 26, y: 314, width: 44, height: 46 });
     });
 
     it('omits frame details at max_depth=0', async () => {
-      const fixture = loadFixture('resource-spriteframes-depth0');
-      mock.mockResponse(fixture);
+      mock.mockResponse(loadFixture('resource-spriteframes-depth0'));
       const ctx = createToolContext(mock);
 
-      const result = await resource.execute(
-        { action: 'get_info', resource_path: 'res://player/player_sprites.tres', max_depth: 0 },
-        ctx
-      );
+      const result = await resource.execute({
+        action: 'get_info',
+        resource_path: 'res://player/player_sprites.tres',
+        max_depth: 0,
+      }, ctx);
       const parsed = JSON.parse(result as string);
 
-      const idleAnim = parsed.type_specific.animations.find(
-        (a: { name: string }) => a.name === 'idle'
-      );
-      expect(idleAnim).toBeDefined();
-      expect(idleAnim.name).toBe('idle');
+      const idleAnim = parsed.type_specific.animations.find((a: { name: string }) => a.name === 'idle');
       expect(idleAnim.frame_count).toBe(1);
-      expect(idleAnim.fps).toBe(10);
-      expect(idleAnim.loop).toBe(true);
       expect(idleAnim.frames).toBeUndefined();
     });
 
     it('correctly identifies non-looping animations', async () => {
-      const fixture = loadFixture('resource-spriteframes');
-      mock.mockResponse(fixture);
+      mock.mockResponse(loadFixture('resource-spriteframes'));
       const ctx = createToolContext(mock);
 
-      const result = await resource.execute(
-        { action: 'get_info', resource_path: 'res://player/player_sprites.tres' },
-        ctx
-      );
+      const result = await resource.execute({
+        action: 'get_info',
+        resource_path: 'res://player/player_sprites.tres',
+      }, ctx);
       const parsed = JSON.parse(result as string);
 
-      const damageAnim = parsed.type_specific.animations.find(
-        (a: { name: string }) => a.name === 'damage'
-      );
+      const damageAnim = parsed.type_specific.animations.find((a: { name: string }) => a.name === 'damage');
       expect(damageAnim.loop).toBe(false);
     });
   });
 
-  describe('Texture2D response structure (from real Godot data)', () => {
-    it('returns dimensions and type for CompressedTexture2D', async () => {
-      const fixture = loadFixture('resource-texture');
-      mock.mockResponse(fixture);
+  describe('Texture2D fixture (real Godot response structure)', () => {
+    it('parses texture dimensions and type', async () => {
+      mock.mockResponse(loadFixture('resource-texture'));
       const ctx = createToolContext(mock);
 
-      const result = await resource.execute(
-        { action: 'get_info', resource_path: 'res://sprites/player/hero.png' },
-        ctx
-      );
+      const result = await resource.execute({
+        action: 'get_info',
+        resource_path: 'res://sprites/player/hero.png',
+      }, ctx);
       const parsed = JSON.parse(result as string);
 
       expect(parsed.resource_type).toBe('CompressedTexture2D');
       expect(parsed.type_specific.width).toBe(1026);
       expect(parsed.type_specific.height).toBe(1280);
-      expect(parsed.type_specific.texture_type).toBe('CompressedTexture2D');
-      expect(parsed.type_specific.load_path).toContain('.godot/imported/');
     });
   });
 });

--- a/server/src/__tests__/tools/scene.test.ts
+++ b/server/src/__tests__/tools/scene.test.ts
@@ -9,124 +9,61 @@ describe('scene tool', () => {
     mock = createMockGodot();
   });
 
-  describe('action: open', () => {
-    it('sends open_scene command with scene_path', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      await scene.execute({ action: 'open', scene_path: 'res://scenes/main.tscn' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('open_scene');
-      expect(mock.calls[0].params).toEqual({ scene_path: 'res://scenes/main.tscn' });
-    });
-
-    it('returns confirmation message with path', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      const result = await scene.execute({ action: 'open', scene_path: 'res://levels/level1.tscn' }, ctx);
-
-      expect(result).toBe('Opened scene: res://levels/level1.tscn');
-    });
-
+  describe('schema validation', () => {
     it('requires scene_path for open', () => {
       expect(scene.schema.safeParse({ action: 'open' }).success).toBe(false);
       expect(scene.schema.safeParse({ action: 'open', scene_path: 'res://test.tscn' }).success).toBe(true);
-    });
-  });
-
-  describe('action: save', () => {
-    it('sends save_scene command', async () => {
-      mock.mockResponse({ path: 'res://scenes/saved.tscn' });
-      const ctx = createToolContext(mock);
-
-      await scene.execute({ action: 'save' }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('save_scene');
-    });
-
-    it('passes optional path param', async () => {
-      mock.mockResponse({ path: 'res://new_location.tscn' });
-      const ctx = createToolContext(mock);
-
-      await scene.execute({ action: 'save', scene_path: 'res://new_location.tscn' }, ctx);
-
-      expect(mock.calls[0].params).toEqual({ path: 'res://new_location.tscn' });
-    });
-
-    it('returns saved path from Godot response', async () => {
-      mock.mockResponse({ path: 'res://scenes/current.tscn' });
-      const ctx = createToolContext(mock);
-
-      const result = await scene.execute({ action: 'save' }, ctx);
-
-      expect(result).toBe('Saved scene: res://scenes/current.tscn');
-    });
-
-    it('accepts empty scene_path for save', () => {
-      const result = scene.schema.safeParse({ action: 'save' });
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('action: create', () => {
-    it('sends create_scene command with all params', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      await scene.execute({
-        action: 'create',
-        root_type: 'Node2D',
-        root_name: 'GameRoot',
-        scene_path: 'res://scenes/game.tscn',
-      }, ctx);
-
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0].command).toBe('create_scene');
-      expect(mock.calls[0].params).toEqual({
-        root_type: 'Node2D',
-        root_name: 'GameRoot',
-        scene_path: 'res://scenes/game.tscn',
-      });
-    });
-
-    it('uses root_type as default root_name', async () => {
-      mock.mockResponse({});
-      const ctx = createToolContext(mock);
-
-      await scene.execute({
-        action: 'create',
-        root_type: 'Control',
-        scene_path: 'res://ui/menu.tscn',
-      }, ctx);
-
-      expect(mock.calls[0].params.root_name).toBe('Control');
-    });
-
-    it('returns confirmation message with UID', async () => {
-      mock.mockResponse({ path: 'res://levels/world.tscn', uid: 'uid://abc123xyz' });
-      const ctx = createToolContext(mock);
-
-      const result = await scene.execute({
-        action: 'create',
-        root_type: 'Node3D',
-        scene_path: 'res://levels/world.tscn',
-      }, ctx);
-
-      expect(result).toBe('Created scene: res://levels/world.tscn with root node type Node3D\nUID: uid://abc123xyz');
     });
 
     it('requires root_type and scene_path for create', () => {
       expect(scene.schema.safeParse({ action: 'create' }).success).toBe(false);
       expect(scene.schema.safeParse({ action: 'create', root_type: 'Node2D' }).success).toBe(false);
-      expect(scene.schema.safeParse({ action: 'create', scene_path: 'res://test.tscn' }).success).toBe(false);
       expect(scene.schema.safeParse({
         action: 'create',
         root_type: 'Node2D',
         scene_path: 'res://test.tscn',
       }).success).toBe(true);
+    });
+
+    it('save works with or without scene_path', () => {
+      expect(scene.schema.safeParse({ action: 'save' }).success).toBe(true);
+      expect(scene.schema.safeParse({ action: 'save', scene_path: 'res://new.tscn' }).success).toBe(true);
+    });
+  });
+
+  describe('open/save/create actions', () => {
+    it('open returns confirmation with path', async () => {
+      mock.mockResponse({});
+      const ctx = createToolContext(mock);
+
+      const result = await scene.execute({ action: 'open', scene_path: 'res://main.tscn' }, ctx);
+      expect(result).toBe('Opened scene: res://main.tscn');
+    });
+
+    it('save returns path from Godot response and passes optional path', async () => {
+      const ctx = createToolContext(mock);
+
+      mock.mockResponse({ path: 'res://current.tscn' });
+      expect(await scene.execute({ action: 'save' }, ctx)).toBe('Saved scene: res://current.tscn');
+
+      mock.mockResponse({ path: 'res://new.tscn' });
+      await scene.execute({ action: 'save', scene_path: 'res://new.tscn' }, ctx);
+      expect(mock.calls[1].params).toEqual({ path: 'res://new.tscn' });
+    });
+
+    it('create returns confirmation with UID and uses root_type as default root_name', async () => {
+      mock.mockResponse({ path: 'res://world.tscn', uid: 'uid://abc123' });
+      const ctx = createToolContext(mock);
+
+      const result = await scene.execute({
+        action: 'create',
+        root_type: 'Node3D',
+        scene_path: 'res://world.tscn',
+      }, ctx);
+
+      expect(result).toContain('Created scene: res://world.tscn');
+      expect(result).toContain('UID: uid://abc123');
+      expect(mock.calls[0].params.root_name).toBe('Node3D');
     });
   });
 });


### PR DESCRIPTION
## Summary

Reduces test count from **198 to 84** (58% reduction, -1310 lines) by removing anti-patterns:

- **Tautological tests removed**: "sends X command" tests that just verify mock calls
- **Repetitive tests consolidated**: 6 identical log level tests → 1 parameterized test
- **Trivial checks removed**: `expect(tool.name).toBe('tool')`, export counts
- **Mock-the-mock tests removed**: Tests that verify JSON.stringify works on mock data

### Tests retained (the valuable ones)
- Live integration tests (docs.test.ts hits real Godot docs API)
- Fixture-based tests (resource.test.ts parses real Godot response structures)
- Schema refinement logic (mutual exclusion, conditional requirements)
- Edge cases (empty results, error propagation)
- Stateful behavior (logger queue/flush/rate limiting)

## Test plan

- [x] All 84 tests pass
- [x] Verified remaining tests still cover meaningful behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)