### PR TITLE
docs: update README, add CONTRIBUTING.md, refresh tool docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to godot-mcp
+
+## Dev Setup
+
+```bash
+cd server
+npm install
+npm run build
+npm test
+```
+
+## Making Changes
+
+1. Create a feature branch: `git checkout -b feat/your-feature`
+2. Make your changes
+3. Run tests: `npm test`
+4. Build: `npm run build`
+5. If you changed tool definitions, regenerate docs: `npm run generate-docs`
+6. Commit with a conventional commit message (see below)
+7. Push and open a PR
+
+**Important:** The `main` branch is protected. All changes go through PRs.
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning via release-please.
+
+```
+feat: add new feature        -> minor version bump (2.1.0 -> 2.2.0)
+fix: fix a bug               -> patch version bump (2.1.0 -> 2.1.1)
+refactor: change internals   -> patch version bump
+docs: update documentation   -> no version bump
+chore: maintenance tasks     -> no version bump
+```
+
+Examples:
+- `feat: add input injection tool for testing`
+- `fix: return newest messages instead of oldest`
+- `docs: update Claude Code setup guide`
+
+## Adding a New Tool
+
+1. Create the tool definition in `server/src/tools/<category>.ts` using `defineTool()`
+2. Export it from the category's tools array
+3. Add the corresponding GDScript handler in `godot/addons/godot_mcp/commands/`
+4. Register the command in `command_router.gd`
+5. Add tests in `server/src/__tests__/tools/`
+6. Run `npm run generate-docs` to update API docs
+
+See existing tools for the pattern. The `defineTool()` helper handles schema validation via Zod.
+
+## Releases
+
+**Do not manually bump version numbers.** Release-please handles all versioning automatically.
+
+When your PR is merged:
+1. release-please creates a release PR with version bumps
+2. When that PR is merged, it publishes to npm and creates a GitHub release
+3. The addon zip is attached to the release
+
+The MCP server and Godot addon share version numbers and are released together.
+
+## Architecture
+
+```
+[Claude] <--stdio--> [MCP Server (TypeScript)] <--WebSocket:6550--> [Godot Addon (GDScript)]
+```
+
+- `server/src/tools/` - MCP tool definitions
+- `server/src/resources/` - MCP resource handlers
+- `server/src/connection/` - WebSocket client to Godot
+- `godot/addons/godot_mcp/commands/` - GDScript command handlers
+- `godot/addons/godot_mcp/core/` - Addon utilities (logger, debugger plugin)
+
+## Questions?
+
+Open a [GitHub issue](https://github.com/satelliteoflove/godot-mcp/issues) or start a [discussion](https://github.com/satelliteoflove/godot-mcp/discussions).

--- a/README.md
+++ b/README.md
@@ -1,46 +1,18 @@
 # godot-mcp
 
-An MCP server that gives Claude direct visibility into your Godot editor and running game. Instead of copy-pasting debug output or describing what you're seeing, Claude can observe it directly.
+MCP server that connects Claude to your Godot editor. Less copy-paste, more creating.
 
-## Core Capabilities
+## Why This Exists
 
-**Observe** - Claude sees what you see
-- Live editor state, selection, and open scenes
-- Screenshots from editor viewports or running game
-- Debug output and performance metrics from runtime
-- Camera position and viewport in 2D and 3D
+Using AI assistants for game dev means a lot of back-and-forth: copying error messages, describing what's on screen, pasting debug output, manually applying suggested changes. It works, but it's tedious.
 
-**Inspect** - Deep access to your project
-- Scene tree traversal with node properties
-- 3D spatial data: transforms, bounding boxes, visibility
-- Resource introspection: SpriteFrames, TileSets, Materials
-- Project settings and input mappings
-
-**Modify** - Direct manipulation when needed
-- Create, update, delete, and reparent nodes
-- Attach and detach scripts
-- Edit TileMapLayers and GridMaps cell-by-cell
-- Control animation playback and edit tracks/keyframes
-- Run and stop the game from the editor
+This MCP gives Claude direct access to your Godot editor. It can see your scene tree, capture screenshots, read errors, and make changes directly. You stay focused on the creative work while the mechanical relay disappears. Faster iterations, less busywork, more time building the game you actually want to make.
 
 ## Quick Start
 
-### 1. Configure Your AI Assistant
+### 1. Configure your AI assistant
 
-**Claude Desktop** - Add to config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
-```
-
-**Claude Code** - Add to `.mcp.json`:
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
 {
@@ -53,51 +25,51 @@ An MCP server that gives Claude direct visibility into your Godot editor and run
 }
 ```
 
-### 2. Install the Godot Addon
+**Claude Code** (`.mcp.json` in your project):
+
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
+
+### 2. Install the Godot addon
 
 ```bash
 npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 ```
 
-Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
+Enable in Godot: **Project Settings > Plugins > Godot MCP**
 
-### 3. Start Using
+### 3. Go
 
-Open your Godot project (with addon enabled), restart your AI assistant, and start building.
+Open your Godot project, restart your AI assistant, and start building.
 
-**Version Sync:** The MCP server auto-updates via npx. Version mismatches are detected automatically on connection. If prompted, re-run the install command to update the addon.
+## What Claude Can Do
 
-## Tools
+- **See** your editor, scenes, running game, errors, and performance
+- **Inspect** nodes, resources, animations, tilemaps, 3D spatial data
+- **Modify** scenes, nodes, scripts, animations, tilemaps directly
+- **Test** by running the game and injecting input
+- **Learn** by fetching Godot docs on demand
 
-| Tool | Description |
-|------|-------------|
-| `scene` | Manage scenes: open, save, or create scenes |
-| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals |
-| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_log_messages (errors/warnings with filter/limit), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom |
-| `project` | Get project information and settings |
-| `animation` | Query, control, and edit animations |
-| `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |
-| `gridmap` | Query and edit GridMap data: list gridmaps, get info, get/set cells |
-| `resource` | Manage Godot resources: inspect Resource files by path |
-| `scene3d` | Get spatial information for 3D nodes: global transforms, bounding boxes, visibility |
-| `godot_docs` | Fetch Godot Engine documentation |
-| `input` | Inject input into a running Godot game for testing |
+## Documentation
 
-See [docs/](docs/) for detailed API reference, including the [Claude Code Setup Guide](docs/claude-code-setup.md).
+- [Claude Code Setup Guide](docs/claude-code-setup.md) - CLAUDE.md templates and workflows
+- [Tools Reference](docs/tools/README.md) - All 11 tools with full API docs
+- [Resources Reference](docs/resources.md) - MCP resources for reading project data
+- [Contributing](CONTRIBUTING.md) - Dev setup, adding tools, release process
+- [Changelog](server/CHANGELOG.md) - Release history
 
 ## Architecture
 
 ```
-[AI Assistant] <--stdio--> [MCP Server] <--WebSocket--> [Godot Addon]
-```
-
-## Development
-
-```bash
-cd server
-npm install && npm run build
-npm test
-npm run generate-docs
+[Claude] <--stdio--> [MCP Server] <--WebSocket:6550--> [Godot Addon]
 ```
 
 ## Requirements

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -19,12 +19,17 @@ This project uses godot-mcp for AI-assisted development. The MCP provides real-t
 - Running and stopping the game (`editor` run/stop)
 - Capturing screenshots of game or editor (`editor` screenshot_game/screenshot_editor)
 - Reading debug output from running games (`editor` get_debug_output)
+- Getting structured errors with file:line (`editor` get_log_messages, get_stack_trace)
 - Inspecting node properties at runtime (`node` get_properties)
 - Finding nodes by pattern (`node` find)
+- Connecting signals between nodes (`node` connect_signal)
 - Getting project settings, especially input mappings (`project` get_settings with category)
 - Inspecting complex resources like SpriteFrames or TileSets (`resource` get_info)
 - Editing animations (complex format, easy to break)
 - Editing TileMapLayers or GridMaps (coordinate systems, cell data)
+- Querying 3D spatial data: transforms, bounding boxes (`scene3d`)
+- Fetching Godot documentation (`godot_docs`)
+- Injecting input for automated testing (`input`)
 
 **Use direct file editing for:**
 - GDScript files (.gd) - plain text, easy to edit
@@ -47,10 +52,13 @@ When helping the user navigate the Godot UI:
 When debugging issues:
 1. Use `editor` run to start the game
 2. Use `editor` screenshot_game to see what's happening visually
-3. Use `editor` get_debug_output to check for errors or print statements
-4. Use `editor` get_performance to check FPS and resource usage
-5. Use `node` find to locate nodes in the running scene
-6. Use `editor` stop when done
+3. Use `editor` get_log_messages to get structured errors with file:line
+4. Use `editor` get_stack_trace for the backtrace of the last error
+5. Use `editor` get_debug_output for print statements and raw console output
+6. Use `editor` get_performance to check FPS and resource usage
+7. Use `node` find to locate nodes in the running scene
+8. Use `input` to inject test inputs and reproduce issues
+9. Use `editor` stop when done
 
 ### Common Patterns
 
@@ -82,8 +90,15 @@ Claude Code reads CLAUDE.md at the start of each conversation. By documenting wh
 | Game screenshot | `editor` | screenshot_game |
 | Editor screenshot | `editor` | screenshot_editor |
 | Console output | `editor` | get_debug_output |
+| Structured errors | `editor` | get_log_messages |
+| Error backtrace | `editor` | get_stack_trace |
 | FPS/memory stats | `editor` | get_performance |
+| Control 2D viewport | `editor` | set_viewport_2d |
 | Node configuration | `node` | get_properties |
 | Find nodes | `node` | find |
+| Connect signals | `node` | connect_signal |
 | Input mappings | `project` | get_settings (category: input) |
 | SpriteFrames info | `resource` | get_info |
+| 3D transforms/bounds | `scene3d` | get_spatial_info, get_bounds |
+| Fetch Godot docs | `godot_docs` | fetch_class, fetch_page |
+| Inject test input | `input` | sequence, type_text |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -18,7 +18,7 @@ Node manipulation and script attachment tools
 
 Editor control, debugging, and screenshot tools
 
-- `editor` - Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_log_messages (errors/warnings with filter/limit), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom
+- `editor` - Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, get debug output/errors/stack traces, get performance metrics, control 2D viewport
 
 ## [Project](project.md)
 

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -10,13 +10,13 @@ Editor control, debugging, and screenshot tools
 
 ## editor
 
-Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_log_messages (errors/warnings with filter/limit), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom
+Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, get debug output/errors/stack traces, get performance metrics, control 2D viewport
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_debug_output`, `get_log_messages`, `get_errors`, `get_stack_trace`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_debug_output, get_log_messages (errors/warnings with filtering), get_errors (deprecated alias), get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d |
+| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_debug_output`, `get_log_messages`, `get_errors`, `get_stack_trace`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_debug_output, get_log_messages, get_errors (deprecated), get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d |
 | `node_path` | string | select | Path to node |
 | `scene_path` | string | No | Scene to run (run only, optional) |
 | `clear` | boolean | get_debug_output, get_log_messages, get_errors | Clear buffer after reading |

--- a/server/README.md
+++ b/server/README.md
@@ -1,46 +1,18 @@
 # godot-mcp
 
-An MCP server that gives Claude direct visibility into your Godot editor and running game. Instead of copy-pasting debug output or describing what you're seeing, Claude can observe it directly.
+MCP server that connects Claude to your Godot editor. Less copy-paste, more creating.
 
-## Core Capabilities
+## Why This Exists
 
-**Observe** - Claude sees what you see
-- Live editor state, selection, and open scenes
-- Screenshots from editor viewports or running game
-- Debug output and performance metrics from runtime
-- Camera position and viewport in 2D and 3D
+Using AI assistants for game dev means a lot of back-and-forth: copying error messages, describing what's on screen, pasting debug output, manually applying suggested changes. It works, but it's tedious.
 
-**Inspect** - Deep access to your project
-- Scene tree traversal with node properties
-- 3D spatial data: transforms, bounding boxes, visibility
-- Resource introspection: SpriteFrames, TileSets, Materials
-- Project settings and input mappings
-
-**Modify** - Direct manipulation when needed
-- Create, update, delete, and reparent nodes
-- Attach and detach scripts
-- Edit TileMapLayers and GridMaps cell-by-cell
-- Control animation playback and edit tracks/keyframes
-- Run and stop the game from the editor
+This MCP gives Claude direct access to your Godot editor. It can see your scene tree, capture screenshots, read errors, and make changes directly. You stay focused on the creative work while the mechanical relay disappears. Faster iterations, less busywork, more time building the game you actually want to make.
 
 ## Quick Start
 
-### 1. Configure Your AI Assistant
+### 1. Configure your AI assistant
 
-**Claude Desktop** - Add to config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
-```
-
-**Claude Code** - Add to `.mcp.json`:
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
 {
@@ -53,51 +25,51 @@ An MCP server that gives Claude direct visibility into your Godot editor and run
 }
 ```
 
-### 2. Install the Godot Addon
+**Claude Code** (`.mcp.json` in your project):
+
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
+
+### 2. Install the Godot addon
 
 ```bash
 npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 ```
 
-Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
+Enable in Godot: **Project Settings > Plugins > Godot MCP**
 
-### 3. Start Using
+### 3. Go
 
-Open your Godot project (with addon enabled), restart your AI assistant, and start building.
+Open your Godot project, restart your AI assistant, and start building.
 
-**Version Sync:** The MCP server auto-updates via npx. Version mismatches are detected automatically on connection. If prompted, re-run the install command to update the addon.
+## What Claude Can Do
 
-## Tools
+- **See** your editor, scenes, running game, errors, and performance
+- **Inspect** nodes, resources, animations, tilemaps, 3D spatial data
+- **Modify** scenes, nodes, scripts, animations, tilemaps directly
+- **Test** by running the game and injecting input
+- **Learn** by fetching Godot docs on demand
 
-| Tool | Description |
-|------|-------------|
-| `scene` | Manage scenes: open, save, or create scenes |
-| `node` | Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals |
-| `editor` | Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_log_messages (errors/warnings with filter/limit), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom |
-| `project` | Get project information and settings |
-| `animation` | Query, control, and edit animations |
-| `tilemap` | Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates |
-| `gridmap` | Query and edit GridMap data: list gridmaps, get info, get/set cells |
-| `resource` | Manage Godot resources: inspect Resource files by path |
-| `scene3d` | Get spatial information for 3D nodes: global transforms, bounding boxes, visibility |
-| `godot_docs` | Fetch Godot Engine documentation |
-| `input` | Inject input into a running Godot game for testing |
+## Documentation
 
-See [docs/](docs/) for detailed API reference, including the [Claude Code Setup Guide](docs/claude-code-setup.md).
+- [Claude Code Setup Guide](docs/claude-code-setup.md) - CLAUDE.md templates and workflows
+- [Tools Reference](docs/tools/README.md) - All 11 tools with full API docs
+- [Resources Reference](docs/resources.md) - MCP resources for reading project data
+- [Contributing](CONTRIBUTING.md) - Dev setup, adding tools, release process
+- [Changelog](server/CHANGELOG.md) - Release history
 
 ## Architecture
 
 ```
-[AI Assistant] <--stdio--> [MCP Server] <--WebSocket--> [Godot Addon]
-```
-
-## Development
-
-```bash
-cd server
-npm install && npm run build
-npm test
-npm run generate-docs
+[Claude] <--stdio--> [MCP Server] <--WebSocket:6550--> [Godot Addon]
 ```
 
 ## Requirements

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -473,56 +473,21 @@ Add to your MCP configuration:
 }
 
 function generateRootReadme(): string {
-  const allTools = categories.flatMap(c => c.tools);
-
-  const toolsTable = allTools.map(tool => {
-    const desc = tool.description.split('.')[0];
-    return `| \`${tool.name}\` | ${desc} |`;
-  }).join('\n');
-
   return `# godot-mcp
 
-An MCP server that gives Claude direct visibility into your Godot editor and running game. Instead of copy-pasting debug output or describing what you're seeing, Claude can observe it directly.
+MCP server that connects Claude to your Godot editor. Less copy-paste, more creating.
 
-## Core Capabilities
+## Why This Exists
 
-**Observe** - Claude sees what you see
-- Live editor state, selection, and open scenes
-- Screenshots from editor viewports or running game
-- Debug output and performance metrics from runtime
-- Camera position and viewport in 2D and 3D
+Using AI assistants for game dev means a lot of back-and-forth: copying error messages, describing what's on screen, pasting debug output, manually applying suggested changes. It works, but it's tedious.
 
-**Inspect** - Deep access to your project
-- Scene tree traversal with node properties
-- 3D spatial data: transforms, bounding boxes, visibility
-- Resource introspection: SpriteFrames, TileSets, Materials
-- Project settings and input mappings
-
-**Modify** - Direct manipulation when needed
-- Create, update, delete, and reparent nodes
-- Attach and detach scripts
-- Edit TileMapLayers and GridMaps cell-by-cell
-- Control animation playback and edit tracks/keyframes
-- Run and stop the game from the editor
+This MCP gives Claude direct access to your Godot editor. It can see your scene tree, capture screenshots, read errors, and make changes directly. You stay focused on the creative work while the mechanical relay disappears. Faster iterations, less busywork, more time building the game you actually want to make.
 
 ## Quick Start
 
-### 1. Configure Your AI Assistant
+### 1. Configure your AI assistant
 
-**Claude Desktop** - Add to config (\`~/Library/Application Support/Claude/claude_desktop_config.json\` on macOS):
-
-\`\`\`json
-{
-  "mcpServers": {
-    "godot-mcp": {
-      "command": "npx",
-      "args": ["-y", "@satelliteoflove/godot-mcp"]
-    }
-  }
-}
-\`\`\`
-
-**Claude Code** - Add to \`.mcp.json\`:
+**Claude Desktop** (\`~/Library/Application Support/Claude/claude_desktop_config.json\` on macOS):
 
 \`\`\`json
 {
@@ -535,41 +500,51 @@ An MCP server that gives Claude direct visibility into your Godot editor and run
 }
 \`\`\`
 
-### 2. Install the Godot Addon
+**Claude Code** (\`.mcp.json\` in your project):
+
+\`\`\`json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+\`\`\`
+
+### 2. Install the Godot addon
 
 \`\`\`bash
 npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 \`\`\`
 
-Then enable the addon in Godot: Project Settings > Plugins > Godot MCP.
+Enable in Godot: **Project Settings > Plugins > Godot MCP**
 
-### 3. Start Using
+### 3. Go
 
-Open your Godot project (with addon enabled), restart your AI assistant, and start building.
+Open your Godot project, restart your AI assistant, and start building.
 
-**Version Sync:** The MCP server auto-updates via npx. Version mismatches are detected automatically on connection. If prompted, re-run the install command to update the addon.
+## What Claude Can Do
 
-## Tools
+- **See** your editor, scenes, running game, errors, and performance
+- **Inspect** nodes, resources, animations, tilemaps, 3D spatial data
+- **Modify** scenes, nodes, scripts, animations, tilemaps directly
+- **Test** by running the game and injecting input
+- **Learn** by fetching Godot docs on demand
 
-| Tool | Description |
-|------|-------------|
-${toolsTable}
+## Documentation
 
-See [docs/](docs/) for detailed API reference, including the [Claude Code Setup Guide](docs/claude-code-setup.md).
+- [Claude Code Setup Guide](docs/claude-code-setup.md) - CLAUDE.md templates and workflows
+- [Tools Reference](docs/tools/README.md) - All 11 tools with full API docs
+- [Resources Reference](docs/resources.md) - MCP resources for reading project data
+- [Contributing](CONTRIBUTING.md) - Dev setup, adding tools, release process
+- [Changelog](server/CHANGELOG.md) - Release history
 
 ## Architecture
 
 \`\`\`
-[AI Assistant] <--stdio--> [MCP Server] <--WebSocket--> [Godot Addon]
-\`\`\`
-
-## Development
-
-\`\`\`bash
-cd server
-npm install && npm run build
-npm test
-npm run generate-docs
+[Claude] <--stdio--> [MCP Server] <--WebSocket:6550--> [Godot Addon]
 \`\`\`
 
 ## Requirements

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -37,7 +37,7 @@ const EditorSchema = z
   .object({
     action: z
       .enum(['get_state', 'get_selection', 'select', 'run', 'stop', 'get_debug_output', 'get_log_messages', 'get_errors', 'get_stack_trace', 'get_performance', 'screenshot_game', 'screenshot_editor', 'set_viewport_2d'])
-      .describe('Action: get_state, get_selection, select, run, stop, get_debug_output, get_log_messages (errors/warnings with filtering), get_errors (deprecated alias), get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d'),
+      .describe('Action: get_state, get_selection, select, run, stop, get_debug_output, get_log_messages, get_errors (deprecated), get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d'),
     node_path: z
       .string()
       .optional()
@@ -118,7 +118,7 @@ interface LogMessagesResponse {
 export const editor = defineTool({
   name: 'editor',
   description:
-    'Control the Godot editor: get state (includes viewport/camera info), manage selection, run/stop project, get debug output, get_log_messages (errors/warnings with filter/limit), get_stack_trace (backtrace from last error), get performance metrics, capture screenshots, set 2D viewport position/zoom',
+    'Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, get debug output/errors/stack traces, get performance metrics, control 2D viewport',
   schema: EditorSchema,
   async execute(args: EditorArgs, { godot }) {
     switch (args.action) {


### PR DESCRIPTION
## Summary

- Rewrite README with clearer value proposition ("Less copy-paste, more creating")
- Add CONTRIBUTING.md for external contributors
- Update claude-code-setup.md with new tools (input, scene3d, godot_docs)
- Remove stale filter parameter references from editor tool description
- Use relative paths for documentation links (standard practice)

## Test plan

- [x] npm run generate-docs runs successfully
- [x] npm test passes (98 tests)
- [x] Verify relative links work on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)