### PR TITLE
feat: namespace all tools under godot_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ They don't overlap much, and they don't conflict. Run them side by side for the 
 
 - [Installation Guide](INSTALL.md) - MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more
 - [Claude Code Setup Guide](docs/claude-code-setup.md) - CLAUDE.md template for Godot projects
-- [Tools Reference](docs/tools/README.md) - All 11 tools with full API docs
+- [Tools Reference](docs/tools/README.md) - All 12 tools with full API docs
 - [Resources Reference](docs/resources.md) - MCP resources for reading project data
 - [Contributing](CONTRIBUTING.md) - Dev setup, adding tools, release process
 - [Changelog](server/CHANGELOG.md) - Release history
@@ -76,7 +76,7 @@ If you run the server manually via CLI (for example: `npx -y @satelliteoflove/go
 3) Call a tool
 
 ```json
-{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"editor","arguments":{"action":"get_state"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"godot_editor","arguments":{"action":"get_state"}}}
 ```
 
 4) Response

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) server for Godot Engine integration.
 
 ## Overview
 
-This server provides **11 tools** and **3 resources** for AI-assisted Godot development.
+This server provides **12 tools** and **3 resources** for AI-assisted Godot development.
 
 ## Quick Links
 
@@ -26,6 +26,7 @@ This server provides **11 tools** and **3 resources** for AI-assisted Godot deve
 | [Scene3D](tools/scene3d.md) | 1 | 3D spatial information and bounding box tools |
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |
 | [Input](tools/input.md) | 1 | Input injection for testing running games (action-based, no mouse/coordinates yet) |
+| [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
 
 ## Installation
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -6,50 +6,50 @@ This documentation is auto-generated from the tool definitions.
 
 Scene management tools
 
-- `scene` - Manage scenes: open, save, or create scenes
+- `godot_scene` - Manage scenes: open, save, or create scenes
 
 ## [Node](node.md)
 
 Node manipulation and script attachment tools
 
-- `node` - Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
+- `godot_node` - Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
 
 ## [Editor](editor.md)
 
 Editor control, debugging, and screenshot tools
 
-- `editor` - Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
+- `godot_editor` - Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
 
 ## [Project](project.md)
 
 Project information tools
 
-- `project` - Get project information and settings
+- `godot_project` - Get project information and settings
 
 ## [Animation](animation.md)
 
 Animation query, playback, and editing tools
 
-- `animation` - Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
+- `godot_animation` - Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
 
 ## [TileMapLayer/GridMap](tilemap.md)
 
 TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprecated TileMap)
 
-- `tilemap` - Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates
-- `gridmap` - Query and edit GridMap data: list gridmaps, get info, get/set cells
+- `godot_tilemap` - Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates
+- `godot_gridmap` - Query and edit GridMap data: list gridmaps, get info, get/set cells
 
 ## [Resource](resource.md)
 
 Resource inspection tools for SpriteFrames, TileSet, Materials, etc.
 
-- `resource` - Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.
+- `godot_resource` - Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.
 
 ## [Scene3D](scene3d.md)
 
 3D spatial information and bounding box tools
 
-- `scene3d` - Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
+- `godot_scene3d` - Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
 
 ## [Documentation](docs.md)
 
@@ -61,5 +61,11 @@ Fetch Godot Engine documentation with smart extraction
 
 Input injection for testing running games (action-based, no mouse/coordinates yet)
 
-- `input` - Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.
+- `godot_input` - Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.
+
+## [Profiler](profiler.md)
+
+Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections
+
+- `godot_profiler` - Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections
 

--- a/docs/tools/animation.md
+++ b/docs/tools/animation.md
@@ -4,11 +4,11 @@ Animation query, playback, and editing tools
 
 ## Tools
 
-- [animation](#animation)
+- [godot_animation](#godot_animation)
 
 ---
 
-## animation
+## godot_animation
 
 Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
 

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -4,11 +4,11 @@ Editor control, debugging, and screenshot tools
 
 ## Tools
 
-- [editor](#editor)
+- [godot_editor](#godot_editor)
 
 ---
 
-## editor
+## godot_editor
 
 Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
 

--- a/docs/tools/input.md
+++ b/docs/tools/input.md
@@ -4,11 +4,11 @@ Input injection for testing running games (action-based, no mouse/coordinates ye
 
 ## Tools
 
-- [input](#input)
+- [godot_input](#godot_input)
 
 ---
 
-## input
+## godot_input
 
 Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.
 

--- a/docs/tools/node.md
+++ b/docs/tools/node.md
@@ -4,11 +4,11 @@ Node manipulation and script attachment tools
 
 ## Tools
 
-- [node](#node)
+- [godot_node](#godot_node)
 
 ---
 
-## node
+## godot_node
 
 Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
 

--- a/docs/tools/profiler.md
+++ b/docs/tools/profiler.md
@@ -1,0 +1,62 @@
+# Profiler Tools
+
+Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections
+
+## Tools
+
+- [godot_profiler](#godot_profiler)
+
+---
+
+## godot_profiler
+
+Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `snapshot`, `start`, `stop`, `get_data`, `get_active_processes`, `get_signal_connections` | Yes | Action: snapshot (full perf snapshot), start/stop/get_data (time series profiling), get_active_processes, get_signal_connections |
+| `node_path` | string | No | Node path for get_signal_connections (optional, defaults to scene root) |
+
+### Actions
+
+#### `snapshot`
+
+#### `start`
+
+#### `stop`
+
+#### `get_data`
+
+#### `get_active_processes`
+
+#### `get_signal_connections`
+
+### Examples
+
+```json
+// snapshot
+{
+  "action": "snapshot"
+}
+```
+
+```json
+// start
+{
+  "action": "start"
+}
+```
+
+```json
+// stop
+{
+  "action": "stop"
+}
+```
+
+*3 more actions available: `get_data`, `get_active_processes`, `get_signal_connections`*
+
+---
+

--- a/docs/tools/project.md
+++ b/docs/tools/project.md
@@ -4,11 +4,11 @@ Project information tools
 
 ## Tools
 
-- [project](#project)
+- [godot_project](#godot_project)
 
 ---
 
-## project
+## godot_project
 
 Get project information and settings
 

--- a/docs/tools/resource.md
+++ b/docs/tools/resource.md
@@ -4,11 +4,11 @@ Resource inspection tools for SpriteFrames, TileSet, Materials, etc.
 
 ## Tools
 
-- [resource](#resource)
+- [godot_resource](#godot_resource)
 
 ---
 
-## resource
+## godot_resource
 
 Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.
 

--- a/docs/tools/scene.md
+++ b/docs/tools/scene.md
@@ -4,11 +4,11 @@ Scene management tools
 
 ## Tools
 
-- [scene](#scene)
+- [godot_scene](#godot_scene)
 
 ---
 
-## scene
+## godot_scene
 
 Manage scenes: open, save, or create scenes
 

--- a/docs/tools/scene3d.md
+++ b/docs/tools/scene3d.md
@@ -4,11 +4,11 @@
 
 ## Tools
 
-- [scene3d](#scene3d)
+- [godot_scene3d](#godot_scene3d)
 
 ---
 
-## scene3d
+## godot_scene3d
 
 Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
 

--- a/docs/tools/tilemap.md
+++ b/docs/tools/tilemap.md
@@ -4,12 +4,12 @@ TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprec
 
 ## Tools
 
-- [tilemap](#tilemap)
-- [gridmap](#gridmap)
+- [godot_tilemap](#godot_tilemap)
+- [godot_gridmap](#godot_gridmap)
 
 ---
 
-## tilemap
+## godot_tilemap
 
 Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates
 
@@ -90,7 +90,7 @@ Parameters: `coords`
 
 ---
 
-## gridmap
+## godot_gridmap
 
 Query and edit GridMap data: list gridmaps, get info, get/set cells
 

--- a/server/README.md
+++ b/server/README.md
@@ -44,7 +44,7 @@ They don't overlap much, and they don't conflict. Run them side by side for the 
 
 - [Installation Guide](INSTALL.md) - MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more
 - [Claude Code Setup Guide](../docs/claude-code-setup.md) - CLAUDE.md template for Godot projects
-- [Tools Reference](../docs/tools/README.md) - All 11 tools with full API docs
+- [Tools Reference](../docs/tools/README.md) - All 12 tools with full API docs
 - [Resources Reference](../docs/resources.md) - MCP resources for reading project data
 - [Contributing](../CONTRIBUTING.md) - Dev setup, adding tools, release process
 - [Changelog](CHANGELOG.md) - Release history
@@ -76,7 +76,7 @@ If you run the server manually via CLI (for example: `npx -y @satelliteoflove/go
 3) Call a tool
 
 ```json
-{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"editor","arguments":{"action":"get_state"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"godot_editor","arguments":{"action":"get_state"}}}
 ```
 
 4) Response

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -12,6 +12,7 @@ import { resourceTools } from '../src/tools/resource.js';
 import { scene3dTools } from '../src/tools/scene3d.js';
 import { docsTools } from '../src/tools/docs.js';
 import { inputTools } from '../src/tools/input.js';
