### PR TITLE
feat: model tool inputs as discriminated unions per action

### DIFF
--- a/docs/tools/animation.md
+++ b/docs/tools/animation.md
@@ -12,102 +12,164 @@ Animation query, playback, and editing tools
 
 Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `list_players`, `get_info`, `get_details`, `get_keyframes`, `play`, `stop`, `seek`, `create`, `delete`, `update_props`, `add_track`, `remove_track`, `add_keyframe`, `remove_keyframe`, `update_keyframe` | Yes | Action: list_players, get_info, get_details, get_keyframes (query), play, stop, seek (playback), create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe (edit) |
-| `root_path` | string | list_players | Starting node path |
-| `node_path` | string | No | Path to AnimationPlayer (required except list_players) |
-| `animation_name` | string | No | Animation name |
-| `track_index` | number | No | Track index |
-| `custom_blend` | number | No | Custom blend time, -1 for default (play) |
-| `custom_speed` | number | No | Playback speed, 1.0 default (play) |
-| `from_end` | boolean | No | Play from end for reverse (play) |
-| `keep_state` | boolean | No | Keep current animation state (stop) |
-| `seconds` | number | No | Position to seek to (seek) |
-| `update` | boolean | No | Update node immediately, default true (seek) |
-| `library_name` | string | create, delete | Library name |
-| `length` | number | create, update_props | Animation length in seconds |
-| `loop_mode` | `none`, `linear`, `pingpong` | create, update_props | Loop mode: none, linear, pingpong |
-| `step` | number | create, update_props | Step value for keyframe snapping |
-| `track_type` | `value`, `position_3d`, `rotation_3d`, `scale_3d`, `blend_shape`, `method`, `bezier`, `audio`, `animation` | No | Type of track (add_track) |
-| `track_path` | string | No | Node path and property, e.g. "Sprite2D:frame" (add_track) |
-| `insert_at` | number | No | Track index to insert at, -1 for end (add_track) |
-| `time` | number | add_keyframe, update_keyframe | Keyframe time in seconds |
-| `value` | unknown | add_keyframe, update_keyframe | Keyframe value |
-| `transition` | number | add_keyframe, update_keyframe | Transition curve, 1.0 = linear |
-| `method_name` | string | No | Method name for method tracks (add_keyframe) |
-| `args` | array | No | Method arguments (add_keyframe) |
-| `keyframe_index` | number | remove_keyframe, update_keyframe | Keyframe index |
-
 ### Actions
 
 #### `list_players`
 
-Parameters: `root_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Starting node path (defaults to scene root) |
 
 #### `get_info`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+
 #### `get_details`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
 
 #### `get_keyframes`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+
 #### `play`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `custom_blend` | number | No | Custom blend time, -1 for default |
+| `custom_speed` | number | No | Playback speed, 1.0 default |
+| `from_end` | boolean | No | Play from end for reverse |
 
 #### `stop`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `keep_state` | boolean | No | Keep current animation state |
+
 #### `seek`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `seconds` | number | Yes | Position to seek to |
+| `update` | boolean | No | Update node immediately, default true |
 
 #### `create`
 
-Parameters: `library_name`, `length`, `loop_mode`, `step`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `library_name` | string | No | Library name |
+| `length` | number | No | Animation length in seconds |
+| `loop_mode` | `none`, `linear`, `pingpong` | No | Loop mode: none, linear, pingpong |
+| `step` | number | No | Step value for keyframe snapping |
 
 #### `delete`
 
-Parameters: `library_name`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `library_name` | string | No | Library name |
 
 #### `update_props`
 
-Parameters: `length`, `loop_mode`, `step`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `length` | number | No | Animation length in seconds |
+| `loop_mode` | `none`, `linear`, `pingpong` | No | Loop mode: none, linear, pingpong |
+| `step` | number | No | Step value for keyframe snapping |
 
 #### `add_track`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_type` | `value`, `position_3d`, `rotation_3d`, `scale_3d`, `blend_shape`, `method`, `bezier`, `audio`, `animation` | Yes | Type of track |
+| `track_path` | string | Yes | Node path and property, e.g. "Sprite2D:frame" |
+| `insert_at` | number | No | Track index to insert at, -1 for end |
+
 #### `remove_track`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
 
 #### `add_keyframe`
 
-Parameters: `time`, `value`, `transition`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+| `time` | number | Yes | Keyframe time in seconds |
+| `value` | unknown | No | Keyframe value |
+| `transition` | number | No | Transition curve, 1.0 = linear |
+| `method_name` | string | No | Method name for method tracks |
+| `args` | array | No | Method arguments |
 
 #### `remove_keyframe`
 
-Parameters: `keyframe_index`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+| `keyframe_index` | number | Yes | Keyframe index |
 
 #### `update_keyframe`
 
-Parameters: `time`, `value`, `transition`, `keyframe_index`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+| `keyframe_index` | number | Yes | Keyframe index |
+| `time` | number | No | Keyframe time in seconds |
+| `value` | unknown | No | Keyframe value |
+| `transition` | number | No | Transition curve, 1.0 = linear |
 
 ### Examples
 
 ```json
 // list_players
 {
-  "action": "list_players",
-  "root_path": "/root/Main"
+  "action": "list_players"
 }
 ```
 
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // get_details
 {
-  "action": "get_details"
+  "action": "get_details",
+  "node_path": "/root/Main/Player",
+  "animation_name": "idle"
 }
 ```
 

--- a/docs/tools/docs.md
+++ b/docs/tools/docs.md
@@ -12,25 +12,23 @@ Fetch Godot Engine documentation with smart extraction
 
 Fetch Godot Engine documentation. Use fetch_class for class references (e.g. CharacterBody2D), fetch_page for tutorials/guides. Auto-detects Godot version from editor connection. Returns clean markdown.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `fetch_class`, `fetch_page` | Yes | Action: fetch_class (get class reference by name), fetch_page (get any docs page by path) |
-| `class_name` | string | fetch_class | Class name to fetch, e.g. "CharacterBody2D" |
-| `path` | string | fetch_page | Documentation path, e.g. "/tutorials/2d/2d_movement.html" |
-| `version` | `stable`, `latest`, `4.5`, `4.4`, `4.3`, `4.2` | No | Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable" |
-| `section` | `full`, `description`, `properties`, `methods`, `signals` | Yes | Which section to return (default: full). Use specific sections to reduce token usage. |
-
 ### Actions
 
 #### `fetch_class`
 
-Parameters: `class_name`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `class_name` | string | Yes | Class name to fetch, e.g. "CharacterBody2D" |
+| `version` | `stable`, `latest`, `4.5`, `4.4`, `4.3`, `4.2` | No | Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable" |
+| `section` | `full`, `description`, `properties`, `methods`, `signals` | Yes | Which section to return (default: full). Use specific sections to reduce token usage. |
 
 #### `fetch_page`
 
-Parameters: `path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Documentation path, e.g. "/tutorials/2d/2d_movement.html" |
+| `version` | `stable`, `latest`, `4.5`, `4.4`, `4.3`, `4.2` | No | Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable" |
+| `section` | `full`, `description`, `properties`, `methods`, `signals` | Yes | Which section to return (default: full). Use specific sections to reduce token usage. |
 
 ### Examples
 

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -12,52 +12,63 @@ Editor control, debugging, and screenshot tools
 
 Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes | Action: get_state, get_selection, select, run, stop, get_log_messages, get_stack_trace, screenshot_game, screenshot_editor, set_viewport_2d |
-| `node_path` | string | select | Path to node |
-| `scene_path` | string | No | Scene to run (run only, optional) |
-| `clear` | boolean | get_log_messages | Clear buffer after reading |
-| `limit` | integer | No | Maximum number of messages to return (get_log_messages only, default: 50) |
-| `viewport` | `2d`, `3d` | screenshot_editor | Which editor viewport to capture |
-| `max_width` | number | screenshot_game, screenshot_editor | Maximum width in pixels for screenshot |
-| `center_x` | number | set_viewport_2d | X coordinate to center the 2D viewport on |
-| `center_y` | number | set_viewport_2d | Y coordinate to center the 2D viewport on |
-| `zoom` | number | set_viewport_2d | Zoom level for 2D viewport, e.g. 1.0 = 100%, 2.0 = 200% |
-
 ### Actions
 
 #### `get_state`
 
+*No parameters.*
+
 #### `get_selection`
+
+*No parameters.*
 
 #### `select`
 
-Parameters: `node_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to node to select |
 
 #### `run`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | No | Scene to run (optional, defaults to main scene) |
+
 #### `stop`
+
+*No parameters.*
 
 #### `get_log_messages`
 
-Parameters: `clear`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `clear` | boolean | No | Clear buffer after reading |
+| `limit` | integer | No | Maximum number of messages to return (default: 50) |
 
 #### `get_stack_trace`
 
+*No parameters.*
+
 #### `screenshot_game`
 
-Parameters: `max_width`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `max_width` | number | No | Maximum width in pixels for the screenshot |
 
 #### `screenshot_editor`
 
-Parameters: `viewport`*, `max_width`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `viewport` | `2d`, `3d` | No | Which editor viewport to capture |
+| `max_width` | number | No | Maximum width in pixels for the screenshot |
 
 #### `set_viewport_2d`
 
-Parameters: `center_x`*, `center_y`*, `zoom`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `center_x` | number | No | X coordinate to center the 2D viewport on |
+| `center_y` | number | No | Y coordinate to center the 2D viewport on |
+| `zoom` | number | No | Zoom level, e.g. 1.0 = 100%, 2.0 = 200% |
 
 ### Examples
 

--- a/docs/tools/input.md
+++ b/docs/tools/input.md
@@ -12,36 +12,32 @@ Input injection for testing running games (action-based, no mouse/coordinates ye
 
 Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_map`, `sequence`, `type_text` | Yes | Action: get_map (list available input actions), sequence (execute input timeline), type_text (type text into focused UI element) |
