### PR TITLE
feat: add MCP tool annotations (title + readOnly/destructive/openWorld hints)

### DIFF
--- a/server/src/__tests__/core/annotations.test.ts
+++ b/server/src/__tests__/core/annotations.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { registry } from '../../core/registry.js';
+import { registerAllTools } from '../../tools/index.js';
+
+describe('tool annotations passthrough', () => {
+  beforeAll(() => {
+    registerAllTools();
+  });
+
+  const byName = () => new Map(registry.getToolList().map((t) => [t.name, t]));
+
+  it('every registered tool exposes a title annotation', () => {
+    for (const tool of registry.getToolList()) {
+      expect(tool.annotations?.title, tool.name).toBeTruthy();
+    }
+  });
+
+  it('pure-read tools are marked readOnlyHint true', () => {
+    const map = byName();
+    const readOnly = ['godot_docs', 'godot_scene3d', 'godot_resource', 'godot_profiler', 'godot_project'];
+    for (const name of readOnly) {
+      expect(map.get(name)?.annotations?.readOnlyHint, name).toBe(true);
+    }
+  });
+
+  it('write-capable tools are not read-only and flag destructive where apt', () => {
+    const map = byName();
+    expect(map.get('godot_node')?.annotations?.readOnlyHint).toBe(false);
+    expect(map.get('godot_node')?.annotations?.destructiveHint).toBe(true);
+    expect(map.get('godot_tilemap')?.annotations?.destructiveHint).toBe(true);
+  });
+
+  it('only the docs tool reaches the open world', () => {
+    const map = byName();
+    expect(map.get('godot_docs')?.annotations?.openWorldHint).toBe(true);
+    expect(map.get('godot_node')?.annotations?.openWorldHint).toBe(false);
+  });
+});

--- a/server/src/core/define-tool.ts
+++ b/server/src/core/define-tool.ts
@@ -1,9 +1,10 @@
 import type { z } from 'zod';
