### PR TITLE
feat: JPEG screenshots with quality param and 1024px default

### DIFF
--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -21,7 +21,8 @@ Control the Godot editor: get state, manage selection, run/stop project, capture
 | `scene_path` | string | No | Scene to run (optional, defaults to main scene) |
 | `clear` | boolean | No | Clear buffer after reading |
 | `limit` | integer | No | Maximum number of messages to return (default: 50) |
-| `max_width` | number | No | Maximum width in pixels for the screenshot |
+| `max_width` | integer | No | Maximum width in pixels (default: 1024) |
+| `quality` | integer | No | JPEG quality 1-100 (default: 75) |
 | `viewport` | `2d`, `3d` | No | Which editor viewport to capture |
 | `center_x` | number | No | X coordinate to center the 2D viewport on |
 | `center_y` | number | No | Y coordinate to center the 2D viewport on |

--- a/godot/addons/godot_mcp/commands/screenshot_commands.gd
+++ b/godot/addons/godot_mcp/commands/screenshot_commands.gd
@@ -2,7 +2,8 @@
 extends MCPBaseCommand
 class_name MCPScreenshotCommands
 
-const DEFAULT_MAX_WIDTH := 1920
+const DEFAULT_MAX_WIDTH := 1024
+const DEFAULT_JPEG_QUALITY := 75
 const SCREENSHOT_TIMEOUT := 5.0
 
 var _screenshot_result: Dictionary = {}
@@ -21,6 +22,7 @@ func capture_game_screenshot(params: Dictionary) -> Dictionary:
 		return _error("NOT_RUNNING", "No game is currently running. Use run_project first.")
 
 	var max_width: int = params.get("max_width", DEFAULT_MAX_WIDTH)
+	var quality: float = params.get("quality", DEFAULT_JPEG_QUALITY) / 100.0
 
 	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
 	if debugger_plugin == null:
@@ -33,7 +35,7 @@ func capture_game_screenshot(params: Dictionary) -> Dictionary:
 	_screenshot_result = {}
 
 	debugger_plugin.screenshot_received.connect(_on_screenshot_received, CONNECT_ONE_SHOT)
-	debugger_plugin.request_screenshot(max_width)
+	debugger_plugin.request_screenshot(max_width, quality)
 
 	var start_time := Time.get_ticks_msec()
 	while _screenshot_pending:
