### PR TITLE
feat(editor)!: remove deprecated debug/errors/performance actions

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -18,7 +18,7 @@ Node manipulation and script attachment tools
 
 Editor control, debugging, and screenshot tools
 
-- `editor` - Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, get debug output (deprecated - use minimal-godot-mcp)/errors/stack traces, get performance metrics, control 2D viewport
+- `editor` - Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
 
 ## [Project](project.md)
 

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -10,18 +10,17 @@ Editor control, debugging, and screenshot tools
 
 ## editor
 
-Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, get debug output (deprecated - use minimal-godot-mcp)/errors/stack traces, get performance metrics, control 2D viewport
+Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_debug_output`, `get_log_messages`, `get_errors`, `get_stack_trace`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_debug_output (deprecated - use minimal-godot-mcp), get_log_messages, get_errors (deprecated), get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d |
+| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_log_messages, get_stack_trace, screenshot_game, screenshot_editor, set_viewport_2d |
 | `node_path` | string | select | Path to node |
 | `scene_path` | string | No | Scene to run (run only, optional) |
-| `clear` | boolean | get_debug_output, get_log_messages, get_errors | Clear buffer after reading |
+| `clear` | boolean | get_log_messages | Clear buffer after reading |
 | `limit` | integer | No | Maximum number of messages to return (get_log_messages only, default: 50) |
-| `source` | `editor`, `game` | No | Output source: "editor" for editor panel messages (script errors, loading failures), "game" for running game output. If omitted, returns game output when running, else editor output. |
 | `viewport` | `2d`, `3d` | screenshot_editor | Which editor viewport to capture |
 | `max_width` | number | screenshot_game, screenshot_editor | Maximum width in pixels for screenshot |
 | `center_x` | number | set_viewport_2d | X coordinate to center the 2D viewport on |
@@ -42,21 +41,11 @@ Parameters: `node_path`*
 
 #### `stop`
 
-#### `get_debug_output`
-
-Parameters: `clear`
-
 #### `get_log_messages`
 
-Parameters: `clear`
-
-#### `get_errors`
-
-Parameters: `clear`
+Parameters: `clear`*
 
 #### `get_stack_trace`
-
-#### `get_performance`
 
 #### `screenshot_game`
 
@@ -94,7 +83,7 @@ Parameters: `center_x`*, `center_y`*, `zoom`*
 }
 ```
 
-*10 more actions available: `run`, `stop`, `get_debug_output`, `get_log_messages`, `get_errors`, `get_stack_trace`, `get_performance`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d`*
+*7 more actions available: `run`, `stop`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d`*
 
 ---
 

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -66,32 +66,6 @@ describe('editor tool', () => {
     });
   });
 