-import type { ToolDefinition, ToolContext, ToolResult } from './types.js';
+import type { ToolDefinition, ToolContext, ToolResult, ToolAnnotations } from './types.js';
 
 export function defineTool<TSchema extends z.ZodType>(config: {
   name: string;
   description: string;
+  annotations?: ToolAnnotations;
   schema: TSchema;
   execute: (args: z.infer<TSchema>, ctx: ToolContext) => Promise<string | ToolResult>;
 }): ToolDefinition<TSchema> {

--- a/server/src/core/registry.ts
+++ b/server/src/core/registry.ts
@@ -1,4 +1,4 @@
-import type { AnyToolDefinition, ResourceDefinition, ToolContext, ToolResult } from './types.js';
+import type { AnyToolDefinition, ResourceDefinition, ToolAnnotations, ToolContext, ToolResult } from './types.js';
 import { toInputSchema } from './schema.js';
 import {
   formatError,
@@ -34,11 +34,17 @@ class ToolRegistry {
     resources.forEach((resource) => this.registerResource(resource));
   }
 
-  getToolList(): Array<{ name: string; description: string; inputSchema: object }> {
+  getToolList(): Array<{
+    name: string;
+    description: string;
+    inputSchema: object;
+    annotations?: ToolAnnotations;
+  }> {
     return Array.from(this.tools.values()).map((tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: toInputSchema(tool.schema),
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
     }));
   }
 

--- a/server/src/core/types.ts
+++ b/server/src/core/types.ts
@@ -9,9 +9,20 @@ export type TextContent = { type: 'text'; text: string };
 export type ImageContent = { type: 'image'; data: string; mimeType: string };
 export type ToolResult = TextContent | ImageContent;
 
+// MCP tool annotations: advisory hints clients use to label tools and decide
+// auto-approval. See the MCP spec's ToolAnnotations.
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
 export interface ToolDefinition<TSchema extends z.ZodType = z.ZodType> {
   name: string;
   description: string;
+  annotations?: ToolAnnotations;
   schema: TSchema;
   execute: (args: z.infer<TSchema>, ctx: ToolContext) => Promise<string | ToolResult>;
 }
@@ -19,6 +30,7 @@ export interface ToolDefinition<TSchema extends z.ZodType = z.ZodType> {
 export interface AnyToolDefinition {
   name: string;
   description: string;
+  annotations?: ToolAnnotations;
   schema: z.ZodType;
   execute: (args: unknown, ctx: ToolContext) => Promise<string | ToolResult>;
 }

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -110,6 +110,7 @@ type AnimationArgs = z.infer<typeof AnimationSchema>;
 
 export const animation = defineTool({
   name: 'godot_animation',
+  annotations: { title: 'Animation', readOnlyHint: false, destructiveHint: true, openWorldHint: false },
   description:
     'Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe',
   schema: AnimationSchema,

--- a/server/src/tools/docs.ts
+++ b/server/src/tools/docs.ts
@@ -144,6 +144,7 @@ function extractSection(markdown: string, section: string): string {
 
 export const docs = defineTool({
   name: 'godot_docs',
+  annotations: { title: 'Godot Docs', readOnlyHint: true, openWorldHint: true },
   description:
     'Fetch Godot Engine documentation. Use fetch_class for class references (e.g. CharacterBody2D), fetch_page for tutorials/guides. Auto-detects Godot version from editor connection. Returns clean markdown.',
   schema: DocsSchema,

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -113,6 +113,7 @@ interface LogMessagesResponse {
 
 export const editor = defineTool({
   name: 'godot_editor',
+  annotations: { title: 'Editor Control', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
     'Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport',
   schema: EditorSchema,

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -58,6 +58,7 @@ interface InputMapAction {
 
 export const input = defineTool({
   name: 'godot_input',
+  annotations: { title: 'Input Injection', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
     'Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.',
   schema: InputSchema,

--- a/server/src/tools/node.ts
+++ b/server/src/tools/node.ts
@@ -108,6 +108,7 @@ type NodeArgs = z.infer<typeof NodeSchema>;
 
 export const node = defineTool({
   name: 'godot_node',
+  annotations: { title: 'Node', readOnlyHint: false, destructiveHint: true, openWorldHint: false },
   description:
     'Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals',
   schema: NodeSchema,

--- a/server/src/tools/profiler.ts
+++ b/server/src/tools/profiler.ts
@@ -195,6 +195,7 @@ type ProfilerArgs = z.infer<typeof ProfilerSchema>;
 
 export const profiler = defineTool({
   name: 'godot_profiler',
+  annotations: { title: 'Profiler', readOnlyHint: true, openWorldHint: false },
   description:
     'Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections',
   schema: ProfilerSchema,

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -21,6 +21,7 @@ type ProjectArgs = z.infer<typeof ProjectSchema>;
 
 export const project = defineTool({
   name: 'godot_project',
+  annotations: { title: 'Project Info', readOnlyHint: true, openWorldHint: false },
   description: 'Get project information and settings',
   schema: ProjectSchema,
   async execute(args: ProjectArgs, { godot }) {

--- a/server/src/tools/resource.ts
+++ b/server/src/tools/resource.ts
@@ -45,6 +45,7 @@ type ResourceArgs = z.infer<typeof ResourceSchema>;
 
 export const resource = defineTool({
   name: 'godot_resource',
+  annotations: { title: 'Resource Inspector', readOnlyHint: true, openWorldHint: false },
   description:
     'Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.',
   schema: ResourceSchema,

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -43,6 +43,7 @@ type SceneArgs = z.infer<typeof SceneSchema>;
 
 export const scene = defineTool({
   name: 'godot_scene',
+  annotations: { title: 'Scene', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description: 'Manage scenes: open, save, or create scenes',
   schema: SceneSchema,
   async execute(args: SceneArgs, { godot }) {

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -93,6 +93,7 @@ function formatAABB(aabb: AABB): string {
 
 export const scene3d = defineTool({
   name: 'godot_scene3d',
+  annotations: { title: '3D Scene Info', readOnlyHint: true, openWorldHint: false },
   description:
     'Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.',
   schema: Scene3DSchema,

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -87,6 +87,7 @@ type TilemapArgs = z.infer<typeof TilemapSchema>;
 
 export const tilemap = defineTool({
   name: 'godot_tilemap',
+  annotations: { title: 'TileMapLayer', readOnlyHint: false, destructiveHint: true, openWorldHint: false },
   description:
     'Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates',
   schema: TilemapSchema,
@@ -223,6 +224,7 @@ type GridmapArgs = z.infer<typeof GridmapSchema>;
 
 export const gridmap = defineTool({
   name: 'godot_gridmap',
+  annotations: { title: 'GridMap', readOnlyHint: false, destructiveHint: true, openWorldHint: false },
   description:
     'Query and edit GridMap data: list gridmaps, get info, get/set cells',
   schema: GridmapSchema,


### PR DESCRIPTION
Closes #186. Tier 1 of the modernization chain (tracking: #192).

## What

Wires optional `annotations` through `defineTool` -> `ToolDefinition` -> `registry.getToolList`, so they show up in `tools/list`. These are advisory hints clients use to label tools and decide auto-approval; the win is for non-Claude clients (VS Code, Cursor, etc.) that can auto-approve safe reads.

## Annotations applied

| Tool | readOnly | destructive | openWorld | title |
|---|---|---|---|---|
| `godot_docs` | yes | - | **yes** | Godot Docs |
| `godot_scene3d` | yes | - | no | 3D Scene Info |
| `godot_resource` | yes | - | no | Resource Inspector |
| `godot_profiler` | yes | - | no | Profiler |
| `godot_project` | yes | - | no | Project Info |
| `godot_scene` | no | no | no | Scene |
| `godot_editor` | no | no | no | Editor Control |
| `godot_input` | no | no | no | Input Injection |
| `godot_node` | no | **yes** | no | Node |
| `godot_animation` | no | **yes** | no | Animation |
| `godot_tilemap` | no | **yes** | no | TileMapLayer |
| `godot_gridmap` | no | **yes** | no | GridMap |

`godot_docs` is the only `openWorldHint: true` tool since it fetches from the web; everything else operates on the local project.

## The granularity caveat (worth noting)

Annotations are per-*tool*, not per-action. The mixed read/write tools (`node`, `editor`, etc.) contain both read and write actions, so they can't be marked read-only even though many of their actions are. They carry `destructiveHint` where deletion is possible and `false` where not. This limitation is itself a future argument for splitting read-heavy tools from write-heavy ones.

## Verification

`npm run build` clean, `npm test` green (184 passed, +4 new in `__tests__/core/annotations.test.ts` asserting the passthrough). Additive and non-breaking -> minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)