+import { profilerTools } from '../src/tools/profiler.js';
 import { sceneResources } from '../src/resources/scene.js';
 import { scriptResources } from '../src/resources/script.js';
 import { toInputSchema } from '../src/core/schema.js';
@@ -41,6 +42,7 @@ const categories: ToolCategory[] = [
   { name: 'Scene3D', filename: 'scene3d', description: '3D spatial information and bounding box tools', tools: scene3dTools },
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },
   { name: 'Input', filename: 'input', description: 'Input injection for testing running games (action-based, no mouse/coordinates yet)', tools: inputTools },
+  { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
 ];
 
 const allResources: ResourceDefinition[] = [...sceneResources, ...scriptResources];

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -109,7 +109,7 @@ const AnimationSchema = z
 type AnimationArgs = z.infer<typeof AnimationSchema>;
 
 export const animation = defineTool({
-  name: 'animation',
+  name: 'godot_animation',
   description:
     'Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe',
   schema: AnimationSchema,

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -112,7 +112,7 @@ interface LogMessagesResponse {
 }
 
 export const editor = defineTool({
-  name: 'editor',
+  name: 'godot_editor',
   description:
     'Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport',
   schema: EditorSchema,

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -57,7 +57,7 @@ interface InputMapAction {
 }
 
 export const input = defineTool({
-  name: 'input',
+  name: 'godot_input',
   description:
     'Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.',
   schema: InputSchema,

--- a/server/src/tools/node.ts
+++ b/server/src/tools/node.ts
@@ -107,7 +107,7 @@ const NodeSchema = z
 type NodeArgs = z.infer<typeof NodeSchema>;
 
 export const node = defineTool({
-  name: 'node',
+  name: 'godot_node',
   description:
     'Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals',
   schema: NodeSchema,

--- a/server/src/tools/profiler.ts
+++ b/server/src/tools/profiler.ts
@@ -194,7 +194,7 @@ const ProfilerSchema = z
 type ProfilerArgs = z.infer<typeof ProfilerSchema>;
 
 export const profiler = defineTool({
-  name: 'profiler',
+  name: 'godot_profiler',
   description:
     'Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections',
   schema: ProfilerSchema,

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -20,7 +20,7 @@ const ProjectSchema = z.object({
 type ProjectArgs = z.infer<typeof ProjectSchema>;
 
 export const project = defineTool({
-  name: 'project',
+  name: 'godot_project',
   description: 'Get project information and settings',
   schema: ProjectSchema,
   async execute(args: ProjectArgs, { godot }) {

--- a/server/src/tools/resource.ts
+++ b/server/src/tools/resource.ts
@@ -44,7 +44,7 @@ const ResourceSchema = z
 type ResourceArgs = z.infer<typeof ResourceSchema>;
 
 export const resource = defineTool({
-  name: 'resource',
+  name: 'godot_resource',
   description:
     'Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.',
   schema: ResourceSchema,

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -42,7 +42,7 @@ const SceneSchema = z
 type SceneArgs = z.infer<typeof SceneSchema>;
 
 export const scene = defineTool({
-  name: 'scene',
+  name: 'godot_scene',
   description: 'Manage scenes: open, save, or create scenes',
   schema: SceneSchema,
   async execute(args: SceneArgs, { godot }) {

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -92,7 +92,7 @@ function formatAABB(aabb: AABB): string {
 }
 
 export const scene3d = defineTool({
-  name: 'scene3d',
+  name: 'godot_scene3d',
   description:
     'Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.',
   schema: Scene3DSchema,

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -86,7 +86,7 @@ const TilemapSchema = z
 type TilemapArgs = z.infer<typeof TilemapSchema>;
 
 export const tilemap = defineTool({
-  name: 'tilemap',
+  name: 'godot_tilemap',
   description:
     'Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates',
   schema: TilemapSchema,
@@ -222,7 +222,7 @@ const GridmapSchema = z
 type GridmapArgs = z.infer<typeof GridmapSchema>;
 
 export const gridmap = defineTool({
-  name: 'gridmap',
+  name: 'godot_gridmap',
   description:
     'Query and edit GridMap data: list gridmaps, get info, get/set cells',
   schema: GridmapSchema,


### PR DESCRIPTION
Closes #185. Tier 1 of the modernization chain (tracking: #192).

## What

Renames every MCP tool with a `godot_` prefix so names are unambiguous when this server runs alongside others (the normal case now). `godot_docs` was already prefixed.

| Before | After |
|---|---|
| `scene` | `godot_scene` |
| `node` | `godot_node` |
| `editor` | `godot_editor` |
| `project` | `godot_project` |
| `animation` | `godot_animation` |
| `tilemap` | `godot_tilemap` |
| `gridmap` | `godot_gridmap` |
| `resource` | `godot_resource` |
| `scene3d` | `godot_scene3d` |
| `input` | `godot_input` |
| `profiler` | `godot_profiler` |

Only the MCP tool name strings change; the Godot-side command names sent over the WebSocket are untouched.

## Collision gate (the hard requirement)

Verified against minimal-godot-mcp's actual tool source: `get_diagnostics`, `scan_workspace_diagnostics`, `get_console_output`, `clear_console_output`. No prefix, all domain-specific, **zero collision** with the `godot_` scheme.

## Bonus: fixed the tool count at its root

The docs generator never imported `profilerTools`, so it only ever documented 11 of the 12 registered tools, which is where the stale "All 11 tools" README line came from. Added the profiler to the generator, so all 12 are now documented (`docs/tools/profiler.md` is new) and the count is derived correctly instead of hard-coded.

## Versioning (intentional)

This is technically a rename, but it is released as a **minor bump, not a major**. It lands right after 3.0.0 and adoption is early, so we are not inflating the major version for back-to-back renames. Migration heads-up for users: anything referencing tools by name (scripts, CLAUDE.md templates) should switch to the `godot_` prefix.

## Verification

`npm run build` clean, `npm test` green (180 passed), `npm run generate-docs` regenerated all tool docs (now 12 tools). Tests reference tools by import, not by name string, so none needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)