### PR TITLE
feat(addon): display version in MCP panel

### DIFF
--- a/godot/addons/godot_mcp/commands/system_commands.gd
+++ b/godot/addons/godot_mcp/commands/system_commands.gd
@@ -12,6 +12,9 @@ func get_commands() -> Dictionary:
 func mcp_handshake(params: Dictionary) -> Dictionary:
 	var server_version: String = params.get("server_version", "unknown")
 
+	if _plugin and _plugin.has_method("on_server_version_received"):
+		_plugin.on_server_version_received(server_version)
+
 	return _success({
 		"addon_version": _get_addon_version(),
 		"godot_version": Engine.get_version_info()["string"],

--- a/godot/addons/godot_mcp/plugin.gd
+++ b/godot/addons/godot_mcp/plugin.gd
@@ -42,6 +42,7 @@ func _enter_tree() -> void:
 	_ensure_game_bridge_autoload()
 	_ensure_bind_settings()
 	_setup_bind_ui()
+	_setup_version_display()
 	_apply_bind_settings(true)
 	MCPLog.info("Plugin initialized")
 
@@ -239,9 +240,29 @@ func _on_client_connected() -> void:
 
 func _on_client_disconnected() -> void:
 	_update_status("Disconnected")
+	if _status_panel and _status_panel.has_method("clear_server_version"):
+		_status_panel.clear_server_version()
 	MCPLog.info("Client disconnected")
 
 
 func _update_status(status: String) -> void:
 	if _status_panel and _status_panel.has_method("set_status"):
 		_status_panel.set_status(status)
+
+
+func _setup_version_display() -> void:
+	if _status_panel and _status_panel.has_method("set_addon_version"):
+		_status_panel.set_addon_version(_get_addon_version())
+
+
+func _get_addon_version() -> String:
+	var config := ConfigFile.new()
+	var err := config.load("res://addons/godot_mcp/plugin.cfg")
+	if err == OK:
+		return config.get_value("plugin", "version", "")
+	return ""
+
+
+func on_server_version_received(version: String) -> void:
+	if _status_panel and _status_panel.has_method("set_server_version"):
+		_status_panel.set_server_version(version)

--- a/godot/addons/godot_mcp/ui/status_panel.gd
+++ b/godot/addons/godot_mcp/ui/status_panel.gd
@@ -9,13 +9,16 @@ func _get_minimum_size() -> Vector2:
 
 @onready var status_label: Label = $MarginContainer/VBoxContainer/StatusRow/StatusLabel
 @onready var status_icon: ColorRect = $MarginContainer/VBoxContainer/StatusRow/StatusIcon
+@onready var version_label: Label = $MarginContainer/VBoxContainer/StatusRow/VersionLabel
 @onready var bind_mode_option: OptionButton = $MarginContainer/VBoxContainer/SettingsGrid/BindModeOption
 @onready var custom_ip_label: Label = $MarginContainer/VBoxContainer/SettingsGrid/CustomIpLabel
-@onready var custom_ip_edit: LineEdit = $MarginContainer/VBoxContainer/SettingsGrid/CustomIpControls/CustomIpEdit
+@onready var custom_ip_edit: LineEdit = $MarginContainer/VBoxContainer/SettingsGrid/CustomIpEdit
 @onready var port_override_label: Label = $MarginContainer/VBoxContainer/SettingsGrid/PortOverrideLabel
 @onready var port_override_enabled: CheckBox = $MarginContainer/VBoxContainer/SettingsGrid/PortOverrideControls/PortOverrideEnabled
 @onready var port_override_spin: SpinBox = $MarginContainer/VBoxContainer/SettingsGrid/PortOverrideControls/PortOverrideSpin
 @onready var apply_button: Button = $MarginContainer/VBoxContainer/SettingsGrid/PortOverrideControls/ApplyButton
+
+var _addon_version: String = ""
 
 var _updating_ui := false
 
@@ -187,3 +190,37 @@ func _update_controls_enabled() -> void:
 		port_override_spin.modulate.a = 1.0 if port_enabled else 0.5
 	if port_override_label:
 		port_override_label.modulate.a = 1.0 if port_enabled else 0.5
+
+
+func set_addon_version(version: String) -> void:
+	_addon_version = version
+	_update_version_label()
+
+
+func set_server_version(version: String) -> void:
+	if not version_label:
+		return
+	if version.is_empty():
+		_update_version_label()
+	elif _addon_version.is_empty():
+		version_label.text = "Server: %s" % version
+	elif version == _addon_version:
+		version_label.text = "v%s" % version
+	else:
+		version_label.text = "Addon: %s | Server: %s" % [_addon_version, version]
+		version_label.add_theme_color_override("font_color", Color.ORANGE)
+
+
+func clear_server_version() -> void:
+	_update_version_label()
+	if version_label:
+		version_label.remove_theme_color_override("font_color")
+
+
+func _update_version_label() -> void:
+	if not version_label:
+		return
+	if _addon_version.is_empty():
+		version_label.text = ""
+	else:
+		version_label.text = "v%s" % _addon_version

--- a/godot/addons/godot_mcp/ui/status_panel.tscn
+++ b/godot/addons/godot_mcp/ui/status_panel.tscn
@@ -39,6 +39,11 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Initializing..."
 
+[node name="VersionLabel" type="Label" parent="MarginContainer/VBoxContainer/StatusRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+text = ""
+
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
@@ -53,22 +58,16 @@ layout_mode = 2
 text = "Bind mode"
 
 [node name="BindModeOption" type="OptionButton" parent="MarginContainer/VBoxContainer/SettingsGrid"]
+custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
-size_flags_horizontal = 3
 
 [node name="CustomIpLabel" type="Label" parent="MarginContainer/VBoxContainer/SettingsGrid"]
 layout_mode = 2
 text = "Custom bind IP"
 
-[node name="CustomIpControls" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SettingsGrid"]
+[node name="CustomIpEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/SettingsGrid"]
+custom_minimum_size = Vector2(180, 0)
 layout_mode = 2
-theme_override_constants/separation = 8
-size_flags_horizontal = 3
-
-[node name="CustomIpEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/SettingsGrid/CustomIpControls"]
-custom_minimum_size = Vector2(220, 0)
-layout_mode = 2
-size_flags_horizontal = 3
 placeholder_text = "e.g. 127.0.0.1"
 
 [node name="PortOverrideLabel" type="Label" parent="MarginContainer/VBoxContainer/SettingsGrid"]
@@ -78,7 +77,6 @@ text = "Port override"
 [node name="PortOverrideControls" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SettingsGrid"]
 layout_mode = 2
 theme_override_constants/separation = 8
-size_flags_horizontal = 3
 
 [node name="PortOverrideEnabled" type="CheckBox" parent="MarginContainer/VBoxContainer/SettingsGrid/PortOverrideControls"]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- Display addon and server versions in the top-right corner of the MCP status panel
- Shows "v2.12.1" when versions match, or "Addon: X | Server: Y" (in orange) when mismatched
- Constrains Bind mode dropdown and Custom IP field widths to match Port override controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)