### PR TITLE
feat: emit structuredContent for query actions (#190)

### DIFF
--- a/server/src/__tests__/core/structured-output.test.ts
+++ b/server/src/__tests__/core/structured-output.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { registry } from '../../core/registry.js';
+import { registerAllTools } from '../../tools/index.js';
+import { structured, isStructuredResult } from '../../core/structured.js';
+import { resource } from '../../tools/resource.js';
+import { createMockGodot, createToolContext } from '../helpers/mock-godot.js';
+
+describe('structured tool output', () => {
+  beforeAll(() => {
+    registerAllTools();
+  });
+
+  const byName = () => new Map(registry.getToolList().map((t) => [t.name, t]));
+
+  it('structured() renders compact JSON text alongside the object', () => {
+    const data = { a: 1, b: { c: 2 } };
+    const result = structured(data);
+    expect(result.text).toBe('{"a":1,"b":{"c":2}}');
+    expect(result.structuredContent).toEqual(data);
+  });
+
+  it('isStructuredResult recognizes a structured result', () => {
+    expect(isStructuredResult(structured({ x: 1 }))).toBe(true);
+  });
+
+  it('isStructuredResult rejects a plain string result', () => {
+    expect(isStructuredResult('Opened scene: res://main.tscn')).toBe(false);
+  });
+
+  it('isStructuredResult rejects text and image content items', () => {
+    expect(isStructuredResult({ type: 'text', text: 'hi' })).toBe(false);
+    expect(isStructuredResult({ type: 'image', data: 'x', mimeType: 'image/png' })).toBe(false);
+  });
+
+  it('advertises outputSchema for godot_resource', () => {
+    const tool = byName().get('godot_resource');
+    const schema = tool?.outputSchema as { type?: string; required?: string[] } | undefined;
+    expect(schema?.type).toBe('object');
+    expect(schema?.required).toEqual(expect.arrayContaining(['resource_path', 'resource_type']));
+  });
+
+  it('omits outputSchema for tools that do not define one', () => {
+    expect(byName().get('godot_scene')).not.toHaveProperty('outputSchema');
+  });
+
+  it('resource get_info returns a structured result, not a string', async () => {
+    const mock = createMockGodot();
+    mock.mockResponse({ resource_path: 'res://x.tres', resource_type: 'Resource' });
+    const result = await resource.execute(
+      { action: 'get_info', resource_path: 'res://x.tres' },
+      createToolContext(mock)
+    );
+    expect(isStructuredResult(result)).toBe(true);
+  });
+
+  it('resource get_info structuredContent matches the Godot payload', async () => {
+    const mock = createMockGodot();
+    const payload = { resource_path: 'res://x.tres', resource_type: 'Texture2D', properties: { width: 64 } };
+    mock.mockResponse(payload);
+    const result = await resource.execute(
+      { action: 'get_info', resource_path: 'res://x.tres' },
+      createToolContext(mock)
+    );
+    expect(isStructuredResult(result) && result.structuredContent).toEqual(payload);
+  });
+
+  it('resource get_info text fallback is compact JSON of the payload', async () => {
+    const mock = createMockGodot();
+    const payload = { resource_path: 'res://x.tres', resource_type: 'Resource' };
+    mock.mockResponse(payload);
+    const result = await resource.execute(
+      { action: 'get_info', resource_path: 'res://x.tres' },
+      createToolContext(mock)
+    );
+    expect(isStructuredResult(result) && result.text).toBe(JSON.stringify(payload));
+  });
+});

--- a/server/src/__tests__/helpers/mock-godot.ts
+++ b/server/src/__tests__/helpers/mock-godot.ts
@@ -54,3 +54,17 @@ export function createToolContext(mock: MockGodotConnection) {
     } as unknown as GodotConnection,
   };
 }
