### PR TITLE
feat(node): undo/redo support for all mutating commands

### DIFF
--- a/godot/addons/godot_mcp/commands/node_commands.gd
+++ b/godot/addons/godot_mcp/commands/node_commands.gd
@@ -168,9 +168,23 @@ func create_node(params: Dictionary) -> Dictionary:
 			var deserialized := MCPUtils.deserialize_value(properties[key])
 			node.set(key, deserialized)
 
-	parent.add_child(node)
 	var scene_root := EditorInterface.get_edited_scene_root()
-	_set_owner_recursive(node, scene_root)
+	var undo_redo := _plugin.get_undo_redo()
+	undo_redo.create_action("MCP: Create Node '%s'" % node_name, UndoRedo.MERGE_DISABLE)
+	undo_redo.add_do_method(parent, "add_child", node)
+	undo_redo.add_do_method(self, "_set_owner_recursive", node, scene_root)
+	# Re-apply spatial transforms after add_child: the editor viewport may
+	# snap newly added Node3D nodes to the current 3D cursor position.
+	if node is Node3D:
+		if "position" in properties:
+			undo_redo.add_do_property(node, "position", MCPUtils.deserialize_value(properties["position"]))
+		if "rotation" in properties:
+			undo_redo.add_do_property(node, "rotation", MCPUtils.deserialize_value(properties["rotation"]))
+		if "scale" in properties:
+			undo_redo.add_do_property(node, "scale", MCPUtils.deserialize_value(properties["scale"]))
+	undo_redo.add_undo_method(parent, "remove_child", node)
+	undo_redo.add_undo_reference(node)
+	undo_redo.commit_action()
 
 	return _success({"node_path": str(scene_root.get_path_to(node))})
 
@@ -194,10 +208,15 @@ func update_node(params: Dictionary) -> Dictionary:
 	if not node:
 		return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
 
+	var undo_redo := _plugin.get_undo_redo()
+	undo_redo.create_action("MCP: Update Node '%s'" % node_path, UndoRedo.MERGE_DISABLE)
 	for key in properties:
 		if key in node:
-			var deserialized := MCPUtils.deserialize_value(properties[key])
-			node.set(key, deserialized)
+			var old_value = node.get(key)
+			var new_value = MCPUtils.deserialize_value(properties[key])
+			undo_redo.add_do_property(node, key, new_value)
+			undo_redo.add_undo_property(node, key, old_value)
+	undo_redo.commit_action()
 
 	return _success({})
 
@@ -219,8 +238,16 @@ func delete_node(params: Dictionary) -> Dictionary:
 	if node == root:
 		return _error("CANNOT_DELETE_ROOT", "Cannot delete the root node")
 
-	node.get_parent().remove_child(node)
-	node.queue_free()
+	var parent := node.get_parent()
+	var idx := node.get_index()
+	var undo_redo := _plugin.get_undo_redo()
+	undo_redo.create_action("MCP: Delete Node '%s'" % node_path, UndoRedo.MERGE_DISABLE)
+	undo_redo.add_do_method(parent, "remove_child", node)
+	undo_redo.add_undo_method(parent, "add_child", node)
+	undo_redo.add_undo_method(parent, "move_child", node, idx)
+	undo_redo.add_undo_method(self, "_set_owner_recursive", node, root)
+	undo_redo.add_undo_reference(node)
+	undo_redo.commit_action()
 
 	return _success({})
 
@@ -253,7 +280,16 @@ func reparent_node(params: Dictionary) -> Dictionary:
 	if new_parent == node or node.is_ancestor_of(new_parent):
 		return _error("INVALID_REPARENT", "Cannot reparent a node to itself or its descendant")
 
