### PR TITLE
fix(utils): serialize inline resources recursively

### DIFF
--- a/godot/addons/godot_mcp/core/mcp_utils.gd
+++ b/godot/addons/godot_mcp/core/mcp_utils.gd
@@ -59,10 +59,33 @@ static func serialize_value(value: Variant) -> Variant:
 			if value == null:
 				return null
 			if value is Resource:
-				return value.resource_path if value.resource_path else str(value)
+				if not value.resource_path.is_empty():
+					return value.resource_path
+				# Inline resource — serialize properties recursively
+				return _serialize_inline_resource(value)
 			return str(value)
 		_:
 			return value
+
+
+static func _serialize_inline_resource(res: Resource, depth: int = 0) -> Dictionary:
+	var props := {"_resource": res.get_class()}
+	if depth > 3:
+		return props
+	for prop in res.get_property_list():
+		var pname: String = prop["name"]
+		if pname.begins_with("_"):
+			continue
+		if prop["usage"] & PROPERTY_USAGE_EDITOR == 0:
+			continue
+		if pname in ["resource_local_to_scene", "resource_path", "resource_name", "script"]:
+			continue
+		var pval = res.get(pname)
+		if pval is Resource and pval.resource_path.is_empty():
+			props[pname] = _serialize_inline_resource(pval, depth + 1)
+		else:
+			props[pname] = serialize_value(pval)
+	return props
 
 
 static func deserialize_value(value: Variant) -> Variant:


### PR DESCRIPTION
## Summary

Split out from #166 as requested by @satelliteoflove.

### What problem this solves

`serialize_value()` calls `str(value)` for inline Resources (resources not saved to disk), returning useless debug strings like `"():<BoxMesh#-9223366414658558960>"`. An AI agent calling `get_node_properties` on a MeshInstance3D with an inline BoxMesh **cannot see** the mesh size, material colors, or any other property — it's blind to inline resources.

Meanwhile, `deserialize_value()` already supports creating inline resources from `{"_resource": "BoxMesh", "size": {...}}` dicts via `_create_resource()`. The serialization side was the missing half.

### Before / After

```
# Before
"mesh": "():<BoxMesh#-9223366414658558960>"

# After
"mesh": {"_resource": "BoxMesh", "size": {"x": 2, "y": 3, "z": 1}, ...}
```

### What changed

- `serialize_value()` TYPE_OBJECT branch: saved Resources still return `"res://..."` (no change), inline Resources now call `_serialize_inline_resource()`
- New `_serialize_inline_resource()`: recursively serializes Resource properties using `PROPERTY_USAGE_EDITOR` filter, skipping internal props. Includes depth limit (max 3) to prevent infinite recursion on circular references.

## Changed files

| File | Change |
|------|--------|
| `godot/addons/godot_mcp/core/mcp_utils.gd` | `_serialize_inline_resource()` + updated `serialize_value()` |

## Test plan

- [x] Inline BoxMesh returns `{"_resource": "BoxMesh", "size": {...}}` instead of debug string
- [x] Inline StandardMaterial3D with nested Color/Vector3 properties serializes correctly
- [x] Saved resources (`resource_path` set) still return `"res://..."` path string
- [x] Depth limit prevents crash on deeply nested resources
- [x] Tested live via MCP plugin in Godot 4.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)