-| `inputs` | object[] | sequence | Array of inputs to execute |
-| `text` | string | type_text | Text to type |
-| `delay_ms` | integer | Yes | Delay between keystrokes in milliseconds (type_text only, default 50) |
-| `submit` | boolean | Yes | Press Enter after typing to submit (type_text only, for LineEdit text_submitted) |
-
 ### Actions
 
 #### `get_map`
 
+*No parameters.*
+
 #### `sequence`
 
-Parameters: `inputs`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `inputs` | object[] | Yes | Array of inputs to execute |
 
 #### `type_text`
 
-Parameters: `text`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | Text to type |
+| `delay_ms` | integer | Yes | Delay between keystrokes in milliseconds (default 50) |
+| `submit` | boolean | Yes | Press Enter after typing to submit (for LineEdit text_submitted) |
 
 ### Examples
 
 ```json
 // get_map
 {
-  "action": "get_map",
-  "delay_ms": null,
-  "submit": false
+  "action": "get_map"
 }
 ```
 
@@ -49,9 +45,7 @@ Parameters: `text`*
 // sequence
 {
   "action": "sequence",
-  "inputs": [],
-  "delay_ms": null,
-  "submit": false
+  "inputs": []
 }
 ```
 

--- a/docs/tools/node.md
+++ b/docs/tools/node.md
@@ -12,63 +12,73 @@ Node manipulation and script attachment tools
 
 Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_properties`, `find`, `create`, `update`, `delete`, `reparent`, `attach_script`, `detach_script`, `connect_signal` | Yes | Action: get_properties, find, create, update, delete, reparent, attach_script, detach_script, connect_signal |
-| `node_path` | string | get_properties, update, delete, reparent, attach_script, detach_script | Path to the node |
-| `name_pattern` | string | find | Glob pattern to match node names, e.g. "*Spawner*", "Turret?" |
-| `type` | string | find | Filter by node type, e.g. "CharacterBody2D", "Area2D" |
-| `root_path` | string | No | Path to start search from (find only, defaults to scene root) |
-| `parent_path` | string | create | Path to the parent node |
-| `node_type` | string | No | Type of node to create, e.g. "Sprite2D" (create only, use this OR scene_path) |
-| `scene_path` | string | No | Path to scene to instantiate, e.g. "res://enemies/goblin.tscn" (create only, use this OR node_type) |
-| `node_name` | string | create | Name for the new node |
-| `properties` | Record<string, unknown> | create, update | Properties to set |
-| `new_parent_path` | string | reparent | Path to the new parent node |
-| `script_path` | string | attach_script | Path to the script file |
-| `signal_name` | string | connect_signal | Name of the signal to connect, e.g. "pressed", "body_entered" |
-| `target_path` | string | connect_signal | Path to the target node that will receive the signal |
-| `method_name` | string | connect_signal | Name of the method to call on the target node |
-
 ### Actions
 
 #### `get_properties`
 
-Parameters: `node_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
 
 #### `find`
 
-Parameters: `name_pattern`*, `type`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name_pattern` | string | No | Glob pattern to match node names, e.g. "*Spawner*", "Turret?" |
+| `type` | string | No | Filter by node type, e.g. "CharacterBody2D", "Area2D" |
+| `root_path` | string | No | Path to start search from (defaults to scene root) |
 
 #### `create`
 
-Parameters: `parent_path`*, `node_name`*, `properties`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `parent_path` | string | Yes | Path to the parent node |
+| `node_name` | string | Yes | Name for the new node |
+| `node_type` | string | No | Type of node to create, e.g. "Sprite2D" (use this OR scene_path) |
+| `scene_path` | string | No | Path to scene to instantiate, e.g. "res://enemies/goblin.tscn" (use this OR node_type) |
+| `properties` | Record<string, unknown> | No | Properties to set on the node |
 
 #### `update`
 
-Parameters: `node_path`*, `properties`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `properties` | Record<string, unknown> | No | Properties to set on the node |
 
 #### `delete`
 
-Parameters: `node_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
 
 #### `reparent`
 
-Parameters: `node_path`*, `new_parent_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `new_parent_path` | string | Yes | Path to the new parent node |
 
 #### `attach_script`
 
-Parameters: `node_path`*, `script_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `script_path` | string | Yes | Path to the script file |
 
 #### `detach_script`
 
-Parameters: `node_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
 
 #### `connect_signal`
 
-Parameters: `signal_name`*, `target_path`*, `method_name`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node emitting the signal |
+| `signal_name` | string | Yes | Name of the signal, e.g. "pressed", "body_entered" |
+| `target_path` | string | Yes | Path to the target node that will receive the signal |
+| `method_name` | string | Yes | Name of the method to call on the target node |
 
 ### Examples
 
@@ -83,10 +93,7 @@ Parameters: `signal_name`*, `target_path`*, `method_name`*
 ```json
 // find
 {
-  "action": "find",
-  "name_pattern": "*Enemy*",
-  "type": "CharacterBody2D",
-  "root_path": "/root/Main"
+  "action": "find"
 }
 ```
 
@@ -95,7 +102,6 @@ Parameters: `signal_name`*, `target_path`*, `method_name`*
 {
   "action": "create",
   "parent_path": "/root/Main",
-  "node_type": "Sprite2D",
   "node_name": "NewNode"
 }
 ```

--- a/docs/tools/profiler.md
+++ b/docs/tools/profiler.md
@@ -12,26 +12,33 @@ Performance profiling: snapshots, per-frame time series with spike detection, ac
 
 Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `snapshot`, `start`, `stop`, `get_data`, `get_active_processes`, `get_signal_connections` | Yes | Action: snapshot (full perf snapshot), start/stop/get_data (time series profiling), get_active_processes, get_signal_connections |
-| `node_path` | string | No | Node path for get_signal_connections (optional, defaults to scene root) |
-
 ### Actions
 
 #### `snapshot`
 
+*No parameters.*
+
 #### `start`
+
+*No parameters.*
 
 #### `stop`
 
+*No parameters.*
+
 #### `get_data`
+
+*No parameters.*
 
 #### `get_active_processes`
 
+*No parameters.*
+
 #### `get_signal_connections`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | No | Node path (defaults to scene root) |
 
 ### Examples
 

--- a/docs/tools/project.md
+++ b/docs/tools/project.md
@@ -12,23 +12,22 @@ Project information tools
 
 Get project information and settings
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_info`, `get_settings`, `addon_status` | Yes | Action: get_info, get_settings, addon_status (check addon/server version compatibility) |
-| `category` | string | No | Settings category to filter by (get_settings only, use "input" for input mappings) |
-| `include_builtin` | boolean | get_settings with category="input" | Include built-in ui_* actions |
-
 ### Actions
 
 #### `get_info`
 
+*No parameters.*
+
 #### `get_settings`
 
-Parameters: `include_builtin`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `category` | string | No | Settings category to filter by (use "input" for input mappings) |
+| `include_builtin` | boolean | No | Include built-in ui_* actions (with category="input") |
 
 #### `addon_status`
+
+*No parameters.*
 
 ### Examples
 
@@ -42,8 +41,7 @@ Parameters: `include_builtin`*
 ```json
 // get_settings
 {
-  "action": "get_settings",
-  "category": "example"
+  "action": "get_settings"
 }
 ```
 

--- a/docs/tools/resource.md
+++ b/docs/tools/resource.md
@@ -12,25 +12,23 @@ Resource inspection tools for SpriteFrames, TileSet, Materials, etc.
 
 Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_info` | Yes | Action: get_info |
-| `resource_path` | string | No | Resource path (e.g., "res://player/sprites.tres") (get_info) |
-| `max_depth` | number | No | Detail level: 0 = summary only, 1 = full detail (default), 2+ = expand sub-resources (get_info) |
-| `include_internal` | boolean | No | Include internal properties starting with underscore (get_info, default: false) |
-
 ### Actions
 
 #### `get_info`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `resource_path` | string | Yes | Resource path (e.g., "res://player/sprites.tres") |
+| `max_depth` | number | No | Detail level: 0 = summary only, 1 = full detail (default), 2+ = expand sub-resources |
+| `include_internal` | boolean | No | Include internal properties starting with underscore (default: false) |
 
 ### Examples
 
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "resource_path": "res://resources/spriteframes.tres"
 }
 ```
 

--- a/docs/tools/scene.md
+++ b/docs/tools/scene.md
@@ -12,28 +12,27 @@ Scene management tools
 
 Manage scenes: open, save, or create scenes
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `open`, `save`, `create` | Yes | Action: open, save, create |
-| `scene_path` | string | open, create; optional for: save | Path to scene file |
-| `root_type` | string | create | Type of root node, e.g. "Node2D" |
-| `root_name` | string | No | Name of root node (create only, defaults to root_type) |
-
 ### Actions
 
 #### `open`
 
-Parameters: `scene_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | Yes | Path to scene file to open |
 
 #### `save`
 
-Parameters: `scene_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | No | Path to save to (defaults to the current scene path) |
 
 #### `create`
 
-Parameters: `root_type`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | Yes | Path for the new scene file |
+| `root_type` | string | Yes | Type of root node, e.g. "Node2D" |
+| `root_name` | string | No | Name of root node (defaults to root_type) |
 
 ### Examples
 
@@ -48,8 +47,7 @@ Parameters: `root_type`*
 ```json
 // save
 {
-  "action": "save",
-  "scene_path": "res://scenes/enemy.tscn"
+  "action": "save"
 }
 ```
 