-  describe('get_debug_output (deprecated)', () => {
-    it('returns deprecation notice with labeled output based on source', async () => {
-      const ctx = createToolContext(mock);
-      const deprecation = '[DEPRECATED] get_debug_output is deprecated. Use minimal-godot-mcp\'s get_console_output tool instead (no addon required).';
-
-      mock.mockResponse({ output: '', source: 'editor' });
-      const emptyResult = await editor.execute({ action: 'get_debug_output', source: 'editor' }, ctx);
-      expect(emptyResult).toContain(deprecation);
-      expect(emptyResult).toContain('No editor output');
-
-      mock.mockResponse({ output: 'Player spawned', source: 'game' });
-      const result = await editor.execute({ action: 'get_debug_output', source: 'game' }, ctx);
-      expect(result).toContain(deprecation);
-      expect(result).toContain('Game output:');
-      expect(result).toContain('Player spawned');
-    });
-
-    it('passes clear parameter to Godot', async () => {
-      mock.mockResponse({ output: 'test', source: 'game' });
-      const ctx = createToolContext(mock);
-
-      await editor.execute({ action: 'get_debug_output', clear: true }, ctx);
-      expect(mock.calls[0].params.clear).toBe(true);
-    });
-  });
-
   describe('get_log_messages', () => {
     it('returns "No log messages" when empty', async () => {
       const ctx = createToolContext(mock);
@@ -119,34 +93,6 @@ describe('editor tool', () => {
       mock.mockResponse({ total_count: 0, returned_count: 0, messages: [] });
       await editor.execute({ action: 'get_log_messages', limit: 10 }, ctx);
       expect(mock.calls[0].params.limit).toBe(10);
-    });
-  });
-
-  describe('get_errors (deprecated alias)', () => {
-    it('returns "No errors" when empty, JSON when present', async () => {
-      const ctx = createToolContext(mock);
-
-      mock.mockResponse({ total_count: 0, returned_count: 0, messages: [] });
-      expect(await editor.execute({ action: 'get_errors' }, ctx)).toBe('No errors');
-
-      const responseData = {
-        total_count: 1,
-        returned_count: 1,
-        messages: [{
-          timestamp: 12345,
-          type: 'Parser Error',
-          message: 'Could not find type',
-          file: 'res://test.gd',
-          line: 10,
-          error_type: 0,
-          frames: [],
-        }],
-      };
-      mock.mockResponse(responseData);
-      const result = await editor.execute({ action: 'get_errors' }, ctx);
-      const parsed = JSON.parse(result as string);
-      expect(parsed.error_count).toBe(1);
-      expect(parsed.errors).toEqual(responseData.messages);
     });
   });
 

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -36,8 +36,8 @@ function toImageContent(base64: string): ImageContent {
 const EditorSchema = z
   .object({
     action: z
-      .enum(['get_state', 'get_selection', 'select', 'run', 'stop', 'get_debug_output', 'get_log_messages', 'get_errors', 'get_stack_trace', 'get_performance', 'screenshot_game', 'screenshot_editor', 'set_viewport_2d'])
-      .describe('Action: get_state, get_selection, select, run, stop, get_debug_output (deprecated - use minimal-godot-mcp), get_log_messages, get_errors (deprecated), get_stack_trace, get_performance, screenshot_game, screenshot_editor, set_viewport_2d'),
+      .enum(['get_state', 'get_selection', 'select', 'run', 'stop', 'get_log_messages', 'get_stack_trace', 'screenshot_game', 'screenshot_editor', 'set_viewport_2d'])
+      .describe('Action: get_state, get_selection, select, run, stop, get_log_messages, get_stack_trace, screenshot_game, screenshot_editor, set_viewport_2d'),
     node_path: z
       .string()
       .optional()
@@ -49,17 +49,13 @@ const EditorSchema = z
     clear: z
       .boolean()
       .optional()
-      .describe('Clear buffer after reading (get_debug_output, get_log_messages, get_errors)'),
+      .describe('Clear buffer after reading (get_log_messages only)'),
     limit: z
       .number()
       .int()
       .positive()
       .optional()
       .describe('Maximum number of messages to return (get_log_messages only, default: 50)'),
-    source: z
-      .enum(['editor', 'game'])
-      .optional()
-      .describe('Output source: "editor" for editor panel messages (script errors, loading failures), "game" for running game output. If omitted, returns game output when running, else editor output.'),
     viewport: z
       .enum(['2d', '3d'])
       .optional()
@@ -118,7 +114,7 @@ interface LogMessagesResponse {
 export const editor = defineTool({
   name: 'editor',
   description:
-    'Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, get debug output (deprecated - use minimal-godot-mcp)/errors/stack traces, get performance metrics, control 2D viewport',
+    'Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport',
   schema: EditorSchema,
   async execute(args: EditorArgs, { godot }) {
     switch (args.action) {
@@ -160,19 +156,6 @@ export const editor = defineTool({
         return 'Stopped project';
       }
 
-      case 'get_debug_output': {
-        const deprecation = '[DEPRECATED] get_debug_output is deprecated. Use minimal-godot-mcp\'s get_console_output tool instead (no addon required).\n\n';
-        const result = await godot.sendCommand<{ output: string; source: string }>(
-          'get_debug_output',
-          { clear: args.clear ?? false, source: args.source }
-        );
-        if (!result.output || result.output.trim() === '') {
-          return `${deprecation}No ${result.source ?? 'debug'} output`;
-        }
-        const label = result.source === 'editor' ? 'Editor' : result.source === 'game' ? 'Game' : 'Debug';
-        return `${deprecation}${label} output:\n\`\`\`\n${result.output}\n\`\`\``;
-      }
-
       case 'get_log_messages': {
         const result = await godot.sendCommand<LogMessagesResponse>(
           'get_log_messages',
@@ -187,23 +170,6 @@ export const editor = defineTool({
         return JSON.stringify(result, null, 2);
       }
 
-      case 'get_errors': {
-        const result = await godot.sendCommand<LogMessagesResponse>(
-          'get_log_messages',
-          {
-            clear: args.clear ?? false,
-            limit: args.limit ?? 50,
-          }
-        );
-        if (result.returned_count === 0) {
-          return 'No errors';
-        }
-        return JSON.stringify({
-          error_count: result.returned_count,
-          errors: result.messages,
-        }, null, 2);
-      }
-
       case 'get_stack_trace': {
         const result = await godot.sendCommand<{
           error: string;
@@ -216,12 +182,6 @@ export const editor = defineTool({
           return 'No stack trace available';
         }
         return JSON.stringify(result, null, 2);
-      }
-
-      case 'get_performance': {
-        const deprecation = '[DEPRECATED] get_performance is deprecated. Use profiler > snapshot instead for all 59 monitors + render timing.\n\n';
-        const result = await godot.sendCommand<Record<string, number>>('get_performance_metrics');
-        return deprecation + JSON.stringify(result, null, 2);
       }
 
       case 'screenshot_game': {


### PR DESCRIPTION
Closes #184. First link in the modernization chain (tracking: #192).

## What

Removes three already-deprecated `editor` actions that were still in the schema, costing tokens and inviting models to call the wrong thing. Each had a different, already-existing replacement, and no capability is lost:

| Removed action | Replacement | Still in godot-mcp? |
|---|---|---|
| `get_debug_output` | minimal-godot-mcp's `get_console_output` (console output is the piece being handed off) | no |
| `get_errors` | the editor tool's own `get_log_messages` (kept) | yes |
| `get_performance` | the `profiler` tool's `snapshot` action | yes |

Note on performance metrics specifically: they are **not** going away. `editor:get_performance` and `profiler:snapshot` call the exact same Godot command (`get_performance_metrics`), so `snapshot` returns the same data, and the `profiler` tool adds the richer time-series flow (`start`/`stop`/`get_data` with spike detection) on top. This change just collapses a duplicate door into the better-equipped one. Only `get_debug_output` (console output) is being handed to minimal-godot-mcp.

Also drops the now-orphaned `source` param (only `get_debug_output` used it). `get_log_messages` and `get_stack_trace` are untouched. The addon's wire command handlers are left in place; only the server-facing tool surface changes.

## Breaking

The `editor` tool no longer accepts `get_debug_output`, `get_errors`, or `get_performance`. Commit is marked breaking so release-please bumps accordingly.

## Verification

`npm run build` clean, `npm test` green (180 passed), `npm run generate-docs` regenerated `docs/tools/editor.md` with the actions gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)