### PR TITLE
fix(node,screenshot): 3D cursor snap and viewport hint

### DIFF
--- a/godot/addons/godot_mcp/commands/node_commands.gd
+++ b/godot/addons/godot_mcp/commands/node_commands.gd
@@ -184,7 +184,6 @@ func create_node(params: Dictionary) -> Dictionary:
 		if "scale" in properties:
 			n3d.scale = MCPUtils.deserialize_value(properties["scale"])
 
-	EditorInterface.mark_scene_as_unsaved()
 	return _success({"node_path": str(scene_root.get_path_to(node))})
 
 
@@ -212,7 +211,6 @@ func update_node(params: Dictionary) -> Dictionary:
 			var deserialized := MCPUtils.deserialize_value(properties[key])
 			node.set(key, deserialized)
 
-	EditorInterface.mark_scene_as_unsaved()
 	return _success({})
 
 
@@ -236,7 +234,6 @@ func delete_node(params: Dictionary) -> Dictionary:
 	node.get_parent().remove_child(node)
 	node.queue_free()
 
-	EditorInterface.mark_scene_as_unsaved()
 	return _success({})
 
 
@@ -270,7 +267,6 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	node.reparent(new_parent)
 
-	EditorInterface.mark_scene_as_unsaved()
 	return _success({"new_path": str(root.get_path_to(node))})
 
 

--- a/godot/addons/godot_mcp/commands/node_commands.gd
+++ b/godot/addons/godot_mcp/commands/node_commands.gd
@@ -172,6 +172,19 @@ func create_node(params: Dictionary) -> Dictionary:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	_set_owner_recursive(node, scene_root)
 
+	# Re-apply spatial transforms after add_child: the editor viewport may
+	# snap newly added Node3D nodes to the current 3D cursor position,
+	# overriding properties set before add_child.
+	if node is Node3D:
+		var n3d := node as Node3D
+		if "position" in properties:
+			n3d.position = MCPUtils.deserialize_value(properties["position"])
+		if "rotation" in properties:
+			n3d.rotation = MCPUtils.deserialize_value(properties["rotation"])
+		if "scale" in properties:
+			n3d.scale = MCPUtils.deserialize_value(properties["scale"])
+
+	EditorInterface.mark_scene_as_unsaved()
 	return _success({"node_path": str(scene_root.get_path_to(node))})
 
 
@@ -199,6 +212,7 @@ func update_node(params: Dictionary) -> Dictionary:
 			var deserialized := MCPUtils.deserialize_value(properties[key])
 			node.set(key, deserialized)
 
+	EditorInterface.mark_scene_as_unsaved()
 	return _success({})
 
 
@@ -222,6 +236,7 @@ func delete_node(params: Dictionary) -> Dictionary:
 	node.get_parent().remove_child(node)
 	node.queue_free()
 
+	EditorInterface.mark_scene_as_unsaved()
 	return _success({})
 
 
@@ -255,6 +270,7 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	node.reparent(new_parent)
 
+	EditorInterface.mark_scene_as_unsaved()
 	return _success({"new_path": str(root.get_path_to(node))})
 
 

--- a/godot/addons/godot_mcp/commands/screenshot_commands.gd
+++ b/godot/addons/godot_mcp/commands/screenshot_commands.gd
@@ -117,10 +117,24 @@ func _find_3d_viewport() -> SubViewport:
 
 func _find_viewport_in_tree(node: Node, hint: String) -> SubViewport:
 	if node is SubViewportContainer:
-		var container := node as SubViewportContainer
-		for child in container.get_children():
-			if child is SubViewport:
-				return child as SubViewport
+		# Walk up the parent chain to find a node whose name matches the hint
+		# (e.g. "3D" for the 3D viewport panel, "2D" for the 2D viewport panel).
+		# This prevents returning the wrong SubViewport when multiple exist.
+		var matches_hint := true
+		if not hint.is_empty():
+			matches_hint = false
+			var ancestor := node.get_parent()
+			while ancestor != null:
+				if ancestor.name.containsn(hint):
+					matches_hint = true
+					break
+				ancestor = ancestor.get_parent()
+
+		if matches_hint:
+			var container := node as SubViewportContainer
+			for child in container.get_children():
+				if child is SubViewport:
+					return child as SubViewport
 
 	for child in node.get_children():
 		var result := _find_viewport_in_tree(child, hint)

--- a/godot/addons/godot_mcp/commands/screenshot_commands.gd
+++ b/godot/addons/godot_mcp/commands/screenshot_commands.gd
@@ -117,24 +117,10 @@ func _find_3d_viewport() -> SubViewport:
 
 func _find_viewport_in_tree(node: Node, hint: String) -> SubViewport:
 	if node is SubViewportContainer:
-		# Walk up the parent chain to find a node whose name matches the hint
-		# (e.g. "3D" for the 3D viewport panel, "2D" for the 2D viewport panel).
-		# This prevents returning the wrong SubViewport when multiple exist.
-		var matches_hint := true
-		if not hint.is_empty():
-			matches_hint = false
-			var ancestor := node.get_parent()
-			while ancestor != null:
-				if ancestor.name.containsn(hint):
-					matches_hint = true
-					break
-				ancestor = ancestor.get_parent()
-
-		if matches_hint:
-			var container := node as SubViewportContainer
-			for child in container.get_children():
-				if child is SubViewport:
-					return child as SubViewport
+		var container := node as SubViewportContainer
+		for child in container.get_children():
+			if child is SubViewport:
+				return child as SubViewport
 
 	for child in node.get_children():
 		var result := _find_viewport_in_tree(child, hint)


### PR DESCRIPTION
## Summary

Bug fixes split out from #166 as requested by @satelliteoflove.

- **fix(node): re-apply transforms after `add_child`** — the editor 3D cursor can snap newly created `Node3D` nodes to an unexpected position, overriding properties set before `add_child`. Now re-applies `position`/`rotation`/`scale` only when explicitly passed by the caller.
- **fix(screenshot): `_find_viewport_in_tree` hint matching** — walks the ancestor chain to match the `hint` string (`"2D"`/`"3D"`), preventing the wrong `SubViewport` from being returned when multiple exist.

## Changed files

| File | Change |
|------|--------|
| `godot/addons/godot_mcp/commands/node_commands.gd` | Transform re-apply fix for Node3D after `add_child` |
| `godot/addons/godot_mcp/commands/screenshot_commands.gd` | `_find_viewport_in_tree` hint ancestor walk |

## Test plan

- [x] Verified transform re-apply only fires for explicitly passed properties (no `else: Vector3.ZERO`)
- [x] Verified screenshot hint fix walks ancestor chain to match `"2D"`/`"3D"`
- [x] Tested against official plugin build

🤖 Generated with [Claude Code](https://claude.com/claude-code)