@@ -58,8 +56,7 @@ Parameters: `root_type`*
 {
   "action": "create",
   "scene_path": "res://scenes/enemy.tscn",
-  "root_type": "example",
-  "root_name": "example"
+  "root_type": "example"
 }
 ```
 

--- a/docs/tools/scene3d.md
+++ b/docs/tools/scene3d.md
@@ -12,25 +12,23 @@
 
 Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_spatial_info`, `get_bounds` | Yes | Action: get_spatial_info (node spatial data), get_bounds (combined AABB) |
-| `node_path` | string | No | Path to the Node3D (required for get_spatial_info) |
-| `root_path` | string | No | Path to search root (get_bounds only, defaults to scene root) |
-| `include_children` | boolean | Yes | Include child nodes |
-| `type_filter` | string | get_spatial_info | Filter by node type, e.g. "MeshInstance3D" |
-| `max_results` | integer | get_spatial_info | Limit number of results. Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed. |
-| `within_aabb` | object {position, size} | get_spatial_info | Only include nodes whose global position is within this AABB |
-
 ### Actions
 
 #### `get_spatial_info`
 
-Parameters: `include_children`*, `type_filter`*, `max_results`*, `within_aabb`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the Node3D |
+| `include_children` | boolean | Yes | Include child nodes |
+| `type_filter` | string | No | Filter by node type, e.g. "MeshInstance3D" |
+| `max_results` | integer | No | Limit number of results. Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed. |
+| `within_aabb` | object {position, size} | No | Only include nodes whose global position is within this AABB |
 
 #### `get_bounds`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Path to search root (defaults to scene root) |
 
 ### Examples
 
@@ -38,19 +36,15 @@ Parameters: `include_children`*, `type_filter`*, `max_results`*, `within_aabb`*
 // get_spatial_info
 {
   "action": "get_spatial_info",
-  "include_children": false,
-  "type_filter": "example",
-  "max_results": null,
-  "within_aabb": {}
+  "node_path": "/root/Main/Player",
+  "include_children": false
 }
 ```
 
 ```json
 // get_bounds
 {
-  "action": "get_bounds",
-  "root_path": "/root/Main",
-  "include_children": false
+  "action": "get_bounds"
 }
 ```
 

--- a/docs/tools/tilemap.md
+++ b/docs/tools/tilemap.md
@@ -13,76 +13,107 @@ TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprec
 
 Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `list_layers`, `get_info`, `get_tileset_info`, `get_used_cells`, `get_cell`, `get_cells_in_region`, `convert_coords`, `set_cell`, `erase_cell`, `clear_layer`, `set_cells_batch` | Yes | Action: list_layers, get_info, get_tileset_info, get_used_cells, get_cell, get_cells_in_region, convert_coords, set_cell, erase_cell, clear_layer, set_cells_batch |
-| `root_path` | string | list_layers | Starting node path |
-| `node_path` | string | No | Path to TileMapLayer (required except list_layers) |
-| `coords` | object {x, y} | get_cell, set_cell, erase_cell | Cell coordinates |
-| `min_coords` | object {x, y} | No | Minimum corner of region (get_cells_in_region) |
-| `max_coords` | object {x, y} | No | Maximum corner of region (get_cells_in_region) |
-| `local_position` | object {x, y} | No | Local position to convert to map coords (convert_coords) |
-| `map_coords` | object {x, y} | No | Map coordinates to convert to local position (convert_coords) |
-| `source_id` | integer | No | TileSet source ID, default 0 (set_cell) |
-| `atlas_coords` | object {x, y} | No | Atlas coordinates, default 0,0 (set_cell) |
-| `alternative_tile` | integer | No | Alternative tile ID, default 0 (set_cell) |
-| `cells` | object[] | No | Array of cells to set (set_cells_batch) |
-
 ### Actions
 
 #### `list_layers`
 
-Parameters: `root_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Starting node path (defaults to scene root) |
 
 #### `get_info`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+
 #### `get_tileset_info`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
 
 #### `get_used_cells`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+
 #### `get_cell`
 
-Parameters: `coords`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `coords` | object {x, y} | Yes | Cell coordinates |
 
 #### `get_cells_in_region`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `min_coords` | object {x, y} | Yes | Minimum corner of region |
+| `max_coords` | object {x, y} | Yes | Maximum corner of region |
+
 #### `convert_coords`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `local_position` | object {x, y} | No | Local position to convert to map coords |
+| `map_coords` | object {x, y} | No | Map coordinates to convert to local position |
 
 #### `set_cell`
 
-Parameters: `coords`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `coords` | object {x, y} | Yes | Cell coordinates |
+| `source_id` | integer | No | TileSet source ID, default 0 |
+| `atlas_coords` | object {x, y} | No | Atlas coordinates, default 0,0 |
+| `alternative_tile` | integer | No | Alternative tile ID, default 0 |
 
 #### `erase_cell`
 
-Parameters: `coords`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `coords` | object {x, y} | Yes | Cell coordinates |
 
 #### `clear_layer`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+
 #### `set_cells_batch`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `cells` | object[] | Yes | Array of cells to set |
 
 ### Examples
 
 ```json
 // list_layers
 {
-  "action": "list_layers",
-  "root_path": "/root/Main"
+  "action": "list_layers"
 }
 ```
 
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // get_tileset_info
 {
-  "action": "get_tileset_info"
+  "action": "get_tileset_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
@@ -94,71 +125,97 @@ Parameters: `coords`
 
 Query and edit GridMap data: list gridmaps, get info, get/set cells
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `list`, `get_info`, `get_meshlib_info`, `get_used_cells`, `get_cell`, `get_cells_by_item`, `set_cell`, `clear_cell`, `clear`, `set_cells_batch` | Yes | Action: list, get_info, get_meshlib_info, get_used_cells, get_cell, get_cells_by_item, set_cell, clear_cell, clear, set_cells_batch |
-| `root_path` | string | list | Starting node path |
-| `node_path` | string | No | Path to GridMap (required except list) |
-| `coords` | object {x, y, z} | get_cell, set_cell, clear_cell | Cell coordinates |
-| `item` | integer | get_cells_by_item, set_cell | MeshLibrary item index |
-| `orientation` | integer | No | Orientation 0-23, default 0 (set_cell) |
-| `cells` | object[] | No | Array of cells to set (set_cells_batch) |
-
 ### Actions
 
 #### `list`
 
-Parameters: `root_path`*
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Starting node path (defaults to scene root) |
 
 #### `get_info`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+
 #### `get_meshlib_info`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
 
 #### `get_used_cells`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+
 #### `get_cell`
 
-Parameters: `coords`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `coords` | object {x, y, z} | Yes | Cell coordinates |
 
 #### `get_cells_by_item`
 
-Parameters: `item`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `item` | integer | Yes | MeshLibrary item index |
 
 #### `set_cell`
 
-Parameters: `coords`, `item`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `coords` | object {x, y, z} | Yes | Cell coordinates |
+| `item` | integer | Yes | MeshLibrary item index |
+| `orientation` | integer | No | Orientation 0-23, default 0 |
 
 #### `clear_cell`
 
-Parameters: `coords`
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `coords` | object {x, y, z} | Yes | Cell coordinates |
 
 #### `clear`
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+
 #### `set_cells_batch`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `cells` | object[] | Yes | Array of cells to set |
 
 ### Examples
 
 ```json
 // list
 {
-  "action": "list",
-  "root_path": "/root/Main"
+  "action": "list"
 }
 ```
 
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // get_meshlib_info
 {
-  "action": "get_meshlib_info"
+  "action": "get_meshlib_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -338,10 +338,89 @@ function getExampleValue(name: string, prop: Record<string, unknown>): unknown {
   }
 }
 
+interface ActionVariant {
+  action: string;
+  properties: Record<string, Record<string, unknown>>;
+  required: string[];
+}
+
+// Discriminated-union schemas serialize to oneOf (one object variant per
+// action). Pull each variant's action literal, properties, and required list.
+function getActionVariants(schema: Record<string, unknown>): ActionVariant[] | null {
+  const branches = (schema.oneOf || schema.anyOf) as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(branches)) return null;
+
+  const variants: ActionVariant[] = [];
+  for (const branch of branches) {
+    const properties = (branch.properties as Record<string, Record<string, unknown>>) || {};
+    const actionProp = properties.action;
+    const action =
+      (actionProp?.const as string | undefined) ??
+      (Array.isArray(actionProp?.enum) ? (actionProp!.enum as string[])[0] : undefined);
+    if (action === undefined) continue;
+    variants.push({ action, properties, required: (branch.required as string[]) || [] });
+  }
+  return variants.length > 0 ? variants : null;
+}
+
+function generateUnionActionDocs(variants: ActionVariant[]): string {
+  let md = '### Actions\n\n';
+
+  for (const variant of variants) {
+    md += `#### \`${variant.action}\`\n\n`;
+    const paramNames = Object.keys(variant.properties).filter((n) => n !== 'action');
+
+    if (paramNames.length === 0) {
+      md += '*No parameters.*\n\n';
+      continue;
+    }
+
+    md += '| Parameter | Type | Required | Description |\n';
+    md += '|-----------|------|----------|-------------|\n';
+    for (const name of paramNames) {
+      const prop = variant.properties[name];
+      const typeStr = getTypeString(prop);
+      const reqStr = variant.required.includes(name) ? 'Yes' : 'No';
+      const desc = escapeMarkdown(String(prop.description || ''));
+      md += `| \`${name}\` | ${typeStr} | ${reqStr} | ${desc} |\n`;
+    }
+    md += '\n';
+  }
+
+  return md;
+}
+
+function generateUnionExamples(variants: ActionVariant[]): string {
+  let md = '### Examples\n\n';
+
+  for (const variant of variants.slice(0, 3)) {
+    const example: Record<string, unknown> = { action: variant.action };
+    for (const name of variant.required) {
+      if (name === 'action') continue;
+      example[name] = getExampleValue(name, variant.properties[name]);
+    }
+    md += `\`\`\`json\n// ${variant.action}\n${JSON.stringify(example, null, 2)}\n\`\`\`\n\n`;
+  }
+
+  if (variants.length > 3) {
+    md += `*${variants.length - 3} more actions available: ${variants.slice(3).map((v) => `\`${v.action}\``).join(', ')}*\n\n`;
+  }
+
+  return md;
+}
+
 function generateToolMarkdown(tool: AnyToolDefinition): string {
   const schema = toInputSchema(tool.schema);
   let md = `## ${tool.name}\n\n`;
   md += `${tool.description}\n\n`;
