### PR TITLE
fix: use proper semver comparison for addon version checks

### DIFF
--- a/server/src/__tests__/installer/install.test.ts
+++ b/server/src/__tests__/installer/install.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { compareVersions } from '../../installer/install.js';
+
+describe('compareVersions', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0);
+    expect(compareVersions('2.12.0', '2.12.0')).toBe(0);
+    expect(compareVersions('0.0.1', '0.0.1')).toBe(0);
+  });
+
+  it('returns 1 when first version is greater', () => {
+    expect(compareVersions('2.0.0', '1.0.0')).toBe(1);
+    expect(compareVersions('1.1.0', '1.0.0')).toBe(1);
+    expect(compareVersions('1.0.1', '1.0.0')).toBe(1);
+    expect(compareVersions('2.12.0', '2.6.1')).toBe(1);
+    expect(compareVersions('10.0.0', '9.0.0')).toBe(1);
+  });
+
+  it('returns -1 when first version is lesser', () => {
+    expect(compareVersions('1.0.0', '2.0.0')).toBe(-1);
+    expect(compareVersions('1.0.0', '1.1.0')).toBe(-1);
+    expect(compareVersions('1.0.0', '1.0.1')).toBe(-1);
+    expect(compareVersions('2.6.1', '2.12.0')).toBe(-1);
+    expect(compareVersions('9.0.0', '10.0.0')).toBe(-1);
+  });
+
+  it('handles versions with different segment counts', () => {
+    expect(compareVersions('1.0', '1.0.0')).toBe(0);
+    expect(compareVersions('1.0.0', '1.0')).toBe(0);
+    expect(compareVersions('1.0', '1.0.1')).toBe(-1);
+    expect(compareVersions('1.0.1', '1.0')).toBe(1);
+    expect(compareVersions('2', '1.9.9')).toBe(1);
+  });
+
+  it('correctly handles the reported bug case (2.12.0 vs 2.6.1)', () => {
+    expect(compareVersions('2.12.0', '2.6.1')).toBe(1);
+    expect(compareVersions('2.6.1', '2.12.0')).toBe(-1);
+  });
+
+  it('handles edge cases', () => {
+    expect(compareVersions('0.0.0', '0.0.0')).toBe(0);
+    expect(compareVersions('0.0.1', '0.0.0')).toBe(1);
+    expect(compareVersions('0.1.0', '0.0.9')).toBe(1);
+  });
+});

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -6,6 +6,7 @@ import { getServerVersion } from './version.js';
 const { values, positionals } = parseArgs({
   options: {
     'install-addon': { type: 'boolean', short: 'i' },
+    force: { type: 'boolean', short: 'f' },
     version: { type: 'boolean', short: 'v' },
     help: { type: 'boolean', short: 'h' },
   },
@@ -23,6 +24,7 @@ Usage:
 
 Options:
   -i, --install-addon    Install the Godot addon to the specified project path
+  -f, --force            Force install even if it would downgrade the addon
   -v, --version          Show version number
   -h, --help             Show help
 `);
@@ -42,14 +44,16 @@ if (values['install-addon']) {
     process.exit(1);
   }
 
-  const result = await installAddon(projectPath);
+  const result = await installAddon(projectPath, { force: values.force });
   if (result.success) {
     console.log(result.message);
-    console.log('\nNext steps:');
-    console.log('  1. Open the Godot project');
-    console.log('  2. Go to Project > Project Settings > Plugins');
-    console.log('  3. Enable "Godot MCP"');
-    console.log('  4. Restart your AI assistant to reconnect');
+    if (!result.skipped) {
+      console.log('\nNext steps:');
+      console.log('  1. Open the Godot project');
+      console.log('  2. Go to Project > Project Settings > Plugins');
+      console.log('  3. Enable "Godot MCP"');
+      console.log('  4. Restart your AI assistant to reconnect');
+    }
     process.exit(0);
   } else {
     console.error('Error:', result.message);


### PR DESCRIPTION
## Summary

- Add `compareVersions()` function for proper numeric semver comparison
- Skip installation if addon is already up to date (same version)
- Prevent downgrades unless `--force` flag is used
- Add tests for version comparison logic

Fixes #116

## The Bug

The `--install-addon` command compared version strings lexicographically:

```
"2.12.0" vs "2.6.1"
   ^         ^
   "1" < "6"  (character comparison)
```

This caused `2.12.0` to be incorrectly considered older than `2.6.1`, leading to unwanted downgrades.

## Test plan

- [x] `npm test` passes (141 tests, including 6 new version comparison tests)
- [x] `npm run build` succeeds
- [ ] Manual test: run `--install-addon` on a project with newer addon, verify it skips
- [ ] Manual test: run `--install-addon --force` to verify forced downgrade works

:robot: Generated with [Claude Code](https://claude.com/claude-code)