### PR TITLE
chore: clarify intentional handshake failure behavior

### DIFF
--- a/server/src/connection/websocket.ts
+++ b/server/src/connection/websocket.ts
@@ -200,13 +200,15 @@ export class GodotConnection extends EventEmitter {
 
         try {
           await this.performHandshake();
-          this.currentState = 'connected';
         } catch (error) {
-          this.currentState = 'connected';
           const errorMessage = error instanceof Error ? error.message : String(error);
           logger.error('Handshake failed (addon may be outdated)', { error: errorMessage });
           this.emit('handshake_failed', { error: errorMessage });
         }
+
+        // Connection is valid regardless of handshake outcome - handshake provides
+        // version metadata but isn't required for operation (backwards compatibility)
+        this.currentState = 'connected';
 
         this.emit('connected');
         resolve();


### PR DESCRIPTION
## Summary

- Deduplicate `currentState = 'connected'` assignment that appeared in both try and catch blocks
- Add comment explaining this is intentional for backwards compatibility

The code previously set `currentState = 'connected'` in both the success and failure paths, which looked like a copy-paste bug but is actually intentional. The WebSocket connection is functional even if handshake fails, allowing backwards compatibility with older addons.

Fixes #128

## Test plan

- [x] Build passes
- [x] All 151 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)