+
+  const variants = getActionVariants(schema);
+  if (variants) {
+    md += generateUnionActionDocs(variants);
+    md += generateUnionExamples(variants);
+    return md;
+  }
+
   md += `### Parameters\n\n`;
   md += generateParamsTable(schema);
   md += '\n';

--- a/server/src/__tests__/core/discriminated-union-schema.test.ts
+++ b/server/src/__tests__/core/discriminated-union-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { toInputSchema } from '../../core/schema.js';
+import { node } from '../../tools/node.js';
+import { animation } from '../../tools/animation.js';
+import { editor } from '../../tools/editor.js';
+
+type JsonSchema = Record<string, unknown>;
+const variantsOf = (tool: { schema: Parameters<typeof toInputSchema>[0] }): JsonSchema[] =>
+  (toInputSchema(tool.schema) as JsonSchema).oneOf as JsonSchema[];
+const actionOf = (variant: JsonSchema): string =>
+  ((variant.properties as Record<string, JsonSchema>).action as JsonSchema).const as string;
+
+describe('discriminated-union tool schemas', () => {
+  it('serialize to oneOf with one variant per action', () => {
+    const variants = variantsOf(node);
+    expect(Array.isArray(variants)).toBe(true);
+    expect(variants).toHaveLength(9);
+    const actions = variants.map(actionOf);
+    expect(actions).toContain('create');
+    expect(actions).toContain('connect_signal');
+  });
+
+  it('encode per-action required fields in each variant', () => {
+    const create = variantsOf(node).find((v) => actionOf(v) === 'create')!;
+    expect(create.required).toEqual(expect.arrayContaining(['action', 'parent_path', 'node_name']));
+    // node_type / scene_path are the XOR pair, so neither is individually required
+    expect(create.required).not.toContain('node_type');
+    expect(create.required).not.toContain('scene_path');
+  });
+
+  it('keep residual constraints the union cannot express on its own', () => {
+    // node create requires exactly one of node_type / scene_path
+    expect(node.schema.safeParse({ action: 'create', parent_path: '/r', node_name: 'X' }).success).toBe(false);
+    expect(node.schema.safeParse({ action: 'create', parent_path: '/r', node_name: 'X', node_type: 'Sprite2D' }).success).toBe(true);
+    expect(
+      node.schema.safeParse({ action: 'create', parent_path: '/r', node_name: 'X', node_type: 'Sprite2D', scene_path: 'res://e.tscn' }).success
+    ).toBe(false);
+    // editor set_viewport_2d requires at least one of center_x / center_y / zoom
+    expect(editor.schema.safeParse({ action: 'set_viewport_2d' }).success).toBe(false);
+    expect(editor.schema.safeParse({ action: 'set_viewport_2d', zoom: 2 }).success).toBe(true);
+  });
+
+  it('reject unknown actions', () => {
+    expect(animation.schema.safeParse({ action: 'not_a_real_action' }).success).toBe(false);
+  });
+});

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -49,7 +49,7 @@ describe('input tool', () => {
       });
       const ctx = createToolContext(mock);
 
-      const result = await input.execute({ action: 'get_map', delay_ms: 50, submit: false }, ctx);
+      const result = await input.execute({ action: 'get_map' }, ctx);
       expect(result).toContain('jump: Space, Joypad Button 0');
       expect(result).toContain('move_left: A, Left');
       expect(result).toContain('source: game');
@@ -59,7 +59,7 @@ describe('input tool', () => {
       mock.mockResponse({ actions: [], source: 'editor' });
       const ctx = createToolContext(mock);
 
-      const result = await input.execute({ action: 'get_map', delay_ms: 50, submit: false }, ctx);
+      const result = await input.execute({ action: 'get_map' }, ctx);
       expect(result).toContain('No custom input actions defined');
     });
   });
@@ -72,8 +72,6 @@ describe('input tool', () => {
       const result = await input.execute({
         action: 'sequence',
         inputs: [{ action_name: 'jump', start_ms: 0, duration_ms: 0 }],
-        delay_ms: 50,
-        submit: false,
       }, ctx);
 
       expect(result).toContain('1 action(s) executed');
@@ -91,8 +89,6 @@ describe('input tool', () => {
           { action_name: 'move_forward', start_ms: 0, duration_ms: 1000 },
           { action_name: 'jump', start_ms: 500, duration_ms: 250 },
         ],
-        delay_ms: 50,
-        submit: false,
       }, ctx);
 
       expect(result).toContain('2 action(s) executed');
@@ -107,8 +103,6 @@ describe('input tool', () => {
       await expect(input.execute({
         action: 'sequence',
         inputs: [{ action_name: 'invalid', start_ms: 0, duration_ms: 0 }],
-        delay_ms: 50,
-        submit: false,
       }, ctx)).rejects.toThrow('Unknown action: invalid');
     });
   });

--- a/server/src/__tests__/tools/profiler.test.ts
+++ b/server/src/__tests__/tools/profiler.test.ts
@@ -18,8 +18,12 @@ describe('profiler tool', () => {
       expect(profiler.schema.safeParse({ action: 'get_active_processes' }).success).toBe(true);
     });
 