-	node.reparent(new_parent)
+	var old_parent := node.get_parent()
+	var old_idx := node.get_index()
+	var undo_redo := _plugin.get_undo_redo()
+	undo_redo.create_action("MCP: Reparent Node '%s'" % node_path, UndoRedo.MERGE_DISABLE)
+	undo_redo.add_do_method(node, "reparent", new_parent)
+	undo_redo.add_do_method(self, "_set_owner_recursive", node, root)
+	undo_redo.add_undo_method(node, "reparent", old_parent)
+	undo_redo.add_undo_method(old_parent, "move_child", node, old_idx)
+	undo_redo.add_undo_method(self, "_set_owner_recursive", node, root)
+	undo_redo.commit_action()
 
 	return _success({"new_path": str(root.get_path_to(node))})
 
@@ -291,11 +327,12 @@ func connect_signal(params: Dictionary) -> Dictionary:
 	if source_node.is_connected(signal_name, Callable(target_node, method_name)):
 		return _error("ALREADY_CONNECTED", "Signal '%s' is already connected to %s.%s()" % [signal_name, target_path, method_name])
 
-	var err := source_node.connect(signal_name, Callable(target_node, method_name), CONNECT_PERSIST)
-	if err != OK:
-		return _error("CONNECT_FAILED", "Failed to connect signal: %s" % error_string(err))
-
-	EditorInterface.mark_scene_as_unsaved()
+	var callable := Callable(target_node, method_name)
+	var undo_redo := _plugin.get_undo_redo()
+	undo_redo.create_action("MCP: Connect Signal '%s'" % signal_name, UndoRedo.MERGE_DISABLE)
+	undo_redo.add_do_method(source_node, "connect", signal_name, callable, CONNECT_PERSIST)
+	undo_redo.add_undo_method(source_node, "disconnect", signal_name, callable)
+	undo_redo.commit_action()
 
 	return _success({})
 


### PR DESCRIPTION
## Summary

Split out from #166 as requested by @satelliteoflove.

All five mutating node commands now wrap their operations in `EditorUndoRedoManager` actions, so **Ctrl+Z / Ctrl+Y works** in the editor after MCP edits.

### What problem this solves

When an AI agent (e.g. Claude) builds a scene via MCP — creating, moving, or deleting nodes — there was **no way to undo** those changes. Particularly `delete_node` used `queue_free()`, making deleted nodes **permanently irrecoverable**. This made iterating with AI-assisted scene building risky: one wrong deletion meant manually rebuilding.

### What changed

| Command | Do | Undo |
|---------|-----|------|
| `create_node` | `add_child` + `set_owner_recursive` + transform re-apply via `add_do_property` | `remove_child` + `add_undo_reference` |
| `update_node` | `add_do_property` per key | `add_undo_property` with captured `old_value` |
| `delete_node` | `remove_child` (no more `queue_free`) | `add_child` + restore sibling index + `set_owner_recursive` + `add_undo_reference` |
| `reparent_node` | `reparent` + `set_owner_recursive` | `reparent` back + restore index + `set_owner_recursive` |
| `connect_signal` | `connect` with `CONNECT_PERSIST` | `disconnect` |

### Other improvements

- **Removed explicit `mark_scene_as_unsaved()`** — `create_action()` defaults `mark_unsaved=true`, so `commit_action()` handles scene dirty marking automatically.
- **Transform re-apply inside undo action** — `position`/`rotation`/`scale` are registered as `add_do_property` so they survive Undo→Redo cycles (previously they were applied outside the action and would be lost on redo).

## Changed files

| File | Change |
|------|--------|
| `godot/addons/godot_mcp/commands/node_commands.gd` | Undo/redo for all 5 mutating commands |

## Test plan

- [x] `create_node` → Ctrl+Z removes node → Ctrl+Y restores it with correct position
- [x] `delete_node` → Ctrl+Z restores node (no more `queue_free`)
- [x] `update_node` → change property → Ctrl+Z reverts to old value
- [x] `reparent_node` → move node → Ctrl+Z moves it back to original parent
- [x] `connect_signal` → connect signal → Ctrl+Z disconnects it
- [x] All tested live via MCP plugin in Godot 4.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)