### PR TITLE
perf: compact JSON in tool query responses (#189)

### DIFF
--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -154,7 +154,7 @@ export const animation = defineTool({
           libraries: Record<string, string[]>;
           animation_count: number;
         }>('get_animation_player_info', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_details': {
         const result = await godot.sendCommand<{
@@ -175,7 +175,7 @@ export const animation = defineTool({
           node_path: args.node_path,
           animation_name: args.animation_name,
         });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_keyframes': {
         const result = await godot.sendCommand<{
@@ -195,7 +195,7 @@ export const animation = defineTool({
           animation_name: args.animation_name,
           track_index: args.track_index,
         });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'play': {
         const result = await godot.sendCommand<{ playing: string; from_position: number }>(

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -114,7 +114,7 @@ export const editor = defineTool({
           camera?: CameraInfo;
           viewport_2d?: Viewport2DInfo;
         }>('get_editor_state');
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
 
       case 'get_selection': {
@@ -153,7 +153,7 @@ export const editor = defineTool({
         if (result.returned_count === 0) {
           return 'No log messages';
         }
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
 
       case 'get_stack_trace': {
@@ -167,7 +167,7 @@ export const editor = defineTool({
         if (!result.error && result.frames.length === 0) {
           return 'No stack trace available';
         }
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
 
       case 'screenshot_game': {

--- a/server/src/tools/node.ts
+++ b/server/src/tools/node.ts
@@ -98,7 +98,7 @@ export const node = defineTool({
         const result = await godot.sendCommand<{
           properties: Record<string, unknown>;
         }>('get_node_properties', { node_path: args.node_path });
-        return JSON.stringify(result.properties, null, 2);
+        return JSON.stringify(result.properties);
       }
 
       case 'find': {

--- a/server/src/tools/profiler.ts
+++ b/server/src/tools/profiler.ts
@@ -190,7 +190,7 @@ export const profiler = defineTool({
         const result = await godot.sendCommand<Record<string, number | string>>(
           'get_performance_metrics'
         );
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
 
       case 'start': {
@@ -212,7 +212,7 @@ export const profiler = defineTool({
             active: result.active,
             frame_count: 0,
             message: 'No frames collected. Start the profiler first with action: start',
-          }, null, 2);
+          });
         }
 
         const frameTimeStats = computePercentiles(frames.map((f) => f.ft));
@@ -245,7 +245,7 @@ export const profiler = defineTool({
             frames: spikes.slice(0, 20),
           },
           monitor_trends: monitorTrends,
-        }, null, 2);
+        });
       }
 
       case 'get_active_processes': {

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -39,7 +39,7 @@ export const project = defineTool({
           godot_version: string;
           main_scene: string | null;
         }>('get_project_info');
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
 
       case 'get_settings': {
@@ -49,7 +49,7 @@ export const project = defineTool({
           category: args.category,
           include_builtin: args.include_builtin,
         });
-        return JSON.stringify(result.settings, null, 2);
+        return JSON.stringify(result.settings);
       }
 
       case 'addon_status': {
@@ -62,9 +62,7 @@ export const project = defineTool({
               server_version: serverVersion,
               recommendation:
                 'Not connected to Godot. Ask user for their project path, then install with: npx @satelliteoflove/godot-mcp --install-addon <path>',
-            },
-            null,
-            2
+            }
           );
         }
 
@@ -84,9 +82,7 @@ export const project = defineTool({
             recommendation: versionsMatch
               ? null
               : `Version mismatch. Close Godot and run: npx @satelliteoflove/godot-mcp --install-addon "${projectPath}"`,
-          },
-          null,
-          2
+          }
         );
       }
     }

--- a/server/src/tools/resource.ts
+++ b/server/src/tools/resource.ts
@@ -45,7 +45,7 @@ export const resource = defineTool({
             include_internal: args.include_internal ?? false,
           }
         );
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
     }
   },

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -95,19 +95,19 @@ export const tilemap = defineTool({
       }
       case 'get_info': {
         const result = await godot.sendCommand('get_tilemap_layer_info', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_tileset_info': {
         const result = await godot.sendCommand('get_tileset_info', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_used_cells': {
         const result = await godot.sendCommand('get_used_cells', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_cell': {
         const result = await godot.sendCommand('get_cell', { node_path: args.node_path, coords: args.coords });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_cells_in_region': {
         const result = await godot.sendCommand('get_cells_in_region', {
@@ -115,7 +115,7 @@ export const tilemap = defineTool({
           min_coords: args.min_coords,
           max_coords: args.max_coords,
         });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'convert_coords': {
         const result = await godot.sendCommand('convert_coords', {
@@ -123,7 +123,7 @@ export const tilemap = defineTool({
           local_position: args.local_position,
           map_coords: args.map_coords,
         });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'set_cell': {
         const result = await godot.sendCommand<{
@@ -234,23 +234,23 @@ export const gridmap = defineTool({
       }
       case 'get_info': {
         const result = await godot.sendCommand('get_gridmap_info', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_meshlib_info': {
         const result = await godot.sendCommand('get_meshlib_info', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_used_cells': {
         const result = await godot.sendCommand('get_gridmap_used_cells', { node_path: args.node_path });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_cell': {
         const result = await godot.sendCommand('get_gridmap_cell', { node_path: args.node_path, coords: args.coords });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'get_cells_by_item': {
         const result = await godot.sendCommand('get_cells_by_item', { node_path: args.node_path, item: args.item });
-        return JSON.stringify(result, null, 2);
+        return JSON.stringify(result);
       }
       case 'set_cell': {
         const result = await godot.sendCommand<{


### PR DESCRIPTION
Closes #189.

## What

Replaces pretty-printed `JSON.stringify(x, null, 2)` with compact `JSON.stringify(x)` in tool query/read responses. The indentation and newlines were pure overhead in the model's context window — minified JSON parses identically and costs fewer tokens.

Touched: `editor` (get_editor_state, get_log_messages, get_stack_trace), `node` (get_properties), `project` (get_info, get_settings, addon_status), `profiler` (snapshot, get_data), `resource` (get_info), `animation` (info/details/keyframes), `tilemap`/`gridmap` (all get_* actions).

Human-readable summary strings like "Found N nodes:" and "Set cell at (x, y)" are left as-is — only the raw JSON payloads were minified.

## Why

Read-heavy tools (profiler snapshots, editor state, resource inspection) emit large JSON blobs. Stripping formatting whitespace is a free token reduction with zero behavior change. Server-only, non-breaking.

## Verification

- `npm run build` clean
- `npm test` — 188 passing
- `npm run generate-docs` — no doc changes (docs render input schemas, not output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)