-    it('rejects node_path on non-signal actions', () => {
-      expect(profiler.schema.safeParse({ action: 'snapshot', node_path: '/root/Test' }).success).toBe(false);
+    it('strips node_path from non-signal actions (only get_signal_connections defines it)', () => {
+      const parsed = profiler.schema.safeParse({ action: 'snapshot', node_path: '/root/Test' });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect('node_path' in parsed.data).toBe(false);
+      }
     });
 
     it('accepts node_path on get_signal_connections', () => {

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -15,96 +15,116 @@ const TrackTypeEnum = z.enum([
   'animation',
 ]);
 
-const AnimationSchema = z
-  .object({
-    action: z
-      .enum([
-        'list_players',
-        'get_info',
-        'get_details',
-        'get_keyframes',
-        'play',
-        'stop',
-        'seek',
-        'create',
-        'delete',
-        'update_props',
-        'add_track',
-        'remove_track',
-        'add_keyframe',
-        'remove_keyframe',
-        'update_keyframe',
-      ])
-      .describe(
-        'Action: list_players, get_info, get_details, get_keyframes (query), play, stop, seek (playback), create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe (edit)'
-      ),
-    root_path: z.string().optional().describe('Starting node path (list_players only)'),
-    node_path: z.string().optional().describe('Path to AnimationPlayer (required except list_players)'),
-    animation_name: z.string().optional().describe('Animation name'),
-    track_index: z.number().optional().describe('Track index'),
-    custom_blend: z.number().optional().describe('Custom blend time, -1 for default (play)'),
-    custom_speed: z.number().optional().describe('Playback speed, 1.0 default (play)'),
-    from_end: z.boolean().optional().describe('Play from end for reverse (play)'),
-    keep_state: z.boolean().optional().describe('Keep current animation state (stop)'),
-    seconds: z.number().optional().describe('Position to seek to (seek)'),
-    update: z.boolean().optional().describe('Update node immediately, default true (seek)'),
-    library_name: z.string().optional().describe('Library name (create, delete)'),
-    length: z.number().optional().describe('Animation length in seconds (create, update_props)'),
-    loop_mode: LoopModeEnum.optional().describe('Loop mode: none, linear, pingpong (create, update_props)'),
-    step: z.number().optional().describe('Step value for keyframe snapping (create, update_props)'),
-    track_type: TrackTypeEnum.optional().describe('Type of track (add_track)'),
-    track_path: z.string().optional().describe('Node path and property, e.g. "Sprite2D:frame" (add_track)'),
-    insert_at: z.number().optional().describe('Track index to insert at, -1 for end (add_track)'),
-    time: z.number().optional().describe('Keyframe time in seconds (add_keyframe, update_keyframe)'),
-    value: z.unknown().optional().describe('Keyframe value (add_keyframe, update_keyframe)'),
-    transition: z.number().optional().describe('Transition curve, 1.0 = linear (add_keyframe, update_keyframe)'),
-    method_name: z.string().optional().describe('Method name for method tracks (add_keyframe)'),
-    args: z.array(z.unknown()).optional().describe('Method arguments (add_keyframe)'),
-    keyframe_index: z.number().optional().describe('Keyframe index (remove_keyframe, update_keyframe)'),
-  })
-  .refine(
-    (data) => {
-      switch (data.action) {
-        case 'list_players':
-          return true;
-        case 'get_info':
-        case 'stop':
-          return !!data.node_path;
-        case 'get_details':
-        case 'create':
-        case 'delete':
-        case 'update_props':
-        case 'play':
-          return !!data.node_path && !!data.animation_name;
-        case 'get_keyframes':
-          return !!data.node_path && !!data.animation_name && data.track_index !== undefined;
-        case 'seek':
-          return !!data.node_path && data.seconds !== undefined;
-        case 'add_track':
-          return !!data.node_path && !!data.animation_name && !!data.track_type && !!data.track_path;
-        case 'remove_track':
-          return !!data.node_path && !!data.animation_name && data.track_index !== undefined;
-        case 'add_keyframe':
-          return (
-            !!data.node_path &&
-            !!data.animation_name &&
-            data.track_index !== undefined &&
-            data.time !== undefined
-          );
-        case 'remove_keyframe':
-        case 'update_keyframe':
-          return (
-            !!data.node_path &&
-            !!data.animation_name &&
-            data.track_index !== undefined &&
-            data.keyframe_index !== undefined
-          );
-        default:
-          return false;
-      }
-    },
-    { message: 'Missing required fields for action' }
-  );
+const nodePathField = z.string().describe('Path to the AnimationPlayer');
+const animNameField = z.string().describe('Animation name');
+const trackIndexField = z.number().describe('Track index');
+const keyframeIndexField = z.number().describe('Keyframe index');
+
+const AnimationSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('list_players').describe('List AnimationPlayer nodes in the scene'),
+    root_path: z.string().optional().describe('Starting node path (defaults to scene root)'),
+  }),
+  z.object({
+    action: z.literal('get_info').describe('Get AnimationPlayer state and library list'),
+    node_path: nodePathField,
+  }),
+  z.object({
+    action: z.literal('get_details').describe("Get an animation's tracks and properties"),
+    node_path: nodePathField,
+    animation_name: animNameField,
+  }),
+  z.object({
+    action: z.literal('get_keyframes').describe('Get keyframes for a track'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    track_index: trackIndexField,
+  }),
+  z.object({
+    action: z.literal('play').describe('Play an animation'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    custom_blend: z.number().optional().describe('Custom blend time, -1 for default'),
+    custom_speed: z.number().optional().describe('Playback speed, 1.0 default'),
+    from_end: z.boolean().optional().describe('Play from end for reverse'),
+  }),
+  z.object({
+    action: z.literal('stop').describe('Stop playback'),
+    node_path: nodePathField,
+    keep_state: z.boolean().optional().describe('Keep current animation state'),
+  }),
+  z.object({
+    action: z.literal('seek').describe('Seek to a position in the current animation'),
+    node_path: nodePathField,
+    seconds: z.number().describe('Position to seek to'),
+    update: z.boolean().optional().describe('Update node immediately, default true'),
+  }),
+  z.object({
+    action: z.literal('create').describe('Create an animation'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    library_name: z.string().optional().describe('Library name'),
+    length: z.number().optional().describe('Animation length in seconds'),
+    loop_mode: LoopModeEnum.optional().describe('Loop mode: none, linear, pingpong'),
+    step: z.number().optional().describe('Step value for keyframe snapping'),
+  }),
+  z.object({
+    action: z.literal('delete').describe('Delete an animation'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    library_name: z.string().optional().describe('Library name'),
+  }),
+  z.object({
+    action: z.literal('update_props').describe('Update animation properties'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    length: z.number().optional().describe('Animation length in seconds'),
+    loop_mode: LoopModeEnum.optional().describe('Loop mode: none, linear, pingpong'),
+    step: z.number().optional().describe('Step value for keyframe snapping'),
+  }),
+  z.object({
+    action: z.literal('add_track').describe('Add a track to an animation'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    track_type: TrackTypeEnum.describe('Type of track'),
+    track_path: z.string().describe('Node path and property, e.g. "Sprite2D:frame"'),
+    insert_at: z.number().optional().describe('Track index to insert at, -1 for end'),
+  }),
+  z.object({
+    action: z.literal('remove_track').describe('Remove a track'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    track_index: trackIndexField,
+  }),
+  z.object({
+    action: z.literal('add_keyframe').describe('Add a keyframe to a track'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    track_index: trackIndexField,
+    time: z.number().describe('Keyframe time in seconds'),
+    value: z.unknown().optional().describe('Keyframe value'),
+    transition: z.number().optional().describe('Transition curve, 1.0 = linear'),
+    method_name: z.string().optional().describe('Method name for method tracks'),
+    args: z.array(z.unknown()).optional().describe('Method arguments'),
+  }),
+  z.object({
+    action: z.literal('remove_keyframe').describe('Remove a keyframe'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    track_index: trackIndexField,
+    keyframe_index: keyframeIndexField,
+  }),
+  z.object({
+    action: z.literal('update_keyframe').describe('Update a keyframe'),
+    node_path: nodePathField,
+    animation_name: animNameField,
+    track_index: trackIndexField,
+    keyframe_index: keyframeIndexField,
+    time: z.number().optional().describe('Keyframe time in seconds'),
+    value: z.unknown().optional().describe('Keyframe value'),
+    transition: z.number().optional().describe('Transition curve, 1.0 = linear'),
+  }),
+]);
 
 type AnimationArgs = z.infer<typeof AnimationSchema>;
 

--- a/server/src/tools/docs.ts
+++ b/server/src/tools/docs.ts
@@ -8,28 +8,31 @@ const FETCH_TIMEOUT_MS = 15000;
 const SUPPORTED_VERSIONS = ['stable', 'latest', '4.5', '4.4', '4.3', '4.2'] as const;
 type DocsVersion = (typeof SUPPORTED_VERSIONS)[number];
 
-const DocsSchema = z.object({
-  action: z
-    .enum(['fetch_class', 'fetch_page'])
-    .describe('Action: fetch_class (get class reference by name), fetch_page (get any docs page by path)'),
-  class_name: z
-    .string()
-    .optional()
-    .describe('Class name to fetch, e.g. "CharacterBody2D" (fetch_class only)'),
-  path: z
-    .string()
-    .optional()
-    .describe('Documentation path, e.g. "/tutorials/2d/2d_movement.html" (fetch_page only)'),
-  version: z
-    .enum(SUPPORTED_VERSIONS)
-    .optional()
-    .describe('Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable"'),
-  section: z
-    .enum(['full', 'description', 'properties', 'methods', 'signals'])
-    .optional()
-    .default('full')
-    .describe('Which section to return (default: full). Use specific sections to reduce token usage.'),
-});
+const SectionEnum = z
+  .enum(['full', 'description', 'properties', 'methods', 'signals'])
+  .optional()
+  .default('full')
+  .describe('Which section to return (default: full). Use specific sections to reduce token usage.');
+
+const VersionEnum = z
+  .enum(SUPPORTED_VERSIONS)
+  .optional()
+  .describe('Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable"');
+
+const DocsSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('fetch_class').describe('Get a class reference by name'),
+    class_name: z.string().describe('Class name to fetch, e.g. "CharacterBody2D"'),
+    version: VersionEnum,
+    section: SectionEnum,
+  }),
+  z.object({
+    action: z.literal('fetch_page').describe('Get any docs page by path'),
+    path: z.string().describe('Documentation path, e.g. "/tutorials/2d/2d_movement.html"'),
+    version: VersionEnum,
+    section: SectionEnum,
+  }),
+]);
 
 type DocsArgs = z.infer<typeof DocsSchema>;
 

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -34,62 +34,47 @@ function toImageContent(base64: string): ImageContent {
 }
 
 const EditorSchema = z
-  .object({
-    action: z
-      .enum(['get_state', 'get_selection', 'select', 'run', 'stop', 'get_log_messages', 'get_stack_trace', 'screenshot_game', 'screenshot_editor', 'set_viewport_2d'])
-      .describe('Action: get_state, get_selection, select, run, stop, get_log_messages, get_stack_trace, screenshot_game, screenshot_editor, set_viewport_2d'),
-    node_path: z
-      .string()
-      .optional()
-      .describe('Path to node (select only)'),
-    scene_path: z
-      .string()
-      .optional()
-      .describe('Scene to run (run only, optional)'),
-    clear: z
-      .boolean()
-      .optional()
-      .describe('Clear buffer after reading (get_log_messages only)'),
-    limit: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe('Maximum number of messages to return (get_log_messages only, default: 50)'),
-    viewport: z
-      .enum(['2d', '3d'])
-      .optional()
-      .describe('Which editor viewport to capture (screenshot_editor only)'),
-    max_width: z
-      .number()
-      .optional()
-      .describe('Maximum width in pixels for screenshot (screenshot_game, screenshot_editor)'),
-    center_x: z
-      .number()
-      .optional()
-      .describe('X coordinate to center the 2D viewport on (set_viewport_2d only)'),
-    center_y: z
-      .number()
-      .optional()
-      .describe('Y coordinate to center the 2D viewport on (set_viewport_2d only)'),
-    zoom: z
-      .number()
-      .positive()
-      .optional()
-      .describe('Zoom level for 2D viewport, e.g. 1.0 = 100%, 2.0 = 200% (set_viewport_2d only)'),
-  })
+  .discriminatedUnion('action', [
+    z.object({ action: z.literal('get_state').describe('Get editor state: current scene, play state, version, camera, viewport') }),
+    z.object({ action: z.literal('get_selection').describe('Get the currently selected nodes') }),
+    z.object({
+      action: z.literal('select').describe('Select a node in the editor'),
+      node_path: z.string().describe('Path to node to select'),
+    }),
+    z.object({
+      action: z.literal('run').describe('Run the project'),
+      scene_path: z.string().optional().describe('Scene to run (optional, defaults to main scene)'),
+    }),
+    z.object({ action: z.literal('stop').describe('Stop the running project') }),
+    z.object({
+      action: z.literal('get_log_messages').describe('Get editor/game log messages'),
+      clear: z.boolean().optional().describe('Clear buffer after reading'),
+      limit: z.number().int().positive().optional().describe('Maximum number of messages to return (default: 50)'),
+    }),
+    z.object({ action: z.literal('get_stack_trace').describe('Get the most recent error stack trace') }),
+    z.object({
+      action: z.literal('screenshot_game').describe('Capture a screenshot of the running game'),
+      max_width: z.number().optional().describe('Maximum width in pixels for the screenshot'),
+    }),
+    z.object({
+      action: z.literal('screenshot_editor').describe('Capture a screenshot of an editor viewport'),
+      viewport: z.enum(['2d', '3d']).optional().describe('Which editor viewport to capture'),
+      max_width: z.number().optional().describe('Maximum width in pixels for the screenshot'),
+    }),
+    z.object({
+      action: z.literal('set_viewport_2d').describe('Center and zoom the 2D editor viewport'),
+      center_x: z.number().optional().describe('X coordinate to center the 2D viewport on'),
+      center_y: z.number().optional().describe('Y coordinate to center the 2D viewport on'),
+      zoom: z.number().positive().optional().describe('Zoom level, e.g. 1.0 = 100%, 2.0 = 200%'),
+    }),
+  ])
+  // Constraint a discriminated union can't express on its own, so it lives here:
   .refine(
-    (data) => {
-      switch (data.action) {
-        case 'select':
-          return !!data.node_path;
-        case 'set_viewport_2d':
-          return data.center_x !== undefined || data.center_y !== undefined || data.zoom !== undefined;
-        default:
-          return true;
-      }
-    },
-    { message: 'select requires node_path; set_viewport_2d requires at least one of center_x, center_y, or zoom' }
+    (data) =>
+      data.action === 'set_viewport_2d'
+        ? data.center_x !== undefined || data.center_y !== undefined || data.zoom !== undefined
+        : true,
+    { message: 'set_viewport_2d requires at least one of center_x, center_y, or zoom' }
   );
 
 type EditorArgs = z.infer<typeof EditorSchema>;

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -8,46 +8,37 @@ const InputActionSchema = z.object({
   duration_ms: z.number().int().min(0).optional().default(0).describe('How long to hold the input (0 = instant tap)'),
 });
 
-const InputSchema = z
-  .object({
-    action: z
-      .enum(['get_map', 'sequence', 'type_text'])
-      .describe('Action: get_map (list available input actions), sequence (execute input timeline), type_text (type text into focused UI element)'),
+const InputSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('get_map').describe('List available input actions from the project Input Map'),
+  }),
+  z.object({
+    action: z.literal('sequence').describe('Execute an input timeline'),
     inputs: z
       .array(InputActionSchema)
       .min(1)
-      .optional()
-      .describe('Array of inputs to execute (sequence only)'),
+      .describe('Array of inputs to execute'),
+  }),
+  z.object({
+    action: z.literal('type_text').describe('Type text into the focused UI element'),
     text: z
       .string()
       .min(1)
-      .optional()
-      .describe('Text to type (type_text only)'),
+      .describe('Text to type'),
     delay_ms: z
       .number()
       .int()
       .min(0)
       .optional()
       .default(50)
-      .describe('Delay between keystrokes in milliseconds (type_text only, default 50)'),
+      .describe('Delay between keystrokes in milliseconds (default 50)'),
     submit: z
       .boolean()
       .optional()
       .default(false)
-      .describe('Press Enter after typing to submit (type_text only, for LineEdit text_submitted)'),
-  })
-  .refine(
-    (data) => {
-      if (data.action === 'sequence') {
-        return data.inputs && data.inputs.length > 0;
-      }
-      if (data.action === 'type_text') {
-        return data.text && data.text.length > 0;
-      }
-      return true;
-    },
-    { message: 'sequence requires inputs array; type_text requires text string' }
-  );
+      .describe('Press Enter after typing to submit (for LineEdit text_submitted)'),
+  }),
+]);
 
 type InputArgs = z.infer<typeof InputSchema>;
 