@@ -62,6 +64,7 @@ func _on_screenshot_received(success: bool, image_base64: String, width: int, he
 func capture_editor_screenshot(params: Dictionary) -> Dictionary:
 	var viewport_type: String = params.get("viewport", "")
 	var max_width: int = params.get("max_width", DEFAULT_MAX_WIDTH)
+	var quality: float = params.get("quality", DEFAULT_JPEG_QUALITY) / 100.0
 
 	var viewport: SubViewport = null
 
@@ -76,10 +79,10 @@ func capture_editor_screenshot(params: Dictionary) -> Dictionary:
 		return _error("NO_VIEWPORT", "Could not find editor viewport")
 
 	var image := viewport.get_texture().get_image()
-	return _process_and_encode_image(image, max_width)
+	return _process_and_encode_image(image, max_width, quality)
 
 
-func _process_and_encode_image(image: Image, max_width: int) -> Dictionary:
+func _process_and_encode_image(image: Image, max_width: int, quality: float = 0.75) -> Dictionary:
 	if image == null:
 		return _error("CAPTURE_FAILED", "Failed to capture image from viewport")
 
@@ -88,8 +91,8 @@ func _process_and_encode_image(image: Image, max_width: int) -> Dictionary:
 		var new_height := int(image.get_height() * scale_factor)
 		image.resize(max_width, new_height, Image.INTERPOLATE_LANCZOS)
 
-	var png_buffer := image.save_png_to_buffer()
-	var base64 := Marshalls.raw_to_base64(png_buffer)
+	var jpg_buffer := image.save_jpg_to_buffer(quality)
+	var base64 := Marshalls.raw_to_base64(jpg_buffer)
 
 	return _success({
 		"image_base64": base64,

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -97,14 +97,14 @@ func has_active_session() -> bool:
 	return true
 
 
-func request_screenshot(max_width: int = 1920) -> void:
+func request_screenshot(max_width: int = 1024, quality: float = 0.75) -> void:
 	if _active_session_id < 0:
 		screenshot_received.emit(false, "", 0, 0, "No active game session")
 		return
 	_pending_screenshot = true
 	var session := get_session(_active_session_id)
 	if session:
-		session.send_message("godot_mcp:take_screenshot", [max_width])
+		session.send_message("godot_mcp:take_screenshot", [max_width, quality])
 	else:
 		_pending_screenshot = false
 		screenshot_received.emit(false, "", 0, 0, "Could not get debugger session")

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1,7 +1,8 @@
 extends Node
 class_name MCPGameBridge
 
-const DEFAULT_MAX_WIDTH := 1920
+const DEFAULT_MAX_WIDTH := 1024
+const DEFAULT_JPEG_QUALITY := 0.75
 
 var _logger: _MCPGameLogger
 var _profiler: MCPFrameProfiler
@@ -94,11 +95,12 @@ func _on_debugger_message(message: String, data: Array) -> bool:
 
 func _take_screenshot_deferred(data: Array) -> void:
 	var max_width: int = data[0] if data.size() > 0 else DEFAULT_MAX_WIDTH
+	var quality: float = data[1] if data.size() > 1 else DEFAULT_JPEG_QUALITY
 	await RenderingServer.frame_post_draw
-	_capture_and_send_screenshot(max_width)
+	_capture_and_send_screenshot(max_width, quality)
 
 
-func _capture_and_send_screenshot(max_width: int) -> void:
+func _capture_and_send_screenshot(max_width: int, quality: float = DEFAULT_JPEG_QUALITY) -> void:
 	var viewport := get_viewport()
 	if viewport == null:
 		_send_screenshot_error("NO_VIEWPORT", "Could not get game viewport")
@@ -111,8 +113,8 @@ func _capture_and_send_screenshot(max_width: int) -> void:
 		var scale_factor := float(max_width) / float(image.get_width())
 		var new_height := int(image.get_height() * scale_factor)
 		image.resize(max_width, new_height, Image.INTERPOLATE_LANCZOS)
-	var png_buffer := image.save_png_to_buffer()
-	var base64 := Marshalls.raw_to_base64(png_buffer)
+	var jpg_buffer := image.save_jpg_to_buffer(quality)
+	var base64 := Marshalls.raw_to_base64(jpg_buffer)
 	EngineDebugger.send_message("godot_mcp:screenshot_result", [
 		true,
 		base64,

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -123,7 +123,7 @@ describe('editor tool', () => {
       const ctx = createToolContext(mock);
 
       const result = await editor.execute({ action: 'screenshot_game' }, ctx);
-      expect(result).toEqual({ type: 'image', data: base64, mimeType: 'image/png' });
+      expect(result).toEqual({ type: 'image', data: base64, mimeType: 'image/jpeg' });
     });
 
     it('passes viewport and max_width params for editor screenshot', async () => {

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -30,7 +30,7 @@ function toImageContent(base64: string): ImageContent {
   return {
     type: 'image',
     data: base64,
-    mimeType: 'image/png',
+    mimeType: 'image/jpeg',
   };
 }
 
@@ -54,13 +54,15 @@ const EditorSchema = z
     }),
     z.object({ action: z.literal('get_stack_trace').describe('Get the most recent error stack trace') }),
     z.object({
-      action: z.literal('screenshot_game').describe('Capture a screenshot of the running game'),
-      max_width: z.number().optional().describe('Maximum width in pixels for the screenshot'),
+      action: z.literal('screenshot_game').describe('Capture a JPEG screenshot of the running game'),
+      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 1024)'),
+      quality: z.number().int().min(1).max(100).optional().describe('JPEG quality 1-100 (default: 75)'),
     }),
     z.object({
-      action: z.literal('screenshot_editor').describe('Capture a screenshot of an editor viewport'),
+      action: z.literal('screenshot_editor').describe('Capture a JPEG screenshot of an editor viewport'),
       viewport: z.enum(['2d', '3d']).optional().describe('Which editor viewport to capture'),
-      max_width: z.number().optional().describe('Maximum width in pixels for the screenshot'),
+      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 1024)'),
+      quality: z.number().int().min(1).max(100).optional().describe('JPEG quality 1-100 (default: 75)'),
     }),
     z.object({
       action: z.literal('set_viewport_2d').describe('Center and zoom the 2D editor viewport'),
@@ -174,7 +176,7 @@ export const editor = defineTool({
       case 'screenshot_game': {
         const result = await godot.sendCommand<ScreenshotResponse>(
           'capture_game_screenshot',
-          { max_width: args.max_width }
+          { max_width: args.max_width, quality: args.quality }
         );
         return toImageContent(result.image_base64);
       }
@@ -182,7 +184,7 @@ export const editor = defineTool({
       case 'screenshot_editor': {
         const result = await godot.sendCommand<ScreenshotResponse>(
           'capture_editor_screenshot',
-          { viewport: args.viewport, max_width: args.max_width }
+          { viewport: args.viewport, max_width: args.max_width, quality: args.quality }
         );
         return toImageContent(result.image_base64);
       }


### PR DESCRIPTION
Closes #188.

Drops the screenshot default from 1920px PNG to 1024px JPEG across both capture paths (game bridge and editor viewport).

## Why this matters

Screenshots are the dominant cost in godot-mcp usage — the original telemetry averaged ~369 KB per call across 357 calls, all PNG at 1920px. That base64 string goes straight into your context window on every screenshot call.

Measured on a live Godot 3D viewport (1024px, quality 75):

| | Size | Vision tokens (approx) |
|---|---|---|
| Before (PNG, 1920px) | ~369 KB avg | ~12 tiles (~2100 tokens) |
| After (JPEG, 1024px) | ~42 KB on this scene | ~4 tiles (~700 tokens) |
| **Reduction** | **~9x bytes** | **~3x tokens** |

Real game frames with more texture will land higher than the empty-viewport 42 KB, but still a substantial drop vs PNG at 1920px. For API users on tight context or usage budgets this is meaningful on every single screenshot call.

The `quality` param (1-100, default 75) lets you tune further -- drop to 50 for another ~2x if you just need to read rough game state, or push to 90 if you need to read fine text.

## What changed

**Addon (GDScript):**
- `game_bridge/mcp_game_bridge.gd`: `save_jpg_to_buffer(quality)` instead of `save_png_to_buffer()`; `DEFAULT_MAX_WIDTH` 1920 → 1024; quality forwarded from the `take_screenshot` message
- `commands/screenshot_commands.gd`: same JPEG switch for editor screenshots; reads `quality` param (int 1-100), converts to float 0.0-1.0 for `save_jpg_to_buffer`
- `core/mcp_debugger_plugin.gd`: `request_screenshot` adds `quality` float param, passes it through in the session message

**Server:**
- `editor.ts`: `mimeType` `image/png` → `image/jpeg`; `quality` int param (1-100, default 75) added to `screenshot_game` and `screenshot_editor` actions; `max_width` type tightened to int

197 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)