### PR TITLE
fix: add validation to prevent reparenting node to its own descendant

### DIFF
--- a/godot/addons/godot_mcp/commands/node_commands.gd
+++ b/godot/addons/godot_mcp/commands/node_commands.gd
@@ -250,6 +250,9 @@ func reparent_node(params: Dictionary) -> Dictionary:
 	if node == root:
 		return _error("CANNOT_REPARENT_ROOT", "Cannot reparent the root node")
 
+	if new_parent == node or node.is_ancestor_of(new_parent):
+		return _error("INVALID_REPARENT", "Cannot reparent a node to itself or its descendant")
+
 	node.reparent(new_parent)
 
 	return _success({"new_path": str(root.get_path_to(node))})


### PR DESCRIPTION
## Summary

Add validation before `node.reparent()` to check that the new parent is not:
- The node itself
- A descendant of the node

Without this check, attempting to reparent a node to one of its own children would create an invalid cycle in the scene tree.

Fixes #129

🤖 Generated with [Claude Code](https://claude.ai/code)