--- a/server/src/tools/node.ts
+++ b/server/src/tools/node.ts
@@ -2,106 +2,86 @@ import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
+const propertiesField = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe('Properties to set on the node');
+
 const NodeSchema = z
-  .object({
-    action: z
-      .enum(['get_properties', 'find', 'create', 'update', 'delete', 'reparent', 'attach_script', 'detach_script', 'connect_signal'])
-      .describe(
-        'Action: get_properties, find, create, update, delete, reparent, attach_script, detach_script, connect_signal'
-      ),
-    node_path: z
-      .string()
-      .optional()
-      .describe(
-        'Path to the node (required for: get_properties, update, delete, reparent, attach_script, detach_script)'
-      ),
-    name_pattern: z
-      .string()
-      .optional()
-      .describe('Glob pattern to match node names, e.g. "*Spawner*", "Turret?" (find only)'),
-    type: z
-      .string()
-      .optional()
-      .describe('Filter by node type, e.g. "CharacterBody2D", "Area2D" (find only)'),
-    root_path: z
-      .string()
-      .optional()
-      .describe('Path to start search from (find only, defaults to scene root)'),
-    parent_path: z
-      .string()
-      .optional()
-      .describe('Path to the parent node (create only)'),
-    node_type: z
-      .string()
-      .optional()
-      .describe(
-        'Type of node to create, e.g. "Sprite2D" (create only, use this OR scene_path)'
-      ),
-    scene_path: z
-      .string()
-      .optional()
-      .describe(
-        'Path to scene to instantiate, e.g. "res://enemies/goblin.tscn" (create only, use this OR node_type)'
-      ),
-    node_name: z
-      .string()
-      .optional()
-      .describe('Name for the new node (create only)'),
-    properties: z
-      .record(z.string(), z.unknown())
-      .optional()
-      .describe('Properties to set (create, update)'),
-    new_parent_path: z
-      .string()
-      .optional()
-      .describe('Path to the new parent node (reparent only)'),
-    script_path: z
-      .string()
-      .optional()
-      .describe('Path to the script file (attach_script only)'),
-    signal_name: z
-      .string()
-      .optional()
-      .describe('Name of the signal to connect, e.g. "pressed", "body_entered" (connect_signal only)'),
-    target_path: z
-      .string()
-      .optional()
-      .describe('Path to the target node that will receive the signal (connect_signal only)'),
-    method_name: z
-      .string()
-      .optional()
-      .describe('Name of the method to call on the target node (connect_signal only)'),
-  })
+  .discriminatedUnion('action', [
+    z.object({
+      action: z.literal('get_properties').describe('Get a node\'s properties'),
+      node_path: z.string().describe('Path to the node'),
+    }),
+    z.object({
+      action: z.literal('find').describe('Find nodes by name and/or type'),
+      name_pattern: z
+        .string()
+        .optional()
+        .describe('Glob pattern to match node names, e.g. "*Spawner*", "Turret?"'),
+      type: z
+        .string()
+        .optional()
+        .describe('Filter by node type, e.g. "CharacterBody2D", "Area2D"'),
+      root_path: z
+        .string()
+        .optional()
+        .describe('Path to start search from (defaults to scene root)'),
+    }),
+    z.object({
+      action: z.literal('create').describe('Create a node, or instantiate a scene as a node'),
+      parent_path: z.string().describe('Path to the parent node'),
+      node_name: z.string().describe('Name for the new node'),
+      node_type: z
+        .string()
+        .optional()
+        .describe('Type of node to create, e.g. "Sprite2D" (use this OR scene_path)'),
+      scene_path: z
+        .string()
+        .optional()
+        .describe('Path to scene to instantiate, e.g. "res://enemies/goblin.tscn" (use this OR node_type)'),
+      properties: propertiesField,
+    }),
+    z.object({
+      action: z.literal('update').describe('Update a node\'s properties'),
+      node_path: z.string().describe('Path to the node'),
+      properties: propertiesField,
+    }),
+    z.object({
+      action: z.literal('delete').describe('Delete a node'),
+      node_path: z.string().describe('Path to the node'),
+    }),
+    z.object({
+      action: z.literal('reparent').describe('Move a node to a new parent'),
+      node_path: z.string().describe('Path to the node'),
+      new_parent_path: z.string().describe('Path to the new parent node'),
+    }),
+    z.object({
+      action: z.literal('attach_script').describe('Attach a script to a node'),
+      node_path: z.string().describe('Path to the node'),
+      script_path: z.string().describe('Path to the script file'),
+    }),
+    z.object({
+      action: z.literal('detach_script').describe('Detach a node\'s script'),
+      node_path: z.string().describe('Path to the node'),
+    }),
+    z.object({
+      action: z.literal('connect_signal').describe('Connect a signal to a target method'),
+      node_path: z.string().describe('Path to the node emitting the signal'),
+      signal_name: z.string().describe('Name of the signal, e.g. "pressed", "body_entered"'),
+      target_path: z.string().describe('Path to the target node that will receive the signal'),
+      method_name: z.string().describe('Name of the method to call on the target node'),
+    }),
+  ])
+  // Constraints a discriminated union can't express on its own, so they live here:
   .refine(
-    (data) => {
-      switch (data.action) {
-        case 'get_properties':
-        case 'update':
-        case 'delete':
-        case 'detach_script':
-          return !!data.node_path;
-        case 'find':
-          return !!data.name_pattern || !!data.type;
-        case 'create':
-          return (
-            !!data.parent_path &&
-            !!data.node_name &&
-            !!data.node_type !== !!data.scene_path
-          );
-        case 'reparent':
-          return !!data.node_path && !!data.new_parent_path;
-        case 'attach_script':
-          return !!data.node_path && !!data.script_path;
-        case 'connect_signal':
-          return !!data.node_path && !!data.signal_name && !!data.target_path && !!data.method_name;
-        default:
-          return false;
-      }
-    },
-    {
-      message:
-        'Missing required fields for action. get_properties/update/delete/detach_script need node_path; find needs name_pattern and/or type; create needs parent_path, node_name, and either node_type OR scene_path; reparent needs node_path and new_parent_path; attach_script needs node_path and script_path; connect_signal needs node_path, signal_name, target_path, and method_name',
-    }
+    (data) => (data.action === 'find' ? !!data.name_pattern || !!data.type : true),
+    { message: 'find requires name_pattern and/or type' }
+  )
+  .refine(
+    // create needs exactly one of node_type / scene_path (XOR).
+    (data) => (data.action === 'create' ? !!data.node_type !== !!data.scene_path : true),
+    { message: 'create requires exactly one of node_type or scene_path' }
   );
 
 type NodeArgs = z.infer<typeof NodeSchema>;

