### PR TITLE
fix: add type validation for parsed JSON in websocket server

### DIFF
--- a/godot/addons/godot_mcp/websocket_server.gd
+++ b/godot/addons/godot_mcp/websocket_server.gd
@@ -212,6 +212,11 @@ func _handle_packet(packet: PackedByteArray) -> void:
 		_send_error_response("", "PARSE_ERROR", "Invalid JSON: %s" % json.get_error_message())
 		return
 
+	if not json.data is Dictionary:
+		MCPLog.error("Invalid command format: expected JSON object")
+		_send_error_response("", "INVALID_FORMAT", "Expected JSON object")
+		return
+
 	var data: Dictionary = json.data
 	if not data.has("id") or not data.has("command"):
 		MCPLog.error("Invalid command format")


### PR DESCRIPTION
## Summary

Check that `json.data` is a Dictionary before calling `.has()` on it. Prevents crash if malformed JSON (array, string, etc.) is received.

Fixes #130

🤖 Generated with [Claude Code](https://claude.ai/code)