+
+// Extract the structured payload from a tool result. Query actions return a
+// StructuredToolResult ({ text, structuredContent }); this returns the
+// structuredContent. Falls back to parsing a plain JSON-string result.
+export function structuredOf(result: unknown): any {
+  if (
+    result &&
+    typeof result === 'object' &&
+    'structuredContent' in result
+  ) {
+    return (result as { structuredContent: unknown }).structuredContent;
+  }
+  return JSON.parse(result as string);
+}

--- a/server/src/__tests__/tools/animation.test.ts
+++ b/server/src/__tests__/tools/animation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { animation } from '../../tools/animation.js';
 
 describe('animation tool', () => {
@@ -33,14 +33,14 @@ describe('animation tool', () => {
 
       const info = { current_animation: 'idle', is_playing: true };
       mock.mockResponse(info);
-      expect(JSON.parse(await animation.execute({
+      expect(structuredOf(await animation.execute({
         action: 'get_info',
         node_path: '/root/AnimPlayer',
       }, ctx) as string)).toEqual(info);
 
       const details = { name: 'walk', length: 1.5, track_count: 3 };
       mock.mockResponse(details);
-      expect(JSON.parse(await animation.execute({
+      expect(structuredOf(await animation.execute({
         action: 'get_details',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',
@@ -48,7 +48,7 @@ describe('animation tool', () => {
 
       const keyframes = { track_path: 'Sprite:frame', keyframes: [{ time: 0, value: 0 }] };
       mock.mockResponse(keyframes);
-      expect(JSON.parse(await animation.execute({
+      expect(structuredOf(await animation.execute({
         action: 'get_keyframes',
         node_path: '/root/AnimPlayer',
         animation_name: 'walk',

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { editor } from '../../tools/editor.js';
 
 describe('editor tool', () => {
@@ -37,7 +37,7 @@ describe('editor tool', () => {
 
       const result = await editor.execute({ action: 'get_state' }, ctx);
 
-      expect(JSON.parse(result as string)).toEqual(state);
+      expect(structuredOf(result)).toEqual(state);
     });
   });
 
@@ -85,7 +85,7 @@ describe('editor tool', () => {
       };
       mock.mockResponse(responseData);
       const result = await editor.execute({ action: 'get_log_messages' }, ctx);
-      expect(JSON.parse(result as string)).toEqual(responseData);
+      expect(structuredOf(result)).toEqual(responseData);
     });
 
     it('passes limit param to Godot', async () => {
@@ -112,7 +112,7 @@ describe('editor tool', () => {
       };
       mock.mockResponse(stackData);
       const result = await editor.execute({ action: 'get_stack_trace' }, ctx);
-      expect(JSON.parse(result as string)).toEqual(stackData);
+      expect(structuredOf(result)).toEqual(stackData);
     });
   });
 

--- a/server/src/__tests__/tools/node.test.ts
+++ b/server/src/__tests__/tools/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { node } from '../../tools/node.js';
 
 describe('node tool', () => {
@@ -93,7 +93,7 @@ describe('node tool', () => {
       const ctx = createToolContext(mock);
 
       const result = await node.execute({ action: 'get_properties', node_path: '/root/Player' }, ctx);
-      expect(JSON.parse(result as string)).toEqual(properties);
+      expect(structuredOf(result)).toEqual(properties);
     });
   });
 

--- a/server/src/__tests__/tools/profiler.test.ts
+++ b/server/src/__tests__/tools/profiler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { profiler, computePercentiles, detectSpikes, computeMonitorTrends, computeFrameBudget } from '../../tools/profiler.js';
 
 describe('profiler tool', () => {
@@ -38,7 +38,7 @@ describe('profiler tool', () => {
       mock.mockResponse(metrics);
       const ctx = createToolContext(mock);
       const result = await profiler.execute({ action: 'snapshot' }, ctx);
-      expect(JSON.parse(result as string)).toEqual(metrics);
+      expect(structuredOf(result)).toEqual(metrics);
       expect(mock.calls[0].command).toBe('get_performance_metrics');
     });
   });
@@ -59,7 +59,7 @@ describe('profiler tool', () => {
       mock.mockResponse({ active: false, frame_count: 0, total_frames_collected: 0, frames: [] });
       const ctx = createToolContext(mock);
       const result = await profiler.execute({ action: 'get_data' }, ctx);
-      const parsed = JSON.parse(result as string);
+      const parsed = structuredOf(result);
       expect(parsed.frame_count).toBe(0);
       expect(parsed.message).toContain('No frames collected');
     });
@@ -73,7 +73,7 @@ describe('profiler tool', () => {
       mock.mockResponse({ active: true, frame_count: 3, total_frames_collected: 3, frames });
       const ctx = createToolContext(mock);
       const result = await profiler.execute({ action: 'get_data' }, ctx);
-      const parsed = JSON.parse(result as string);
+      const parsed = structuredOf(result);
       expect(parsed.statistics.frame_time).toBeDefined();
       expect(parsed.statistics.frame_time.avg_ms).toBeGreaterThan(0);
       expect(parsed.frame_budget).toBeDefined();

--- a/server/src/__tests__/tools/resource.test.ts
+++ b/server/src/__tests__/tools/resource.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { resource } from '../../tools/resource.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -69,7 +69,7 @@ describe('resource tool', () => {
         action: 'get_info',
         resource_path: 'res://player/player_sprites.tres',
       }, ctx);
-      const parsed = JSON.parse(result as string);
+      const parsed = structuredOf(result);
 
       expect(parsed.resource_type).toBe('SpriteFrames');
       expect(parsed.type_specific.animations).toHaveLength(5);
@@ -90,7 +90,7 @@ describe('resource tool', () => {
         resource_path: 'res://player/player_sprites.tres',
         max_depth: 0,
       }, ctx);
-      const parsed = JSON.parse(result as string);
+      const parsed = structuredOf(result);
 
       const idleAnim = parsed.type_specific.animations.find((a: { name: string }) => a.name === 'idle');
       expect(idleAnim.frame_count).toBe(1);
@@ -105,7 +105,7 @@ describe('resource tool', () => {
         action: 'get_info',
         resource_path: 'res://player/player_sprites.tres',
       }, ctx);
-      const parsed = JSON.parse(result as string);
+      const parsed = structuredOf(result);
 
       const damageAnim = parsed.type_specific.animations.find((a: { name: string }) => a.name === 'damage');
       expect(damageAnim.loop).toBe(false);
@@ -121,7 +121,7 @@ describe('resource tool', () => {
         action: 'get_info',
         resource_path: 'res://sprites/player/hero.png',
       }, ctx);
-      const parsed = JSON.parse(result as string);
+      const parsed = structuredOf(result);
 
       expect(parsed.resource_type).toBe('CompressedTexture2D');
       expect(parsed.type_specific.width).toBe(1026);

--- a/server/src/__tests__/tools/tilemap.test.ts
+++ b/server/src/__tests__/tools/tilemap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { tilemap, gridmap } from '../../tools/tilemap.js';
 
 describe('tilemap tool', () => {
@@ -31,19 +31,19 @@ describe('tilemap tool', () => {
       const ctx = createToolContext(mock);
 
       mock.mockResponse({ name: 'Ground', enabled: true });
-      expect(JSON.parse(await tilemap.execute({
+      expect(structuredOf(await tilemap.execute({
         action: 'get_info',
         node_path: '/root/Ground',
       }, ctx) as string)).toHaveProperty('name', 'Ground');
 
       mock.mockResponse({ tile_size: { x: 16, y: 16 } });
-      expect(JSON.parse(await tilemap.execute({
+      expect(structuredOf(await tilemap.execute({
         action: 'get_tileset_info',
         node_path: '/root/Ground',
       }, ctx) as string)).toHaveProperty('tile_size');
 
       mock.mockResponse({ cells: [{ x: 0, y: 0 }], count: 1 });
-      expect(JSON.parse(await tilemap.execute({
+      expect(structuredOf(await tilemap.execute({
         action: 'get_used_cells',
         node_path: '/root/Ground',
       }, ctx) as string)).toHaveProperty('count', 1);
@@ -159,13 +159,13 @@ describe('gridmap tool', () => {
       const ctx = createToolContext(mock);
 
       mock.mockResponse({ name: 'Floor', cell_size: { x: 2, y: 2, z: 2 } });
-      expect(JSON.parse(await gridmap.execute({
+      expect(structuredOf(await gridmap.execute({
         action: 'get_info',
         node_path: '/root/Floor',
       }, ctx) as string)).toHaveProperty('cell_size');
 
       mock.mockResponse({ item_count: 3 });
-      expect(JSON.parse(await gridmap.execute({
+      expect(structuredOf(await gridmap.execute({
         action: 'get_meshlib_info',
         node_path: '/root/Floor',
       }, ctx) as string)).toHaveProperty('item_count', 3);

--- a/server/src/core/define-tool.ts
+++ b/server/src/core/define-tool.ts
@@ -1,12 +1,13 @@
 import type { z } from 'zod';
-import type { ToolDefinition, ToolContext, ToolResult, ToolAnnotations } from './types.js';
+import type { ToolDefinition, ToolContext, ToolExecuteResult, ToolAnnotations } from './types.js';
 
 export function defineTool<TSchema extends z.ZodType>(config: {
   name: string;
   description: string;
   annotations?: ToolAnnotations;
   schema: TSchema;
-  execute: (args: z.infer<TSchema>, ctx: ToolContext) => Promise<string | ToolResult>;
+  outputSchema?: z.ZodType;
+  execute: (args: z.infer<TSchema>, ctx: ToolContext) => Promise<ToolExecuteResult>;
 }): ToolDefinition<TSchema> {
   return config;
 }

--- a/server/src/core/registry.ts
+++ b/server/src/core/registry.ts
@@ -1,5 +1,12 @@
-import type { AnyToolDefinition, ResourceDefinition, ToolAnnotations, ToolContext, ToolResult } from './types.js';
+import type {
+  AnyToolDefinition,
+  ResourceDefinition,
+  ToolAnnotations,
+  ToolContext,
+  ToolExecuteResult,
+} from './types.js';
 import { toInputSchema } from './schema.js';
+import { isStructuredResult } from './structured.js';
 import {
   formatError,
   GodotCommandError,
@@ -38,12 +45,14 @@ class ToolRegistry {
     name: string;
     description: string;
     inputSchema: object;
+    outputSchema?: object;
     annotations?: ToolAnnotations;
   }> {
     return Array.from(this.tools.values()).map((tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: toInputSchema(tool.schema),
+      ...(tool.outputSchema ? { outputSchema: toInputSchema(tool.outputSchema) } : {}),
       ...(tool.annotations ? { annotations: tool.annotations } : {}),
     }));
   }
@@ -68,7 +77,7 @@ class ToolRegistry {
     name: string,
     args: Record<string, unknown>,
     ctx: ToolContext
-  ): Promise<string | ToolResult> {
+  ): Promise<ToolExecuteResult> {
     const tool = this.tools.get(name);
     if (!tool) {
       throw new Error(`Unknown tool: ${name}`);
@@ -83,9 +92,13 @@ class ToolRegistry {
       const validated = tool.schema.parse(args);
       const result = await tool.execute(validated, ctx);
       success = true;
-      responseBytes = typeof result === 'string'
-        ? Buffer.byteLength(result, 'utf-8')
-        : Buffer.byteLength(JSON.stringify(result), 'utf-8');
+      const responseText =
+        typeof result === 'string'
+          ? result
+          : isStructuredResult(result)
+            ? result.text
+            : JSON.stringify(result);
+      responseBytes = Buffer.byteLength(responseText, 'utf-8');
       return result;
     } catch (error) {
       errorType = categorizeError(error);

--- a/server/src/core/structured.ts
+++ b/server/src/core/structured.ts
@@ -1,0 +1,20 @@
+import type { StructuredToolResult } from './types.js';
+
+// Wrap a query payload so the tool result carries both a compact-JSON text
+// rendering (the fallback for clients without structured-output support) and
+// the object itself as MCP `structuredContent`.
+export function structured(data: unknown): StructuredToolResult {
+  return {
+    text: JSON.stringify(data),
+    structuredContent: data as Record<string, unknown>,
+  };
+}
+
+export function isStructuredResult(value: unknown): value is StructuredToolResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'structuredContent' in value &&
+    'text' in value
+  );
+}

--- a/server/src/core/types.ts
+++ b/server/src/core/types.ts
@@ -9,6 +9,16 @@ export type TextContent = { type: 'text'; text: string };
 export type ImageContent = { type: 'image'; data: string; mimeType: string };
 export type ToolResult = TextContent | ImageContent;
 
+// A query result that carries both a text rendering (for clients without
+// structured-output support) and the structured object (emitted as the MCP
+// result's `structuredContent`). Additive: the text is the fallback.
+export interface StructuredToolResult {
+  text: string;
+  structuredContent: Record<string, unknown>;
+}
+
+export type ToolExecuteResult = string | ToolResult | StructuredToolResult;
+
 // MCP tool annotations: advisory hints clients use to label tools and decide
 // auto-approval. See the MCP spec's ToolAnnotations.
 export interface ToolAnnotations {
@@ -24,7 +34,8 @@ export interface ToolDefinition<TSchema extends z.ZodType = z.ZodType> {
   description: string;
   annotations?: ToolAnnotations;
   schema: TSchema;
-  execute: (args: z.infer<TSchema>, ctx: ToolContext) => Promise<string | ToolResult>;
+  outputSchema?: z.ZodType;
+  execute: (args: z.infer<TSchema>, ctx: ToolContext) => Promise<ToolExecuteResult>;
 }
 
 export interface AnyToolDefinition {
@@ -32,7 +43,8 @@ export interface AnyToolDefinition {
   description: string;
   annotations?: ToolAnnotations;
   schema: z.ZodType;
-  execute: (args: unknown, ctx: ToolContext) => Promise<string | ToolResult>;
+  outputSchema?: z.ZodType;
+  execute: (args: unknown, ctx: ToolContext) => Promise<ToolExecuteResult>;
 }
 
 export interface ResourceDefinition {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,6 +9,7 @@ import {
 
 import { initializeConnection, getGodotConnection } from './connection/websocket.js';
 import { registry } from './core/registry.js';
+import { isStructuredResult } from './core/structured.js';
 import { registerAllTools } from './tools/index.js';
 import { registerAllResources } from './resources/index.js';
 import { GodotCommandError } from './utils/errors.js';
@@ -48,6 +49,12 @@ export async function main() {
       if (typeof result === 'string') {
         return {
           content: [{ type: 'text', text: result }],
+        };
+      }
+      if (isStructuredResult(result)) {
+        return {
+          content: [{ type: 'text', text: result.text }],
+          structuredContent: result.structuredContent,
         };
       }
       return {

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 const LoopModeEnum = z.enum(['none', 'linear', 'pingpong']);
@@ -154,7 +155,7 @@ export const animation = defineTool({
           libraries: Record<string, string[]>;
           animation_count: number;
         }>('get_animation_player_info', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_details': {
         const result = await godot.sendCommand<{
@@ -175,7 +176,7 @@ export const animation = defineTool({
           node_path: args.node_path,
           animation_name: args.animation_name,
         });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_keyframes': {
         const result = await godot.sendCommand<{
@@ -195,7 +196,7 @@ export const animation = defineTool({
           animation_name: args.animation_name,
           track_index: args.track_index,
         });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'play': {
         const result = await godot.sendCommand<{ playing: string; from_position: number }>(

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition, ImageContent, Vector3 } from '../core/types.js';
 
 interface ScreenshotResponse {
@@ -114,7 +115,7 @@ export const editor = defineTool({
           camera?: CameraInfo;
           viewport_2d?: Viewport2DInfo;
         }>('get_editor_state');
-        return JSON.stringify(result);
+        return structured(result);
       }
 
       case 'get_selection': {
@@ -153,7 +154,7 @@ export const editor = defineTool({
         if (result.returned_count === 0) {
           return 'No log messages';
         }
-        return JSON.stringify(result);
+        return structured(result);
       }
 
       case 'get_stack_trace': {
@@ -167,7 +168,7 @@ export const editor = defineTool({
         if (!result.error && result.frames.length === 0) {
           return 'No stack trace available';
         }
-        return JSON.stringify(result);
+        return structured(result);
       }
 
       case 'screenshot_game': {

--- a/server/src/tools/node.ts
+++ b/server/src/tools/node.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 const propertiesField = z
@@ -98,7 +99,7 @@ export const node = defineTool({
         const result = await godot.sendCommand<{
           properties: Record<string, unknown>;
         }>('get_node_properties', { node_path: args.node_path });
-        return JSON.stringify(result.properties);
+        return structured(result.properties);
       }
 
       case 'find': {

--- a/server/src/tools/profiler.ts
+++ b/server/src/tools/profiler.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 interface FrameEntry {
@@ -190,7 +191,7 @@ export const profiler = defineTool({
         const result = await godot.sendCommand<Record<string, number | string>>(
           'get_performance_metrics'
         );
-        return JSON.stringify(result);
+        return structured(result);
       }
 
       case 'start': {
@@ -208,7 +209,7 @@ export const profiler = defineTool({
         const { frames } = result;
 
         if (frames.length === 0) {
-          return JSON.stringify({
+          return structured({
             active: result.active,
             frame_count: 0,
             message: 'No frames collected. Start the profiler first with action: start',
@@ -228,7 +229,7 @@ export const profiler = defineTool({
 
         const frameBudget = computeFrameBudget(frameTimeStats, targetFps);
 
-        return JSON.stringify({
+        return structured({
           active: result.active,
           frame_count: result.frame_count,
           total_frames_collected: result.total_frames_collected,

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition } from '../core/types.js';
 import { getServerVersion } from '../version.js';
 
@@ -39,7 +40,7 @@ export const project = defineTool({
           godot_version: string;
           main_scene: string | null;
         }>('get_project_info');
-        return JSON.stringify(result);
+        return structured(result);
       }
 
       case 'get_settings': {
@@ -49,14 +50,14 @@ export const project = defineTool({
           category: args.category,
           include_builtin: args.include_builtin,
         });
-        return JSON.stringify(result.settings);
+        return structured(result.settings);
       }
 
       case 'addon_status': {
         const serverVersion = getServerVersion();
 
         if (!godot.isConnected) {
-          return JSON.stringify(
+          return structured(
             {
               connected: false,
               server_version: serverVersion,
@@ -70,7 +71,7 @@ export const project = defineTool({
         const projectPath = godot.projectPath;
         const versionsMatch = godot.versionsMatch;
 
-        return JSON.stringify(
+        return structured(
           {
             connected: true,
             server_version: serverVersion,

--- a/server/src/tools/resource.ts
+++ b/server/src/tools/resource.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 interface ResourceInfoResult {
@@ -8,6 +9,17 @@ interface ResourceInfoResult {
   type_specific?: Record<string, unknown>;
   properties?: Record<string, unknown>;
 }
+
+// Output shape for get_info. Loose so type-specific payloads (SpriteFrames,
+// TileSet, Texture2D, etc.) pass through without over-constraining clients.
+const ResourceInfoOutput = z
+  .object({
+    resource_path: z.string(),
+    resource_type: z.string(),
+    type_specific: z.record(z.string(), z.unknown()).optional(),
+    properties: z.record(z.string(), z.unknown()).optional(),
+  })
+  .loose();
 
 const ResourceSchema = z.discriminatedUnion('action', [
   z.object({
@@ -34,6 +46,7 @@ export const resource = defineTool({
   description:
     'Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.',
   schema: ResourceSchema,
+  outputSchema: ResourceInfoOutput,
   async execute(args: ResourceArgs, { godot }) {
     switch (args.action) {
       case 'get_info': {
@@ -45,7 +58,7 @@ export const resource = defineTool({
             include_internal: args.include_internal ?? false,
           }
         );
-        return JSON.stringify(result);
+        return structured(result);
       }
     }
   },

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 const Vector2iSchema = z.object({
@@ -95,19 +96,19 @@ export const tilemap = defineTool({
       }
       case 'get_info': {
         const result = await godot.sendCommand('get_tilemap_layer_info', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_tileset_info': {
         const result = await godot.sendCommand('get_tileset_info', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_used_cells': {
         const result = await godot.sendCommand('get_used_cells', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_cell': {
         const result = await godot.sendCommand('get_cell', { node_path: args.node_path, coords: args.coords });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_cells_in_region': {
         const result = await godot.sendCommand('get_cells_in_region', {
@@ -115,7 +116,7 @@ export const tilemap = defineTool({
           min_coords: args.min_coords,
           max_coords: args.max_coords,
         });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'convert_coords': {
         const result = await godot.sendCommand('convert_coords', {
@@ -123,7 +124,7 @@ export const tilemap = defineTool({
           local_position: args.local_position,
           map_coords: args.map_coords,
         });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'set_cell': {
         const result = await godot.sendCommand<{
@@ -234,23 +235,23 @@ export const gridmap = defineTool({
       }
       case 'get_info': {
         const result = await godot.sendCommand('get_gridmap_info', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_meshlib_info': {
         const result = await godot.sendCommand('get_meshlib_info', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_used_cells': {
         const result = await godot.sendCommand('get_gridmap_used_cells', { node_path: args.node_path });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_cell': {
         const result = await godot.sendCommand('get_gridmap_cell', { node_path: args.node_path, coords: args.coords });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'get_cells_by_item': {
         const result = await godot.sendCommand('get_cells_by_item', { node_path: args.node_path, item: args.item });
-        return JSON.stringify(result);
+        return structured(result);
       }
       case 'set_cell': {
         const result = await godot.sendCommand<{


### PR DESCRIPTION
Closes #190.

## What

Query/read actions now return their payload as MCP `structuredContent` in addition to the existing text content. This is purely additive — clients that support structured output consume the object directly; clients that don't fall back to the text rendering, so nothing breaks.

- **`StructuredToolResult` + `structured()` helper** (`core/structured.ts`): pairs compact-JSON text with the object. Query branches return `structured(data)` instead of `JSON.stringify(data)`. Touched: `editor` (get_editor_state, get_log_messages, get_stack_trace), `node` (get_properties), `project` (get_info, get_settings, addon_status), `profiler` (snapshot, get_data), `resource` (get_info), `animation` (info/details/keyframes), `tilemap`/`gridmap` (get_* actions). Mutating actions keep returning plain summary strings.
- **CallTool handler** attaches `structuredContent` when a tool returns one; string and image results are unchanged.
- **`outputSchema`** is plumbed through `defineTool` and advertised in `tools/list`. `godot_resource` declares one — its single `get_info` action has a stable shape. The schema is `.loose()` so type-specific payloads (SpriteFrames, TileSet, Texture2D, ...) pass through without over-constraining clients. Multi-action tools with heterogeneous query shapes deliberately don't declare a single `outputSchema`.

Tools that already return composed prose (`scene3d`, `docs`) are untouched — they never embedded JSON.

## Why

Lets structured clients skip re-parsing JSON out of prose, and advertises a real output contract where one exists. Builds on the discriminated-union (stable schemas) and compact-JSON PRs.

## Verification

- `npm run build` clean
- `npm test` — 197 passing (added `core/structured-output.test.ts`, 9 tests covering the helper, the `outputSchema` advertisement, and resource's structured result + text fallback; existing query tests now read `structuredContent` via a `structuredOf` helper)
- `npm run generate-docs` — no doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)