--- a/server/src/tools/profiler.ts
+++ b/server/src/tools/profiler.ts
@@ -164,32 +164,17 @@ export function computeFrameBudget(
   };
 }
 
-const ProfilerSchema = z
-  .object({
-    action: z
-      .enum([
-        'snapshot',
-        'start',
-        'stop',
-        'get_data',
-        'get_active_processes',
-        'get_signal_connections',
-      ])
-      .describe('Action: snapshot (full perf snapshot), start/stop/get_data (time series profiling), get_active_processes, get_signal_connections'),
-    node_path: z
-      .string()
-      .optional()
-      .describe('Node path for get_signal_connections (optional, defaults to scene root)'),
-  })
-  .refine(
-    (data) => {
-      if (data.node_path !== undefined && data.action !== 'get_signal_connections') {
-        return false;
-      }
-      return true;
-    },
-    { message: 'node_path is only valid with get_signal_connections action' }
-  );
+const ProfilerSchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('snapshot').describe('Full performance snapshot (all engine metrics)') }),
+  z.object({ action: z.literal('start').describe('Start per-frame time-series profiling') }),
+  z.object({ action: z.literal('stop').describe('Stop time-series profiling') }),
+  z.object({ action: z.literal('get_data').describe('Get collected time-series data with spike detection') }),
+  z.object({ action: z.literal('get_active_processes').describe('List active _process/_physics_process scripts') }),
+  z.object({
+    action: z.literal('get_signal_connections').describe('Inspect signal connections'),
+    node_path: z.string().optional().describe('Node path (defaults to scene root)'),
+  }),
+]);
 
 type ProfilerArgs = z.infer<typeof ProfilerSchema>;
 

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -3,19 +3,25 @@ import { defineTool } from '../core/define-tool.js';
 import type { AnyToolDefinition } from '../core/types.js';
 import { getServerVersion } from '../version.js';
 
-const ProjectSchema = z.object({
-  action: z
-    .enum(['get_info', 'get_settings', 'addon_status'])
-    .describe('Action: get_info, get_settings, addon_status (check addon/server version compatibility)'),
-  category: z
-    .string()
-    .optional()
-    .describe('Settings category to filter by (get_settings only, use "input" for input mappings)'),
-  include_builtin: z
-    .boolean()
-    .optional()
-    .describe('Include built-in ui_* actions (get_settings with category="input" only)'),
-});
+const ProjectSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('get_info').describe('Get project name, path, version, and main scene'),
+  }),
+  z.object({
+    action: z.literal('get_settings').describe('Get project settings'),
+    category: z
+      .string()
+      .optional()
+      .describe('Settings category to filter by (use "input" for input mappings)'),
+    include_builtin: z
+      .boolean()
+      .optional()
+      .describe('Include built-in ui_* actions (with category="input")'),
+  }),
+  z.object({
+    action: z.literal('addon_status').describe('Check addon/server version compatibility'),
+  }),
+]);
 
 type ProjectArgs = z.infer<typeof ProjectSchema>;
 

--- a/server/src/tools/resource.ts
+++ b/server/src/tools/resource.ts
@@ -9,37 +9,22 @@ interface ResourceInfoResult {
   properties?: Record<string, unknown>;
 }
 
-const ResourceSchema = z
-  .object({
-    action: z
-      .enum(['get_info'])
-      .describe('Action: get_info'),
+const ResourceSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('get_info').describe('Inspect a Resource file by path'),
     resource_path: z
       .string()
-      .optional()
-      .describe('Resource path (e.g., "res://player/sprites.tres") (get_info)'),
+      .describe('Resource path (e.g., "res://player/sprites.tres")'),
     max_depth: z
       .number()
       .optional()
-      .describe(
-        'Detail level: 0 = summary only, 1 = full detail (default), 2+ = expand sub-resources (get_info)'
-      ),
+      .describe('Detail level: 0 = summary only, 1 = full detail (default), 2+ = expand sub-resources'),
     include_internal: z
       .boolean()
       .optional()
-      .describe('Include internal properties starting with underscore (get_info, default: false)'),
-  })
-  .refine(
-    (data) => {
-      switch (data.action) {
-        case 'get_info':
-          return !!data.resource_path;
-        default:
-          return false;
-      }
-    },
-    { message: 'get_info action requires resource_path' }
-  );
+      .describe('Include internal properties starting with underscore (default: false)'),
+  }),
+]);
 
 type ResourceArgs = z.infer<typeof ResourceSchema>;
 

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -2,42 +2,25 @@ import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
-const SceneSchema = z
-  .object({
-    action: z
-      .enum(['open', 'save', 'create'])
-      .describe('Action: open, save, create'),
+const SceneSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('open').describe('Open a scene file'),
+    scene_path: z.string().describe('Path to scene file to open'),
+  }),
+  z.object({
+    action: z.literal('save').describe('Save the current scene'),
     scene_path: z
       .string()
       .optional()
-      .describe('Path to scene file (required for: open, create; optional for: save)'),
-    root_type: z
-      .string()
-      .optional()
-      .describe('Type of root node, e.g. "Node2D" (create only)'),
-    root_name: z
-      .string()
-      .optional()
-      .describe('Name of root node (create only, defaults to root_type)'),
-  })
-  .refine(
-    (data) => {
-      switch (data.action) {
-        case 'save':
-          return true;
-        case 'open':
-          return !!data.scene_path;
-        case 'create':
-          return !!data.scene_path && !!data.root_type;
-        default:
-          return false;
-      }
-    },
-    {
-      message:
-        'Missing required fields for action. open needs scene_path; create needs scene_path and root_type',
-    }
-  );
+      .describe('Path to save to (defaults to the current scene path)'),
+  }),
+  z.object({
+    action: z.literal('create').describe('Create a new scene'),
+    scene_path: z.string().describe('Path for the new scene file'),
+    root_type: z.string().describe('Type of root node, e.g. "Node2D"'),
+    root_name: z.string().optional().describe('Name of root node (defaults to root_type)'),
+  }),
+]);
 
 type SceneArgs = z.infer<typeof SceneSchema>;
 

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -30,56 +30,37 @@ const AABBInputSchema = z.object({
   size: Vector3Schema.describe('Size of the AABB'),
 });
 
-const Scene3DSchema = z
-  .object({
-    action: z
-      .enum(['get_spatial_info', 'get_bounds'])
-      .describe('Action: get_spatial_info (node spatial data), get_bounds (combined AABB)'),
-    node_path: z
-      .string()
-      .optional()
-      .describe('Path to the Node3D (required for get_spatial_info)'),
-    root_path: z
-      .string()
-      .optional()
-      .describe('Path to search root (get_bounds only, defaults to scene root)'),
+const Scene3DSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('get_spatial_info').describe('Get spatial data for a Node3D and optionally its children'),
+    node_path: z.string().describe('Path to the Node3D'),
     include_children: z
       .boolean()
       .optional()
       .default(false)
-      .describe('Include child nodes (get_spatial_info only)'),
+      .describe('Include child nodes'),
     type_filter: z
       .string()
       .optional()
-      .describe('Filter by node type, e.g. "MeshInstance3D" (get_spatial_info only)'),
+      .describe('Filter by node type, e.g. "MeshInstance3D"'),
     max_results: z
       .number()
       .int()
       .positive()
       .optional()
-      .describe(
-        'Limit number of results (get_spatial_info only). Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed.'
-      ),
+      .describe('Limit number of results. Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed.'),
     within_aabb: AABBInputSchema.optional().describe(
-      'Only include nodes whose global position is within this AABB (get_spatial_info only)'
+      'Only include nodes whose global position is within this AABB'
     ),
-  })
-  .refine(
-    (data) => {
-      switch (data.action) {
-        case 'get_spatial_info':
-          return !!data.node_path;
-        case 'get_bounds':
-          return true;
-        default:
-          return false;
-      }
-    },
-    {
-      message:
-        'Missing required fields for action. get_spatial_info requires node_path.',
-    }
-  );
+  }),
+  z.object({
+    action: z.literal('get_bounds').describe('Get the combined AABB of a subtree'),
+    root_path: z
+      .string()
+      .optional()
+      .describe('Path to search root (defaults to scene root)'),
+  }),
+]);
 
 type Scene3DArgs = z.infer<typeof Scene3DSchema>;
 

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -13,38 +13,53 @@ const Vector3iSchema = z.object({
   z: z.number().int(),
 });
 
