### PR TITLE
refactor: sync server version, fix script resource format, remove dead code

### DIFF
--- a/godot/addons/godot_mcp/websocket_server.gd
+++ b/godot/addons/godot_mcp/websocket_server.gd
@@ -68,10 +68,6 @@ func stop_server() -> void:
 	_rejected_connections = 0
 
 
-func get_rejected_connection_count() -> int:
-	return _rejected_connections
-
-
 func send_response(response: Dictionary) -> void:
 	if not _ws_peer or _ws_peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
 		MCPLog.warn("Cannot send response: not connected")

--- a/server/src/connection/websocket.ts
+++ b/server/src/connection/websocket.ts
@@ -1,13 +1,6 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
-import {
-  Request,
-  Response,
-  ResponseSchema,
-  createRequest,
-  isSuccessResponse,
-  isErrorResponse,
-} from './protocol.js';
+import { ResponseSchema, createRequest, isSuccessResponse, isErrorResponse } from './protocol.js';
 import {
   GodotConnectionError,
   GodotCommandError,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import { registerAllTools } from './tools/index.js';
 import { registerAllResources } from './resources/index.js';
 import { GodotCommandError } from './utils/errors.js';
 import { setMcpServer, logger } from './utils/logger.js';
+import { getServerVersion } from './version.js';
 
 registerAllTools();
 registerAllResources();
@@ -21,7 +22,7 @@ export async function main() {
   const server = new Server(
     {
       name: 'godot-mcp',
-      version: '0.1.0',
+      version: getServerVersion(),
     },
     {
       capabilities: {
@@ -95,4 +96,3 @@ export async function main() {
 
   logger.info('Server started');
 }
-

--- a/server/src/resources/script.ts
+++ b/server/src/resources/script.ts
@@ -12,13 +12,12 @@ export const currentScriptResource = defineResource({
     }>('get_current_script');
 
     if (!result.path) {
-      return JSON.stringify({ error: 'No script currently open' });
+      return '# No script currently open';
     }
 
-    return JSON.stringify({
-      path: result.path,
-      content: result.content,
-    });
+    const content = result.content ?? '';
+    const header = `# Path: ${result.path}`;
+    return content.length > 0 ? `${header}\n${content}` : `${header}\n`;
   },
 });
 


### PR DESCRIPTION
## Summary

Synchronize MCP server version with package.json, fix Current Script resource format, and remove dead code.

## Changes

### Server
- **src/index.ts**: Use `getServerVersion()` instead of hard-coded `'0.1.0'` to ensure version consistency across the project
- **src/resources/script.ts**: Return plain GDScript text with `# Path: ...` header instead of JSON, matching the `text/x-gdscript` mime type. Empty editor now returns a friendly comment instead of error JSON
- **src/connection/websocket.ts**: Remove unused `Request` and `Response` imports

### Godot Addon
- **godot/addons/godot_mcp/websocket_server.gd**: Remove unused `get_rejected_connection_count()` method (dead code)

## Testing

- ✅ All tests passing (95/95)
- ✅ Build successful
- ✅ Verified script resource returns proper GDScript format

## Impact

- Server version is now automatically synced with package.json
- Current Script resource is more usable with proper text format
- Cleaner codebase with removed dead code (-19 +7 lines net)