-const TilemapSchema = z
-  .object({
-    action: z
-      .enum([
-        'list_layers',
-        'get_info',
-        'get_tileset_info',
-        'get_used_cells',
-        'get_cell',
-        'get_cells_in_region',
-        'convert_coords',
-        'set_cell',
-        'erase_cell',
-        'clear_layer',
-        'set_cells_batch',
-      ])
-      .describe(
-        'Action: list_layers, get_info, get_tileset_info, get_used_cells, get_cell, get_cells_in_region, convert_coords, set_cell, erase_cell, clear_layer, set_cells_batch'
-      ),
-    root_path: z.string().optional().describe('Starting node path (list_layers only)'),
-    node_path: z.string().optional().describe('Path to TileMapLayer (required except list_layers)'),
-    coords: Vector2iSchema.optional().describe('Cell coordinates (get_cell, set_cell, erase_cell)'),
-    min_coords: Vector2iSchema.optional().describe('Minimum corner of region (get_cells_in_region)'),
-    max_coords: Vector2iSchema.optional().describe('Maximum corner of region (get_cells_in_region)'),
+const tilemapNodePath = z.string().describe('Path to the TileMapLayer');
+
+const TilemapSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('list_layers').describe('List TileMapLayer nodes in the scene'),
+    root_path: z.string().optional().describe('Starting node path (defaults to scene root)'),
+  }),
+  z.object({ action: z.literal('get_info').describe('Get TileMapLayer info'), node_path: tilemapNodePath }),
+  z.object({ action: z.literal('get_tileset_info').describe("Get the layer's TileSet info"), node_path: tilemapNodePath }),
+  z.object({ action: z.literal('get_used_cells').describe('Get all used cells'), node_path: tilemapNodePath }),
+  z.object({
+    action: z.literal('get_cell').describe('Get a single cell'),
+    node_path: tilemapNodePath,
+    coords: Vector2iSchema.describe('Cell coordinates'),
+  }),
+  z.object({
+    action: z.literal('get_cells_in_region').describe('Get cells within a rectangular region'),
+    node_path: tilemapNodePath,
+    min_coords: Vector2iSchema.describe('Minimum corner of region'),
+    max_coords: Vector2iSchema.describe('Maximum corner of region'),
+  }),
+  z.object({
+    action: z.literal('convert_coords').describe('Convert between local position and map coordinates'),
+    node_path: tilemapNodePath,
     local_position: z
       .object({ x: z.number(), y: z.number() })
       .optional()
-      .describe('Local position to convert to map coords (convert_coords)'),
-    map_coords: Vector2iSchema.optional().describe('Map coordinates to convert to local position (convert_coords)'),
-    source_id: z.number().int().optional().describe('TileSet source ID, default 0 (set_cell)'),
-    atlas_coords: Vector2iSchema.optional().describe('Atlas coordinates, default 0,0 (set_cell)'),
-    alternative_tile: z.number().int().optional().describe('Alternative tile ID, default 0 (set_cell)'),
+      .describe('Local position to convert to map coords'),
+    map_coords: Vector2iSchema.optional().describe('Map coordinates to convert to local position'),
+  }),
+  z.object({
+    action: z.literal('set_cell').describe('Set a single cell'),
+    node_path: tilemapNodePath,
+    coords: Vector2iSchema.describe('Cell coordinates'),
+    source_id: z.number().int().optional().describe('TileSet source ID, default 0'),
+    atlas_coords: Vector2iSchema.optional().describe('Atlas coordinates, default 0,0'),
+    alternative_tile: z.number().int().optional().describe('Alternative tile ID, default 0'),
+  }),
+  z.object({
+    action: z.literal('erase_cell').describe('Erase a single cell'),
+    node_path: tilemapNodePath,
+    coords: Vector2iSchema.describe('Cell coordinates'),
+  }),
+  z.object({ action: z.literal('clear_layer').describe('Clear all cells in the layer'), node_path: tilemapNodePath }),
+  z.object({
+    action: z.literal('set_cells_batch').describe('Set many cells at once'),
+    node_path: tilemapNodePath,
     cells: z
       .array(
         z.object({
@@ -54,34 +69,10 @@ const TilemapSchema = z
           alternative_tile: z.number().int().optional(),
         })
       )
-      .optional()
-      .describe('Array of cells to set (set_cells_batch)'),
-  })
-  .refine(
-    (data) => {
-      switch (data.action) {
-        case 'list_layers':
-          return true;
-        case 'get_info':
-        case 'get_tileset_info':
-        case 'get_used_cells':
-        case 'convert_coords':
-        case 'clear_layer':
-          return !!data.node_path;
-        case 'get_cell':
-        case 'set_cell':
-        case 'erase_cell':
-          return !!data.node_path && !!data.coords;
-        case 'get_cells_in_region':
-          return !!data.node_path && !!data.min_coords && !!data.max_coords;
-        case 'set_cells_batch':
-          return !!data.node_path && !!data.cells && data.cells.length > 0;
-        default:
-          return false;
-      }
-    },
-    { message: 'Missing required fields for action' }
-  );
+      .min(1)
+      .describe('Array of cells to set'),
+  }),
+]);
 
 type TilemapArgs = z.infer<typeof TilemapSchema>;
 
@@ -173,16 +164,42 @@ export const tilemap = defineTool({
   },
 });
 
-const GridmapSchema = z
-  .object({
-    action: z
-      .enum(['list', 'get_info', 'get_meshlib_info', 'get_used_cells', 'get_cell', 'get_cells_by_item', 'set_cell', 'clear_cell', 'clear', 'set_cells_batch'])
-      .describe('Action: list, get_info, get_meshlib_info, get_used_cells, get_cell, get_cells_by_item, set_cell, clear_cell, clear, set_cells_batch'),
-    root_path: z.string().optional().describe('Starting node path (list only)'),
-    node_path: z.string().optional().describe('Path to GridMap (required except list)'),
-    coords: Vector3iSchema.optional().describe('Cell coordinates (get_cell, set_cell, clear_cell)'),
-    item: z.number().int().optional().describe('MeshLibrary item index (get_cells_by_item, set_cell)'),
-    orientation: z.number().int().optional().describe('Orientation 0-23, default 0 (set_cell)'),
+const gridmapNodePath = z.string().describe('Path to the GridMap');
+
+const GridmapSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('list').describe('List GridMap nodes in the scene'),
+    root_path: z.string().optional().describe('Starting node path (defaults to scene root)'),
+  }),
+  z.object({ action: z.literal('get_info').describe('Get GridMap info'), node_path: gridmapNodePath }),
+  z.object({ action: z.literal('get_meshlib_info').describe("Get the GridMap's MeshLibrary info"), node_path: gridmapNodePath }),
+  z.object({ action: z.literal('get_used_cells').describe('Get all used cells'), node_path: gridmapNodePath }),
+  z.object({
+    action: z.literal('get_cell').describe('Get a single cell'),
+    node_path: gridmapNodePath,
+    coords: Vector3iSchema.describe('Cell coordinates'),
+  }),
+  z.object({
+    action: z.literal('get_cells_by_item').describe('Get all cells using a given MeshLibrary item'),
+    node_path: gridmapNodePath,
+    item: z.number().int().describe('MeshLibrary item index'),
+  }),
+  z.object({
+    action: z.literal('set_cell').describe('Set a single cell'),
+    node_path: gridmapNodePath,
+    coords: Vector3iSchema.describe('Cell coordinates'),
+    item: z.number().int().describe('MeshLibrary item index'),
+    orientation: z.number().int().optional().describe('Orientation 0-23, default 0'),
+  }),
+  z.object({
+    action: z.literal('clear_cell').describe('Clear a single cell'),
+    node_path: gridmapNodePath,
+    coords: Vector3iSchema.describe('Cell coordinates'),
+  }),
+  z.object({ action: z.literal('clear').describe('Clear all cells'), node_path: gridmapNodePath }),
+  z.object({
+    action: z.literal('set_cells_batch').describe('Set many cells at once'),
+    node_path: gridmapNodePath,
     cells: z
       .array(
         z.object({
@@ -191,34 +208,10 @@ const GridmapSchema = z
           orientation: z.number().int().optional(),
         })
       )
-      .optional()
-      .describe('Array of cells to set (set_cells_batch)'),
-  })
-  .refine(
-    (data) => {
-      switch (data.action) {
-        case 'list':
-          return true;
-        case 'get_info':
-        case 'get_meshlib_info':
-        case 'get_used_cells':
-        case 'clear':
-          return !!data.node_path;
-        case 'get_cell':
-        case 'clear_cell':
-          return !!data.node_path && !!data.coords;
-        case 'get_cells_by_item':
-          return !!data.node_path && data.item !== undefined;
-        case 'set_cell':
-          return !!data.node_path && !!data.coords && data.item !== undefined;
-        case 'set_cells_batch':
-          return !!data.node_path && !!data.cells && data.cells.length > 0;
-        default:
-          return false;
-      }
-    },
-    { message: 'Missing required fields for action' }
-  );
+      .min(1)
+      .describe('Array of cells to set'),
+  }),
+]);
 
 type GridmapArgs = z.infer<typeof GridmapSchema>;
 


### PR DESCRIPTION
Closes #187. Tier 1 of the modernization chain (tracking: #192).

## What

Every multiplexed tool moves from a flat `z.object({...})` + runtime `.refine()` to `z.discriminatedUnion('action', [...])`. Each action variant now declares exactly its own fields, so the emitted JSON schema is a `oneOf` where per-action required/optional fields are explicit, instead of a flat bag of optionals whose rules were hidden in a refine and prose hints.

- Same call shape, behaviorally identical.
- The win: schema clarity for weaker models / non-Claude clients (the per-action requirements are now in the schema they consume), plus clearer validation errors.
- 12 tools converted: scene, node, editor, project, animation, tilemap, gridmap, resource, scene3d, docs, input, profiler.

## The spots worth your review attention

Most of this is mechanical. The only judgment calls are constraints a discriminated union cannot express, which stay as small `.refine()`s on the outer union:

1. **`godot_node` create** - exactly one of `node_type` / `scene_path` (XOR).
2. **`godot_node` find** - `name_pattern` and/or `type` (at least one).
3. **`godot_editor` set_viewport_2d** - at least one of `center_x` / `center_y` / `zoom`.

(zod v4 won't accept a `.refine()`-wrapped object as a discriminated-union member, so these live on the union, not the variant. The `oneOf` JSON output is preserved through the refine - verified.)

## Docs + behavior notes

- `generate-docs` learned the `oneOf` shape and now renders **per-action parameter tables** (more precise than the old single flat table). The flat-schema path is kept for any non-union tool.
- Runtime `.parse()` strips unknown keys per variant (lenient, same as before), so a field belonging to a different action is dropped rather than erroring. The one profiler test that asserted the old reject-behavior is updated to assert the strip.

## Verification

`npm run build` clean, `npm test` green (**188 passed**; +4 new in `discriminated-union-schema.test.ts`, profiler/input tests adjusted), `npm run generate-docs` regenerated all 12 tool docs. Non-breaking -> minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)