### PR TITLE
feat: runtime_state tool (digest + state-over-time + selection tiers)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) server for Godot Engine integration.
 
 ## Overview
 
-This server provides **12 tools** and **3 resources** for AI-assisted Godot development.
+This server provides **13 tools** and **3 resources** for AI-assisted Godot development.
 
 ## Quick Links
 
@@ -27,6 +27,7 @@ This server provides **12 tools** and **3 resources** for AI-assisted Godot deve
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |
 | [Input](tools/input.md) | 1 | Input injection for testing running games (action-based, no mouse/coordinates yet) |
 | [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
+| [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots. |
 
 ## Installation
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -69,3 +69,9 @@ Performance profiling: snapshots, per-frame time series with spike detection, ac
 
 - `godot_profiler` - Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections
 
+## [Runtime State](runtime-state.md)
+
+Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.
+
+- `godot_runtime_state` - Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
+

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -1,0 +1,66 @@
+# Runtime State Tools
+
+Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.
+
+## Tools
+
+- [godot_runtime_state](#godot_runtime_state)
+
+---
+
+## godot_runtime_state
+
+Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `digest`, `watch_start`, `watch_collect`, `watch_stop` | Yes |  |
+| `select` | `group`, `method`, `auto` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → visible CanvasItems) |
+| `group` | string | No | Group name to use when select="group" or "auto" (default: "mcp_watch") |
+| `name` | string | No | Glob filter on node name (e.g. "Player*") |
+| `type` | string | No | Class filter (e.g. "CharacterBody2D") |
+| `max_nodes` | integer | No | Maximum nodes in result (default: 40) |
+| `include` | string[] | No | Subset of fields to include (default: all available) |
+| `specs` | object[] | No | Which nodes and fields to watch |
+| `hz` | integer | No | Sample rate in Hz (default: 20) |
+| `duration_ms` | integer | No | Auto-stop after this many milliseconds (default: 1000) |
+
+### Actions
+
+#### `digest`
+
+#### `watch_start`
+
+#### `watch_collect`
+
+#### `watch_stop`
+
+### Examples
+
+```json
+// digest
+{
+  "action": "digest"
+}
+```
+
+```json
+// watch_start
+{
+  "action": "watch_start"
+}
+```
+
+```json
+// watch_collect
+{
+  "action": "watch_collect"
+}
+```
+
+*1 more actions available: `watch_stop`*
+
+---
+

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -21,6 +21,7 @@ func setup(plugin: EditorPlugin) -> void:
 	_register_handler(MCPScene3DCommands.new(), plugin)
 	_register_handler(MCPInputCommands.new(), plugin)
 	_register_handler(MCPProfilerCommands.new(), plugin)
+	_register_handler(MCPRuntimeStateCommands.new(), plugin)
 
 
 func _register_handler(handler: MCPBaseCommand, plugin: EditorPlugin) -> void:

--- a/godot/addons/godot_mcp/commands/runtime_state_commands.gd
+++ b/godot/addons/godot_mcp/commands/runtime_state_commands.gd
@@ -2,6 +2,9 @@
 extends MCPBaseCommand
 class_name MCPRuntimeStateCommands
 
+const GENERIC_TIMEOUT := 5.0
+var _last_error: Dictionary = {}
+
 
 func get_commands() -> Dictionary:
 	return {
@@ -49,3 +52,31 @@ func watch_stop(_params: Dictionary) -> Dictionary:
 	if result is Dictionary:
 		return _success(result)
 	return _success({"stopped": true})
+
+
+func _send_and_wait(msg_type: String, args: Array = []):
+	if not EditorInterface.is_playing_scene():
+		_last_error = _error("NOT_RUNNING", "No game is currently running")
+		return null
+
+	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
+	if debugger_plugin == null or not debugger_plugin.has_active_session():
+		_last_error = _error("NO_SESSION", "No active debug session")
+		return null
+
+	var sent: bool = debugger_plugin.send_game_message(msg_type, args)
+	if not sent:
+		_last_error = _error("SEND_FAILED", "Failed to send message to game")
+		return null
+
+	var start_time := Time.get_ticks_msec()
+	while not debugger_plugin.has_response(msg_type):
+		await Engine.get_main_loop().process_frame
+		if (Time.get_ticks_msec() - start_time) / 1000.0 > GENERIC_TIMEOUT:
+			debugger_plugin.clear_response(msg_type)
+			_last_error = _error("TIMEOUT", "Timed out waiting for %s response" % msg_type)
+			return null
+
+	var response = debugger_plugin.get_response(msg_type)
+	debugger_plugin.clear_response(msg_type)
+	return response

--- a/godot/addons/godot_mcp/commands/runtime_state_commands.gd
+++ b/godot/addons/godot_mcp/commands/runtime_state_commands.gd
@@ -1,0 +1,51 @@
+@tool
+extends MCPBaseCommand
+class_name MCPRuntimeStateCommands
+
+
+func get_commands() -> Dictionary:
+	return {
+		"get_runtime_state": get_runtime_state,
+		"watch_start": watch_start,
+		"watch_collect": watch_collect,
+		"watch_stop": watch_stop,
+	}
+
+
+func get_runtime_state(params: Dictionary) -> Dictionary:
+	var result = await _send_and_wait("get_runtime_state", [params])
+	if result == null:
+		return _last_error
+	if result is Dictionary:
+		return _success(result)
+	return _success({"data": result})
+
+
+func watch_start(params: Dictionary) -> Dictionary:
+	var specs: Array = params.get("specs", [])
+	var hz: int = params.get("hz", 20)
+	var duration_ms: int = params.get("duration_ms", 1000)
+	var result = await _send_and_wait("watch_start", [specs, hz, duration_ms])
+	if result == null:
+		return _last_error
+	if result is Dictionary:
+		return _success(result)
+	return _success({"started": true})
+
+
+func watch_collect(_params: Dictionary) -> Dictionary:
+	var result = await _send_and_wait("watch_collect", [])
+	if result == null:
+		return _last_error
+	if result is Dictionary:
+		return _success(result)
+	return _success({"data": result})
+
+
+func watch_stop(_params: Dictionary) -> Dictionary:
+	var result = await _send_and_wait("watch_stop", [])
+	if result == null:
+		return _last_error
+	if result is Dictionary:
+		return _success(result)
+	return _success({"stopped": true})

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -6,6 +6,7 @@ const DEFAULT_JPEG_QUALITY := 0.75
 
 var _logger: _MCPGameLogger
 var _profiler: MCPFrameProfiler
+var _sampler: MCPRuntimeStateSampler
 
 
 func _ready() -> void:
@@ -15,6 +16,8 @@ func _ready() -> void:
 	OS.add_logger(_logger)
 	_profiler = MCPFrameProfiler.new()
 	EngineDebugger.register_profiler("mcp_frame_profiler", _profiler)
+	_sampler = MCPRuntimeStateSampler.new()
+	add_child(_sampler)
 	EngineDebugger.register_message_capture("godot_mcp", _on_debugger_message)
 	MCPLog.info("Game bridge initialized")
 
@@ -89,6 +92,18 @@ func _on_debugger_message(message: String, data: Array) -> bool:
 			return true
 		"get_signal_connections":
 			_handle_get_signal_connections(data)
+			return true
+		"get_runtime_state":
+			_handle_get_runtime_state(data)
+			return true
+		"watch_start":
+			_handle_watch_start(data)
+			return true
+		"watch_collect":
+			_handle_watch_collect()
+			return true
+		"watch_stop":
+			_handle_watch_stop()
 			return true
 	return false
 
@@ -374,6 +389,272 @@ func _node_path_string(node: Node, scene_root: Node) -> String:
 	if relative != NodePath("."):
 		path += "/" + str(relative)
 	return path
+
+
+func _handle_get_runtime_state(data: Array) -> void:
+	var params: Dictionary = data[0] if data.size() > 0 and data[0] is Dictionary else {}
+
+	var tree := get_tree()
+	var scene_root := tree.current_scene if tree else null
+	if not scene_root:
+		EngineDebugger.send_message("godot_mcp:game_response", ["get_runtime_state", {
+			"scene": "",
+			"selection": "fallback",
+			"entity_count": 0,
+			"entities": [],
+			"hint": "No scene is currently running.",
+		}])
+		return
+
+	var select_mode: String = params.get("select", "auto")
+	var group_name: String = params.get("group", "mcp_watch")
+	var name_filter: String = params.get("name", "")
+	var type_filter: String = params.get("type", "")
+	var max_nodes: int = params.get("max_nodes", 40)
+	var include_fields: Array = params.get("include", [])
+	max_nodes = clampi(max_nodes, 1, 200)
+
+	# Resolve camera for on-screen checks
+	var camera_2d: Camera2D = _find_camera_2d()
+	var camera_viewport_rect := Rect2()
+	if camera_2d:
+		camera_viewport_rect = camera_2d.get_viewport_rect()
+
+	# Determine which selection tier to use
+	var actual_selection: String = select_mode
+	if select_mode == "auto":
+		if _has_group_members(scene_root, group_name):
+			actual_selection = "group"
+		elif _has_mcp_state_nodes(scene_root):
+			actual_selection = "method"
+		else:
+			actual_selection = "fallback"
+
+	# Collect entities
+	var entities: Array = []
+	_collect_runtime_state(scene_root, scene_root, actual_selection, group_name,
+		name_filter, type_filter, include_fields, camera_2d, camera_viewport_rect,
+		max_nodes, entities)
+
+	# Extract camera entity separately if present
+	var camera_entity = null
+	var cam_node := _find_camera_2d() if actual_selection != "fallback" else camera_2d
+	if cam_node:
+		camera_entity = {
+			"type": "Camera2D",
+			"pos": {"x": snapped(cam_node.global_position.x, 0.01), "y": snapped(cam_node.global_position.y, 0.01)},
+			"zoom": {"x": snapped(cam_node.zoom.x, 0.01), "y": snapped(cam_node.zoom.y, 0.01)},
+			"camera": true,
+		}
+
+	var hint := ""
+	if actual_selection == "fallback":
+		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected. " +
+			"Add nodes to the '%s' group or implement `func _mcp_state() -> Dictionary` " +
+			"on key nodes for richer, targeted state data.") % [group_name, group_name]
+
+	var result: Dictionary = {
+		"scene": scene_root.scene_file_path,
+		"selection": actual_selection,
+		"entity_count": entities.size(),
+		"entities": entities,
+	}
+	if camera_entity:
+		result["camera"] = camera_entity
+	if not hint.is_empty():
+		result["hint"] = hint
+
+	EngineDebugger.send_message("godot_mcp:game_response", ["get_runtime_state", result])
+
+
+func _has_group_members(scene_root: Node, group_name: String) -> bool:
+	var tree := get_tree()
+	if tree == null:
+		return false
+	return tree.get_nodes_in_group(group_name).size() > 0
+
+
+func _has_mcp_state_nodes(node: Node) -> bool:
+	if node.has_method("_mcp_state"):
+		return true
+	for child in node.get_children():
+		if _has_mcp_state_nodes(child):
+			return true
+	return false
+
+
+func _collect_runtime_state(node: Node, scene_root: Node, selection: String, group_name: String,
+		name_filter: String, type_filter: String, include_fields: Array,
+		camera_2d: Camera2D, viewport_rect: Rect2,
+		max_nodes: int, results: Array) -> void:
+	if results.size() >= max_nodes:
+		return
+
+	var include_node := false
+	match selection:
+		"group":
+			include_node = node.is_in_group(group_name)
+		"method":
+			include_node = node.has_method("_mcp_state")
+		"fallback":
+			include_node = (node is CanvasItem and (node as CanvasItem).is_visible_in_tree())
+
+	if include_node:
+		if not name_filter.is_empty() and not node.name.matchn(name_filter):
+			include_node = false
+		if not type_filter.is_empty() and not node.is_class(type_filter):
+			include_node = false
+
+	if include_node:
+		var entity := _extract_node_state(node, scene_root, include_fields, camera_2d, viewport_rect)
+		if entity != null:
+			results.append(entity)
+
+	for child in node.get_children():
+		if results.size() >= max_nodes:
+			return
+		_collect_runtime_state(child, scene_root, selection, group_name,
+			name_filter, type_filter, include_fields, camera_2d, viewport_rect,
+			max_nodes, results)
+
+
+func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
+		camera_2d: Camera2D, viewport_rect: Rect2) -> Dictionary:
+	var want := include_fields.is_empty()
+	var want_transform := want or include_fields.has("transform")
+	var want_velocity := want or include_fields.has("velocity")
+	var want_anim := want or include_fields.has("anim")
+	var want_groups := want or include_fields.has("groups")
+	var want_onscreen := want or include_fields.has("onscreen")
+	var want_state := want or include_fields.has("state")
+
+	var entity: Dictionary = {
+		"path": _node_path_string(node, scene_root),
+		"type": node.get_class(),
+	}
+
+	if want_groups:
+		var groups := node.get_groups().filter(func(g): return not g.begins_with("_"))
+		if not groups.is_empty():
+			entity["groups"] = groups
+
+	if want_transform and node is Node2D:
+		var n2d := node as Node2D
+		entity["pos"] = {"x": snapped(n2d.global_position.x, 0.01), "y": snapped(n2d.global_position.y, 0.01)}
+		entity["rot"] = snapped(rad_to_deg(n2d.global_rotation), 0.01)
+		if n2d.scale != Vector2.ONE:
+			entity["scale"] = {"x": snapped(n2d.scale.x, 0.01), "y": snapped(n2d.scale.y, 0.01)}
+
+	if want_transform and node is Node3D:
+		var n3d := node as Node3D
+		entity["pos"] = {
+			"x": snapped(n3d.global_position.x, 0.01),
+			"y": snapped(n3d.global_position.y, 0.01),
+			"z": snapped(n3d.global_position.z, 0.01),
+		}
+		entity["rot"] = {
+			"x": snapped(rad_to_deg(n3d.global_rotation.x), 0.01),
+			"y": snapped(rad_to_deg(n3d.global_rotation.y), 0.01),
+			"z": snapped(rad_to_deg(n3d.global_rotation.z), 0.01),
+		}
+
+	if want_velocity:
+		if node is CharacterBody2D:
+			var v := (node as CharacterBody2D).velocity
+			entity["vel"] = {"x": snapped(v.x, 0.01), "y": snapped(v.y, 0.01)}
+		elif node is RigidBody2D:
+			var v := (node as RigidBody2D).linear_velocity
+			entity["vel"] = {"x": snapped(v.x, 0.01), "y": snapped(v.y, 0.01)}
+			entity["angvel"] = snapped((node as RigidBody2D).angular_velocity, 0.01)
+		elif node is CharacterBody3D:
+			var v := (node as CharacterBody3D).velocity
+			entity["vel"] = {"x": snapped(v.x, 0.01), "y": snapped(v.y, 0.01), "z": snapped(v.z, 0.01)}
+		elif node is RigidBody3D:
+			var v := (node as RigidBody3D).linear_velocity
+			entity["vel"] = {"x": snapped(v.x, 0.01), "y": snapped(v.y, 0.01), "z": snapped(v.z, 0.01)}
+			var av := (node as RigidBody3D).angular_velocity
+			entity["angvel"] = {"x": snapped(av.x, 0.01), "y": snapped(av.y, 0.01), "z": snapped(av.z, 0.01)}
+
+	if want_anim:
+		if node is AnimationPlayer:
+			var ap := node as AnimationPlayer
+			entity["anim"] = ap.current_animation
+			entity["anim_pos"] = snapped(ap.current_animation_position, 0.01)
+			entity["playing"] = ap.is_playing()
+		elif node is AnimatedSprite2D:
+			var asp := node as AnimatedSprite2D
+			entity["anim"] = asp.animation
+			entity["anim_frame"] = asp.frame
+
+	if want_onscreen and camera_2d and node is Node2D:
+		var pos := (node as Node2D).global_position
+		entity["onscreen"] = viewport_rect.has_point(pos)
+
+	if want_state and node.has_method("_mcp_state"):
+		var raw_state = node._mcp_state()
+		if raw_state is Dictionary:
+			var serialized := _serialize_mcp_state(raw_state)
+			if not serialized.is_empty():
+				entity["state"] = serialized
+
+	return entity
+
+
+const _MCP_STATE_MAX_BYTES := 1024
+
+
+func _serialize_mcp_state(state: Dictionary) -> Dictionary:
+	var result: Dictionary = {}
+	for key in state:
+		var val = state[key]
+		match typeof(val):
+			TYPE_BOOL, TYPE_STRING:
+				result[str(key)] = val
+			TYPE_INT:
+				result[str(key)] = int(val)
+			TYPE_FLOAT:
+				result[str(key)] = snapped(float(val), 0.01)
+			TYPE_ARRAY:
+				result[str(key)] = val
+			TYPE_DICTIONARY:
+				result[str(key)] = val
+		# skip non-serializable types (Objects, NodePaths, RIDs, etc.)
+	# Rough byte cap: convert to string and check length
+	if JSON.stringify(result).length() > _MCP_STATE_MAX_BYTES:
+		result["_truncated"] = true
+	return result
+
+
+func _find_camera_2d() -> Camera2D:
+	var viewport := get_viewport()
+	if viewport == null:
+		return null
+	return viewport.get_camera_2d()
+
+
+func _handle_watch_start(data: Array) -> void:
+	if _sampler == null:
+		EngineDebugger.send_message("godot_mcp:game_response", ["watch_start", {"started": false, "error": "Sampler not initialized"}])
+		return
+	var specs: Array = data[0] if data.size() > 0 else []
+	var hz: int = data[1] if data.size() > 1 else 20
+	var duration_ms: int = data[2] if data.size() > 2 else 1000
+	_sampler.start(specs, hz, duration_ms)
+	EngineDebugger.send_message("godot_mcp:game_response", ["watch_start", {"started": true}])
+
+
+func _handle_watch_collect() -> void:
+	if _sampler == null:
+		EngineDebugger.send_message("godot_mcp:game_response", ["watch_collect", {"window_ms": 0, "sample_count": 0, "fields": {}}])
+		return
+	EngineDebugger.send_message("godot_mcp:game_response", ["watch_collect", _sampler.collect()])
+
+
+func _handle_watch_stop() -> void:
+	if _sampler == null:
+		EngineDebugger.send_message("godot_mcp:game_response", ["watch_stop", {"window_ms": 0, "sample_count": 0, "fields": {}}])
+		return
+	EngineDebugger.send_message("godot_mcp:game_response", ["watch_stop", _sampler.stop()])
 
 
 class _MCPGameLogger extends Logger:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -526,6 +526,8 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 #   (2) static definition context needed to interpret them (puzzle clues, level layout, config)
 # An agent can observe (1) without (2) but cannot verify correctness without both.
 # Optionally include layout geometry (bounds, sizes) to enable programmatic layout checks.
+# Error handling: _mcp_state() runtime errors are non-fatal in GDScript (Godot prints them
+# and the call returns null); the `is Dictionary` check below handles that silently.
 func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 		camera_2d: Camera2D, viewport_rect: Rect2) -> Dictionary:
 	var want := include_fields.is_empty()
@@ -615,21 +617,26 @@ func _serialize_mcp_state(state: Dictionary) -> Dictionary:
 	var result: Dictionary = {}
 	for key in state:
 		var val = state[key]
+		var serializable = null
 		match typeof(val):
 			TYPE_BOOL, TYPE_STRING:
-				result[str(key)] = val
+				serializable = val
 			TYPE_INT:
-				result[str(key)] = int(val)
+				serializable = int(val)
 			TYPE_FLOAT:
-				result[str(key)] = snapped(float(val), 0.01)
+				serializable = snapped(float(val), 0.01)
 			TYPE_ARRAY:
-				result[str(key)] = val
+				serializable = val
 			TYPE_DICTIONARY:
-				result[str(key)] = val
-		# skip non-serializable types (Objects, NodePaths, RIDs, etc.)
-	# Rough byte cap: convert to string and check length
-	if JSON.stringify(result).length() > _MCP_STATE_MAX_BYTES:
-		result["_truncated"] = true
+				serializable = val
+			# skip non-serializable types (Objects, NodePaths, RIDs, etc.)
+		if serializable == null:
+			continue
+		result[str(key)] = serializable
+		if JSON.stringify(result).length() > _MCP_STATE_MAX_BYTES:
+			result.erase(str(key))
+			result["_truncated"] = true
+			break
 	return result
 
 
@@ -647,8 +654,11 @@ func _handle_watch_start(data: Array) -> void:
 	var specs: Array = data[0] if data.size() > 0 else []
 	var hz: int = data[1] if data.size() > 1 else 20
 	var duration_ms: int = data[2] if data.size() > 2 else 1000
-	_sampler.start(specs, hz, duration_ms)
-	EngineDebugger.send_message("godot_mcp:game_response", ["watch_start", {"started": true}])
+	var start_result := _sampler.start(specs, hz, duration_ms)
+	EngineDebugger.send_message("godot_mcp:game_response", ["watch_start", {
+		"started": true,
+		"resolved_fields": start_result.get("resolved_fields", 0),
+	}])
 
 
 func _handle_watch_collect() -> void:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -450,8 +450,11 @@ func _handle_get_runtime_state(data: Array) -> void:
 	var hint := ""
 	if actual_selection == "fallback":
 		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected. " +
-			"Add nodes to the '%s' group or implement `func _mcp_state() -> Dictionary` " +
-			"on key nodes for richer, targeted state data.") % [group_name, group_name]
+			"For richer data: add key nodes to the '%s' group, then implement " +
+			"`func _mcp_state() -> Dictionary` on them. " +
+			"In _mcp_state(), include both live runtime values (position, health, score) " +
+			"AND static definition context (puzzle clues, level config, item data) — " +
+			"an agent needs both to understand and verify game state.") % [group_name, group_name]
 
 	var result: Dictionary = {
 		"scene": scene_root.scene_file_path,
@@ -518,6 +521,11 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 			max_nodes, results)
 
 
+# _mcp_state() contract: return a Dictionary with two categories —
+#   (1) live runtime values that change during play (cursor pos, health, score, fill counts)
+#   (2) static definition context needed to interpret them (puzzle clues, level layout, config)
+# An agent can observe (1) without (2) but cannot verify correctness without both.
+# Optionally include layout geometry (bounds, sizes) to enable programmatic layout checks.
 func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 		camera_2d: Camera2D, viewport_rect: Rect2) -> Dictionary:
 	var want := include_fields.is_empty()

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -9,6 +9,7 @@ var _specs: Array = []       # [{node, fields: [{key, resolver}]}]
 var _hz: int = 20
 var _duration_ms: int = 1000
 var _start_time: int = 0
+var _stop_time: int = 0      # set on auto-stop or manual stop; 0 = still running
 var _frame_index: int = 0
 var _sample_interval: int = 1  # sample every N frames
 var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
@@ -48,6 +49,7 @@ func start(specs: Array, hz: int, duration_ms: int) -> void:
 		if not resolved_fields.is_empty():
 			_specs.append({"node": node, "node_path": node_path, "fields": resolved_fields})
 
+	_stop_time = 0
 	_active = true
 	set_process(true)
 
@@ -60,6 +62,7 @@ func _process(_delta: float) -> void:
 
 	if elapsed >= _duration_ms:
 		_active = false
+		_stop_time = Time.get_ticks_msec()
 		set_process(false)
 		return
 
@@ -87,7 +90,7 @@ func _process(_delta: float) -> void:
 
 
 func collect() -> Dictionary:
-	var elapsed := Time.get_ticks_msec() - _start_time
+	var elapsed := (_stop_time - _start_time) if _stop_time > 0 else (Time.get_ticks_msec() - _start_time)
 	var total_samples := 0
 	for key in _samples:
 		total_samples += (_samples[key] as Array).size()
@@ -100,6 +103,7 @@ func collect() -> Dictionary:
 
 func stop() -> Dictionary:
 	_active = false
+	_stop_time = Time.get_ticks_msec()
 	set_process(false)
 	return collect()
 

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -40,7 +40,7 @@ func start(specs: Array, hz: int, duration_ms: int) -> void:
 		for field_key in fields:
 			if field_count >= MAX_FIELDS:
 				break
-			var full_key := node_path + ":" + field_key
+			var full_key: String = node_path + ":" + str(field_key)
 			_samples[full_key] = []
 			resolved_fields.append({"key": field_key, "full_key": full_key})
 			field_count += 1

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -1,0 +1,203 @@
+extends Node
+class_name MCPRuntimeStateSampler
+
+const MAX_FIELDS := 32
+const MAX_SAMPLES_PER_FIELD := 200
+
+var _active: bool = false
+var _specs: Array = []       # [{node, fields: [{key, resolver}]}]
+var _hz: int = 20
+var _duration_ms: int = 1000
+var _start_time: int = 0
+var _frame_index: int = 0
+var _sample_interval: int = 1  # sample every N frames
+var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
+
+
+func start(specs: Array, hz: int, duration_ms: int) -> void:
+	_specs = []
+	_samples = {}
+	_hz = clampi(hz, 1, 60)
+	_duration_ms = clampi(duration_ms, 100, 5000)
+	_start_time = Time.get_ticks_msec()
+	_frame_index = 0
+	_sample_interval = max(1, int(Engine.get_frames_per_second() / _hz)) if Engine.get_frames_per_second() > 0 else max(1, int(60.0 / _hz))
+
+	var field_count := 0
+	for spec in specs:
+		if field_count >= MAX_FIELDS:
+			break
+		var node_path: String = spec.get("path", "")
+		var fields: Array = spec.get("fields", [])
+		if node_path.is_empty() or fields.is_empty():
+			continue
+
+		var node := _resolve_node(node_path)
+		if node == null:
+			continue
+
+		var resolved_fields: Array = []
+		for field_key in fields:
+			if field_count >= MAX_FIELDS:
+				break
+			var full_key := node_path + ":" + field_key
+			_samples[full_key] = []
+			resolved_fields.append({"key": field_key, "full_key": full_key})
+			field_count += 1
+
+		if not resolved_fields.is_empty():
+			_specs.append({"node": node, "node_path": node_path, "fields": resolved_fields})
+
+	_active = true
+	set_process(true)
+
+
+func _process(_delta: float) -> void:
+	if not _active:
+		return
+
+	var elapsed := Time.get_ticks_msec() - _start_time
+
+	if elapsed >= _duration_ms:
+		_active = false
+		set_process(false)
+		return
+
+	_frame_index += 1
+	if _frame_index % _sample_interval != 0:
+		return
+
+	for spec in _specs:
+		var node: Node = spec.node
+		if not is_instance_valid(node):
+			# node was freed — mark all fields and skip
+			for field_info in spec.fields:
+				var arr: Array = _samples.get(field_info.full_key, [])
+				if arr.size() < MAX_SAMPLES_PER_FIELD:
+					arr.append({"t_ms": elapsed, "value": "freed"})
+			continue
+
+		for field_info in spec.fields:
+			var value = _read_field(node, field_info.key)
+			if value == null:
+				continue
+			var arr: Array = _samples.get(field_info.full_key, [])
+			if arr.size() < MAX_SAMPLES_PER_FIELD:
+				arr.append({"t_ms": elapsed, "value": value})
+
+
+func collect() -> Dictionary:
+	var elapsed := Time.get_ticks_msec() - _start_time
+	var total_samples := 0
+	for key in _samples:
+		total_samples += (_samples[key] as Array).size()
+	return {
+		"window_ms": elapsed,
+		"sample_count": total_samples,
+		"fields": _samples.duplicate(true),
+	}
+
+
+func stop() -> Dictionary:
+	_active = false
+	set_process(false)
+	return collect()
+
+
+func is_active() -> bool:
+	return _active
+
+
+func _resolve_node(path: String) -> Node:
+	var tree := get_tree()
+	if tree == null:
+		return null
+	var scene_root := tree.current_scene
+	if scene_root == null:
+		return null
+
+	if path == "/root/" + scene_root.name or path == "/":
+		return scene_root
+
+	if path.begins_with("/root/"):
+		var parts := path.split("/")
+		# parts[0]="", parts[1]="root", parts[2]=scene_name, parts[3+]=relative
+		if parts.size() >= 3 and parts[2] == scene_root.name:
+			if parts.size() == 3:
+				return scene_root
+			var relative := "/".join(parts.slice(3))
+			return scene_root.get_node_or_null(relative)
+
+	return scene_root.get_node_or_null(path)
+
+
+func _read_field(node: Node, key: String) -> Variant:
+	match key:
+		"pos.x":
+			if node is Node2D:
+				return snapped((node as Node2D).global_position.x, 0.01)
+			if node is Node3D:
+				return snapped((node as Node3D).global_position.x, 0.01)
+		"pos.y":
+			if node is Node2D:
+				return snapped((node as Node2D).global_position.y, 0.01)
+			if node is Node3D:
+				return snapped((node as Node3D).global_position.y, 0.01)
+		"pos.z":
+			if node is Node3D:
+				return snapped((node as Node3D).global_position.z, 0.01)
+		"vel.x":
+			if node is CharacterBody2D:
+				return snapped((node as CharacterBody2D).velocity.x, 0.01)
+			if node is RigidBody2D:
+				return snapped((node as RigidBody2D).linear_velocity.x, 0.01)
+			if node is CharacterBody3D:
+				return snapped((node as CharacterBody3D).velocity.x, 0.01)
+			if node is RigidBody3D:
+				return snapped((node as RigidBody3D).linear_velocity.x, 0.01)
+		"vel.y":
+			if node is CharacterBody2D:
+				return snapped((node as CharacterBody2D).velocity.y, 0.01)
+			if node is RigidBody2D:
+				return snapped((node as RigidBody2D).linear_velocity.y, 0.01)
+			if node is CharacterBody3D:
+				return snapped((node as CharacterBody3D).velocity.y, 0.01)
+			if node is RigidBody3D:
+				return snapped((node as RigidBody3D).linear_velocity.y, 0.01)
+		"vel.z":
+			if node is CharacterBody3D:
+				return snapped((node as CharacterBody3D).velocity.z, 0.01)
+			if node is RigidBody3D:
+				return snapped((node as RigidBody3D).linear_velocity.z, 0.01)
+		"rot":
+			if node is Node2D:
+				return snapped(rad_to_deg((node as Node2D).global_rotation), 0.01)
+			if node is Node3D:
+				return snapped(rad_to_deg((node as Node3D).global_rotation.y), 0.01)
+		"anim":
+			if node is AnimationPlayer:
+				return (node as AnimationPlayer).current_animation
+			if node is AnimatedSprite2D:
+				return (node as AnimatedSprite2D).animation
+		"anim_frame":
+			if node is AnimatedSprite2D:
+				return (node as AnimatedSprite2D).frame
+
+	# Custom state fallback
+	if node.has_method("_mcp_state"):
+		var state = node._mcp_state()
+		if state is Dictionary and state.has(key):
+			var val = state[key]
+			if val is float or val is int:
+				return snapped(float(val), 0.01)
+			return val
+
+	# Generic property fallback
+	if key in node:
+		var val = node.get(key)
+		if val is float or val is int:
+			return snapped(float(val), 0.01)
+		if val is String or val is bool:
+			return val
+
+	return null

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -15,7 +15,7 @@ var _sample_interval: int = 1  # sample every N frames
 var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
 
 
-func start(specs: Array, hz: int, duration_ms: int) -> void:
+func start(specs: Array, hz: int, duration_ms: int) -> Dictionary:
 	_specs = []
 	_samples = {}
 	_hz = clampi(hz, 1, 60)
@@ -52,6 +52,7 @@ func start(specs: Array, hz: int, duration_ms: int) -> void:
 	_stop_time = 0
 	_active = true
 	set_process(true)
+	return {"resolved_fields": field_count}
 
 
 func _process(_delta: float) -> void:
@@ -90,7 +91,13 @@ func _process(_delta: float) -> void:
 
 
 func collect() -> Dictionary:
-	var elapsed := (_stop_time - _start_time) if _stop_time > 0 else (Time.get_ticks_msec() - _start_time)
+	var elapsed: int
+	if _stop_time > 0:
+		elapsed = _stop_time - _start_time
+	elif _start_time > 0:
+		elapsed = Time.get_ticks_msec() - _start_time
+	else:
+		elapsed = 0  # never started
 	var total_samples := 0
 	for key in _samples:
 		total_samples += (_samples[key] as Array).size()
@@ -187,7 +194,8 @@ func _read_field(node: Node, key: String) -> Variant:
 			if node is AnimatedSprite2D:
 				return (node as AnimatedSprite2D).frame
 
-	# Custom state fallback
+	# Custom state fallback — `is Dictionary` guards against _mcp_state() errors,
+	# which are non-fatal in GDScript (Godot prints the error and returns null).
 	if node.has_method("_mcp_state"):
 		var state = node._mcp_state()
 		if state is Dictionary and state.has(key):

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="3.4.1"
+version="3.5.0"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "MCP server for Godot Engine integration",
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -22,11 +22,11 @@
   "homepage": "https://github.com/satelliteoflove/godot-mcp#readme",
   "scripts": {
     "build": "tsc && npm run copy-addon",
-    "copy-addon": "rm -rf addon && cp -r ../godot/addons/godot_mcp addon",
+    "copy-addon": "tsx scripts/copy-addon.ts",
     "start": "node dist/index.js",
     "cli": "node dist/cli.js",
     "dev": "tsc --watch",
-    "dev:cli": "nodemon --exec 'tsx src/cli.ts' --ext ts --watch src",
+    "dev:cli": "nodemon --exec \"tsx src/cli.ts\" --ext ts --watch src",
     "test": "vitest run",
     "test:watch": "vitest",
     "generate-docs": "tsx scripts/generate-docs.ts"

--- a/server/scripts/copy-addon.ts
+++ b/server/scripts/copy-addon.ts
@@ -1,0 +1,9 @@
+import { rmSync, cpSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = resolve(process.cwd(), '../godot/addons/godot_mcp');
+const dest = resolve(process.cwd(), 'addon');
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(src, dest, { recursive: true });
+console.log(`addon copied: ${src} → ${dest}`);

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -13,6 +13,7 @@ import { scene3dTools } from '../src/tools/scene3d.js';
 import { docsTools } from '../src/tools/docs.js';
 import { inputTools } from '../src/tools/input.js';
 import { profilerTools } from '../src/tools/profiler.js';
+import { runtimeStateTools } from '../src/tools/runtime-state.js';
 import { sceneResources } from '../src/resources/scene.js';
 import { scriptResources } from '../src/resources/script.js';
 import { toInputSchema } from '../src/core/schema.js';
@@ -43,6 +44,7 @@ const categories: ToolCategory[] = [
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },
   { name: 'Input', filename: 'input', description: 'Input injection for testing running games (action-based, no mouse/coordinates yet)', tools: inputTools },
   { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
+  { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.', tools: runtimeStateTools },
 ];
 
 const allResources: ResourceDefinition[] = [...sceneResources, ...scriptResources];

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createMockGodot,
+  createToolContext,
+  structuredOf,
+  MockGodotConnection,
+} from '../helpers/mock-godot.js';
+import {
+  runtimeState,
+  summarizeNumericField,
+  summarizeStringField,
+} from '../../tools/runtime-state.js';
+
+describe('runtimeState tool', () => {
+  let mock: MockGodotConnection;
+
+  beforeEach(() => {
+    mock = createMockGodot();
+  });
+
+  // ── Schema validation ────────────────────────────────────────────────────
+
+  describe('schema validation', () => {
+    it('accepts digest with no params', () => {
+      expect(runtimeState.schema.safeParse({ action: 'digest' }).success).toBe(true);
+    });
+
+    it('accepts digest with all params', () => {
+      expect(
+        runtimeState.schema.safeParse({
+          action: 'digest',
+          select: 'group',
+          group: 'my_watch',
+          name: 'Player*',
+          type: 'CharacterBody2D',
+          max_nodes: 10,
+          include: ['transform', 'velocity'],
+        }).success
+      ).toBe(true);
+    });
+
+    it('rejects digest with invalid select value', () => {
+      expect(runtimeState.schema.safeParse({ action: 'digest', select: 'invalid' }).success).toBe(false);
+    });
+
+    it('rejects digest with max_nodes out of range', () => {
+      expect(runtimeState.schema.safeParse({ action: 'digest', max_nodes: 0 }).success).toBe(false);
+      expect(runtimeState.schema.safeParse({ action: 'digest', max_nodes: 201 }).success).toBe(false);
+    });
+
+    it('accepts watch_start with specs', () => {
+      expect(
+        runtimeState.schema.safeParse({
+          action: 'watch_start',
+          specs: [{ path: '/root/Level/Player', fields: ['pos.x', 'vel.y'] }],
+        }).success
+      ).toBe(true);
+    });
+
+    it('rejects watch_start with hz out of range', () => {
+      expect(
+        runtimeState.schema.safeParse({
+          action: 'watch_start',
+          specs: [],
+          hz: 0,
+        }).success
+      ).toBe(false);
+      expect(
+        runtimeState.schema.safeParse({
+          action: 'watch_start',
+          specs: [],
+          hz: 61,
+        }).success
+      ).toBe(false);
+    });
+
+    it('accepts watch_collect and watch_stop with no params', () => {
+      expect(runtimeState.schema.safeParse({ action: 'watch_collect' }).success).toBe(true);
+      expect(runtimeState.schema.safeParse({ action: 'watch_stop' }).success).toBe(true);
+    });
+  });
+
+  // ── digest ───────────────────────────────────────────────────────────────
+
+  describe('digest', () => {
+    it('calls get_runtime_state and returns structured result', async () => {
+      const response = {
+        scene: 'res://levels/level1.tscn',
+        selection: 'group',
+        entity_count: 1,
+        entities: [
+          {
+            path: '/root/Level1/Player',
+            type: 'CharacterBody2D',
+            groups: ['player'],
+            pos: { x: 100.5, y: 200.0 },
+            vel: { x: 150.0, y: 0.0 },
+          },
+        ],
+      };
+      mock.mockResponse(response);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute({ action: 'digest' }, ctx);
+
+      expect(structuredOf(result)).toEqual(response);
+      expect(mock.calls[0].command).toBe('get_runtime_state');
+    });
+
+    it('passes select, group, name, type, max_nodes, include params', async () => {
+      mock.mockResponse({ scene: '', selection: 'group', entity_count: 0, entities: [] });
+      const ctx = createToolContext(mock);
+
+      await runtimeState.execute(
+        {
+          action: 'digest',
+          select: 'group',
+          group: 'my_watch',
+          name: 'Player',
+          type: 'CharacterBody2D',
+          max_nodes: 10,
+          include: ['transform', 'velocity'],
+        },
+        ctx
+      );
+
+      const params = mock.calls[0].params;
+      expect(params.select).toBe('group');
+      expect(params.group).toBe('my_watch');
+      expect(params.name).toBe('Player');
+      expect(params.type).toBe('CharacterBody2D');
+      expect(params.max_nodes).toBe(10);
+      expect(params.include).toEqual(['transform', 'velocity']);
+    });
+
+    it('includes hint field in fallback selection result', async () => {
+      const response = {
+        scene: 'res://main.tscn',
+        selection: 'fallback',
+        entity_count: 2,
+        entities: [{ path: '/root/Main/Sprite2D', type: 'Sprite2D' }],
+        hint: 'No nodes found in group mcp_watch...',
+      };
+      mock.mockResponse(response);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute({ action: 'digest' }, ctx);
+      expect(structuredOf(result).hint).toBeDefined();
+    });
+  });
+
+  // ── watch_start ──────────────────────────────────────────────────────────
+
+  describe('watch_start', () => {
+    it('calls watch_start with specs, hz, duration_ms and returns confirmation', async () => {
+      mock.mockResponse({ started: true });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        {
+          action: 'watch_start',
+          specs: [{ path: '/root/Level/Player', fields: ['pos.x', 'vel.x'] }],
+          hz: 30,
+          duration_ms: 500,
+        },
+        ctx
+      );
+
+      expect(typeof result).toBe('string');
+      expect(result).toContain('500');
+      expect(mock.calls[0].command).toBe('watch_start');
+      expect(mock.calls[0].params.hz).toBe(30);
+      expect(mock.calls[0].params.duration_ms).toBe(500);
+    });
+
+    it('uses defaults for hz and duration_ms when omitted', async () => {
+      mock.mockResponse({ started: true });
+      const ctx = createToolContext(mock);
+
+      await runtimeState.execute(
+        { action: 'watch_start', specs: [{ path: '/root/Player', fields: ['pos.x'] }] },
+        ctx
+      );
+
+      expect(mock.calls[0].params.hz).toBe(20);
+      expect(mock.calls[0].params.duration_ms).toBe(1000);
+    });
+  });
+
+  // ── watch_collect ────────────────────────────────────────────────────────
+
+  describe('watch_collect', () => {
+    it('summarizes numeric fields from raw samples', async () => {
+      const raw = {
+        window_ms: 1000,
+        sample_count: 5,
+        fields: {
+          '/root/Player:pos.x': [
+            { t_ms: 0, value: 100 },
+            { t_ms: 250, value: 150 },
+            { t_ms: 500, value: 200 },
+            { t_ms: 750, value: 200 },
+            { t_ms: 1000, value: 250 },
+          ],
+        },
+      };
+      mock.mockResponse(raw);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute({ action: 'watch_collect' }, ctx);
+      const data = structuredOf(result);
+
+      expect(data.window_ms).toBe(1000);
+      expect(data.sample_count).toBe(5);
+      const summary = data.fields['/root/Player:pos.x'];
+      expect(summary.start).toBe(100);
+      expect(summary.end).toBe(250);
+      expect(summary.min).toBe(100);
+      expect(summary.max).toBe(250);
+      expect(summary.slope).toBe(150); // (250-100) / 1.0s
+    });
+
+    it('summarizes string fields and detects transitions', async () => {
+      const raw = {
+        window_ms: 500,
+        sample_count: 3,
+        fields: {
+          '/root/Player:anim': [
+            { t_ms: 0, value: 'idle' },
+            { t_ms: 200, value: 'idle' },
+            { t_ms: 350, value: 'run' },
+          ],
+        },
+      };
+      mock.mockResponse(raw);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute({ action: 'watch_collect' }, ctx);
+      const summary = structuredOf(result).fields['/root/Player:anim'];
+
+      expect(summary.start).toBe('idle');
+      expect(summary.end).toBe('run');
+      expect(summary.changes).toHaveLength(1);
+      expect(summary.changes[0]).toEqual({ t_ms: 350, from: 'idle', to: 'run' });
+    });
+  });
+
+  // ── watch_stop ───────────────────────────────────────────────────────────
+
+  describe('watch_stop', () => {
+    it('calls watch_stop and returns summarized result', async () => {
+      const raw = {
+        window_ms: 600,
+        sample_count: 2,
+        fields: {
+          '/root/Player:vel.x': [
+            { t_ms: 0, value: 0 },
+            { t_ms: 600, value: 200 },
+          ],
+        },
+      };
+      mock.mockResponse(raw);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute({ action: 'watch_stop' }, ctx);
+
+      expect(mock.calls[0].command).toBe('watch_stop');
+      const summary = structuredOf(result).fields['/root/Player:vel.x'];
+      expect(summary.start).toBe(0);
+      expect(summary.end).toBe(200);
+      expect(typeof summary.slope).toBe('number');
+    });
+  });
+});
+
+// ── summarizeNumericField unit tests ─────────────────────────────────────────
+
+describe('summarizeNumericField', () => {
+  it('returns zeros for empty input', () => {
+    const r = summarizeNumericField([], 1000);
+    expect(r).toEqual({ start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] });
+  });
+
+  it('handles single sample', () => {
+    const r = summarizeNumericField([{ t_ms: 0, value: 42 }], 1000);
+    expect(r.start).toBe(42);
+    expect(r.end).toBe(42);
+    expect(r.slope).toBe(0);
+  });
+
+  it('computes slope correctly', () => {
+    const samples = [
+      { t_ms: 0, value: 0 },
+      { t_ms: 1000, value: 100 },
+    ];
+    const r = summarizeNumericField(samples, 1000);
+    expect(r.slope).toBe(100); // 100 units/sec
+  });
+
+  it('detects sign change events', () => {
+    const samples = [
+      { t_ms: 0, value: 10 },
+      { t_ms: 500, value: -10 },
+    ];
+    const r = summarizeNumericField(samples, 1000);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].kind).toBe('sign_change');
+    expect(r.events[0].t_ms).toBe(500);
+  });
+
+  it('detects zero-crossing events', () => {
+    const samples = [
+      { t_ms: 0, value: 0 },
+      { t_ms: 100, value: 5 },
+    ];
+    const r = summarizeNumericField(samples, 1000);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].kind).toBe('zero_cross');
+  });
+
+  it('computes correct min/max/mean for constant value', () => {
+    const samples = [
+      { t_ms: 0, value: 7 },
+      { t_ms: 500, value: 7 },
+      { t_ms: 1000, value: 7 },
+    ];
+    const r = summarizeNumericField(samples, 1000);
+    expect(r.min).toBe(7);
+    expect(r.max).toBe(7);
+    expect(r.mean).toBe(7);
+    expect(r.slope).toBe(0);
+  });
+});
+
+// ── summarizeStringField unit tests ──────────────────────────────────────────
+
+describe('summarizeStringField', () => {
+  it('returns empty result for empty input', () => {
+    const r = summarizeStringField([]);
+    expect(r).toEqual({ start: '', end: '', changes: [] });
+  });
+
+  it('returns no changes for constant value', () => {
+    const samples = [
+      { t_ms: 0, value: 'idle' },
+      { t_ms: 500, value: 'idle' },
+    ];
+    const r = summarizeStringField(samples);
+    expect(r.start).toBe('idle');
+    expect(r.end).toBe('idle');
+    expect(r.changes).toHaveLength(0);
+  });
+
+  it('detects a single transition', () => {
+    const samples = [
+      { t_ms: 0, value: 'idle' },
+      { t_ms: 350, value: 'run' },
+    ];
+    const r = summarizeStringField(samples);
+    expect(r.changes).toHaveLength(1);
+    expect(r.changes[0]).toEqual({ t_ms: 350, from: 'idle', to: 'run' });
+  });
+
+  it('detects multiple transitions in sequence', () => {
+    const samples = [
+      { t_ms: 0, value: 'idle' },
+      { t_ms: 200, value: 'run' },
+      { t_ms: 400, value: 'jump' },
+      { t_ms: 600, value: 'fall' },
+    ];
+    const r = summarizeStringField(samples);
+    expect(r.start).toBe('idle');
+    expect(r.end).toBe('fall');
+    expect(r.changes).toHaveLength(3);
+  });
+});

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -10,6 +10,7 @@ import { scene3dTools } from './scene3d.js';
 import { docsTools } from './docs.js';
 import { inputTools } from './input.js';
 import { profilerTools } from './profiler.js';
+import { runtimeStateTools } from './runtime-state.js';
 
 export function registerAllTools(): void {
   registry.registerTools(sceneTools);
@@ -23,6 +24,7 @@ export function registerAllTools(): void {
   registry.registerTools(docsTools);
   registry.registerTools(inputTools);
   registry.registerTools(profilerTools);
+  registry.registerTools(runtimeStateTools);
 }
 
 export { sceneTools } from './scene.js';
@@ -36,3 +38,4 @@ export { scene3dTools } from './scene3d.js';
 export { docsTools } from './docs.js';
 export { inputTools } from './input.js';
 export { profilerTools } from './profiler.js';
+export { runtimeStateTools } from './runtime-state.js';

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -177,7 +177,11 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'Start an in-engine sampler that records specified node fields over a time window. ' +
         'Returns immediately; call watch_collect after duration_ms to get the summarized digest. ' +
         'Field keys: "pos.x", "pos.y", "vel.x", "vel.y" for built-in properties; ' +
-        'any key from _mcp_state() for custom game state (e.g. "health", "ammo").'
+        'any key from _mcp_state() for custom game state (e.g. "health", "ammo"). ' +
+        'TIMING: watch_start and the action that drives state change (godot_input sequence, ' +
+        'player input, etc.) must overlap within the watch window. Send both in the same ' +
+        'parallel tool call batch, or use a duration_ms large enough (3000–4000ms) to cover ' +
+        'the round-trip latency before the driving action is approved and sent.'
       ),
     specs: z
       .array(

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -181,7 +181,9 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'TIMING: watch_start and the action that drives state change (godot_input sequence, ' +
         'player input, etc.) must overlap within the watch window. Send both in the same ' +
         'parallel tool call batch, or use a duration_ms large enough (3000–4000ms) to cover ' +
-        'the round-trip latency before the driving action is approved and sent.'
+        'the round-trip latency before the driving action is approved and sent. ' +
+        'NODE PATHS: if a path in specs cannot be resolved, that spec is silently skipped; ' +
+        'check resolved_fields in the response — 0 means all paths were invalid.'
       ),
     specs: z
       .array(
@@ -261,12 +263,16 @@ export const runtimeState = defineTool({
       }
 
       case 'watch_start': {
-        await godot.sendCommand<{ started: boolean }>('watch_start', {
+        const watchResult = await godot.sendCommand<{ started: boolean; resolved_fields?: number }>('watch_start', {
           specs: args.specs,
           hz: args.hz ?? 20,
           duration_ms: args.duration_ms ?? 1000,
         });
-        return `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`;
+        const base = `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`;
+        if ((watchResult.resolved_fields ?? 1) === 0) {
+          return base + ' Warning: 0 fields resolved — verify that all node paths in specs exist in the running scene.';
+        }
+        return `${base} Tracking ${watchResult.resolved_fields} field(s).`;
       }
 
       case 'watch_collect': {

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -1,0 +1,278 @@
+import { z } from 'zod';
+import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
+import type { AnyToolDefinition } from '../core/types.js';
+
+// ── Godot response shapes ────────────────────────────────────────────────────
+
+interface EntitySnapshot {
+  path: string;
+  type: string;
+  groups?: string[];
+  pos?: { x: number; y: number } | { x: number; y: number; z: number };
+  rot?: number | { x: number; y: number; z: number };
+  scale?: { x: number; y: number } | { x: number; y: number; z: number };
+  vel?: { x: number; y: number } | { x: number; y: number; z: number };
+  angvel?: number | { x: number; y: number; z: number };
+  anim?: string;
+  anim_pos?: number;
+  anim_frame?: number;
+  playing?: boolean;
+  camera?: boolean;
+  zoom?: { x: number; y: number };
+  onscreen?: boolean;
+  state?: Record<string, unknown>;
+}
+
+interface DigestResponse {
+  scene: string;
+  selection: 'group' | 'method' | 'fallback';
+  entity_count: number;
+  camera?: EntitySnapshot;
+  entities: EntitySnapshot[];
+  hint?: string;
+}
+
+interface WatchRawSample {
+  t_ms: number;
+  value: number | string;
+}
+
+interface WatchRawResponse {
+  window_ms: number;
+  sample_count: number;
+  fields: Record<string, WatchRawSample[]>;
+}
+
+// ── Server-side summarization helpers ───────────────────────────────────────
+
+export interface NumericFieldSummary {
+  start: number;
+  end: number;
+  min: number;
+  max: number;
+  mean: number;
+  slope: number;
+  events: Array<{ t_ms: number; from: number; to: number; kind: 'sign_change' | 'zero_cross' }>;
+}
+
+export interface StringFieldSummary {
+  start: string;
+  end: string;
+  changes: Array<{ t_ms: number; from: string; to: string }>;
+}
+
+export function summarizeNumericField(
+  samples: WatchRawSample[],
+  windowMs: number
+): NumericFieldSummary {
+  if (samples.length === 0) {
+    return { start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] };
+  }
+
+  const values = samples.map((s) => s.value as number);
+  const first = values[0];
+  const last = values[values.length - 1];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const mean = Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 100) / 100;
+  const slope = windowMs > 0 ? Math.round(((last - first) / (windowMs / 1000)) * 100) / 100 : 0;
+
+  const events: NumericFieldSummary['events'] = [];
+  for (let i = 1; i < samples.length; i++) {
+    const prev = samples[i - 1].value as number;
+    const curr = samples[i].value as number;
+    if (prev === 0 && curr !== 0) {
+      events.push({ t_ms: samples[i].t_ms, from: prev, to: curr, kind: 'zero_cross' });
+    } else if ((prev < 0 && curr > 0) || (prev > 0 && curr < 0)) {
+      events.push({ t_ms: samples[i].t_ms, from: prev, to: curr, kind: 'sign_change' });
+    }
+  }
+
+  return { start: first, end: last, min, max, mean, slope, events };
+}
+
+export function summarizeStringField(samples: WatchRawSample[]): StringFieldSummary {
+  if (samples.length === 0) {
+    return { start: '', end: '', changes: [] };
+  }
+
+  const first = samples[0].value as string;
+  const last = samples[samples.length - 1].value as string;
+  const changes: StringFieldSummary['changes'] = [];
+
+  for (let i = 1; i < samples.length; i++) {
+    const prev = samples[i - 1].value as string;
+    const curr = samples[i].value as string;
+    if (prev !== curr) {
+      changes.push({ t_ms: samples[i].t_ms, from: prev, to: curr });
+    }
+  }
+
+  return { start: first, end: last, changes };
+}
+
+function summarizeWatchRaw(raw: WatchRawResponse): Record<string, NumericFieldSummary | StringFieldSummary> {
+  const result: Record<string, NumericFieldSummary | StringFieldSummary> = {};
+  for (const [key, samples] of Object.entries(raw.fields)) {
+    if (samples.length === 0) continue;
+    const isNumeric = typeof samples[0].value === 'number';
+    result[key] = isNumeric
+      ? summarizeNumericField(samples, raw.window_ms)
+      : summarizeStringField(samples);
+  }
+  return result;
+}
+
+// ── Schema ───────────────────────────────────────────────────────────────────
+
+const INCLUDE_VALUES = ['transform', 'velocity', 'anim', 'groups', 'onscreen', 'state'] as const;
+
+const RuntimeStateSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z
+      .literal('digest')
+      .describe(
+        'Snapshot current game entity state as structured JSON — exact positions, velocities, ' +
+        'animation state, and custom game data. Much cheaper than screenshot_game (no vision tokens). ' +
+        'Works on any game with no setup; add nodes to the "mcp_watch" group or implement ' +
+        '`func _mcp_state() -> Dictionary` on key nodes to expose custom domain state ' +
+        '(e.g. health, score, puzzle progress). If you are building a game and want richer ' +
+        'state in future digest calls, add _mcp_state() to nodes with interesting custom data.'
+      ),
+    select: z
+      .enum(['group', 'method', 'auto'])
+      .optional()
+      .describe(
+        'Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), ' +
+        '"auto" = best available (default: auto picks group → method → visible CanvasItems)'
+      ),
+    group: z
+      .string()
+      .optional()
+      .describe('Group name to use when select="group" or "auto" (default: "mcp_watch")'),
+    name: z.string().optional().describe('Glob filter on node name (e.g. "Player*")'),
+    type: z.string().optional().describe('Class filter (e.g. "CharacterBody2D")'),
+    max_nodes: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Maximum nodes in result (default: 40)'),
+    include: z
+      .array(z.enum(INCLUDE_VALUES))
+      .optional()
+      .describe('Subset of fields to include (default: all available)'),
+  }),
+  z.object({
+    action: z
+      .literal('watch_start')
+      .describe(
+        'Start an in-engine sampler that records specified node fields over a time window. ' +
+        'Returns immediately; call watch_collect after duration_ms to get the summarized digest. ' +
+        'Field keys: "pos.x", "pos.y", "vel.x", "vel.y" for built-in properties; ' +
+        'any key from _mcp_state() for custom game state (e.g. "health", "ammo").'
+      ),
+    specs: z
+      .array(
+        z.object({
+          path: z.string().describe('Full node path (e.g. "/root/Level/Player")'),
+          fields: z
+            .array(z.string())
+            .describe('Field keys to sample (e.g. ["pos.x", "vel.x", "health"])'),
+        })
+      )
+      .describe('Which nodes and fields to watch'),
+    hz: z
+      .number()
+      .int()
+      .min(1)
+      .max(60)
+      .optional()
+      .describe('Sample rate in Hz (default: 20)'),
+    duration_ms: z
+      .number()
+      .int()
+      .min(100)
+      .max(5000)
+      .optional()
+      .describe('Auto-stop after this many milliseconds (default: 1000)'),
+  }),
+  z.object({
+    action: z
+      .literal('watch_collect')
+      .describe(
+        'Collect the current sampler buffer and return a per-field summary: ' +
+        'start/end/min/max/mean/slope for numeric fields; transition events for string fields. ' +
+        'Safe to call before auto-stop — returns whatever has been sampled so far.'
+      ),
+  }),
+  z.object({
+    action: z
+      .literal('watch_stop')
+      .describe(
+        'Stop the sampler early and return the final per-field summary. ' +
+        'Equivalent to watch_collect + stopping the sampler.'
+      ),
+  }),
+]);
+
+type RuntimeStateArgs = z.infer<typeof RuntimeStateSchema>;
+
+// ── Tool definition ──────────────────────────────────────────────────────────
+
+export const runtimeState = defineTool({
+  name: 'godot_runtime_state',
+  annotations: {
+    title: 'Runtime State',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+  },
+  description:
+    'Observe live game state as structured data. ' +
+    'Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). ' +
+    'Use watch_start → watch_collect for state-over-time without context blowup.',
+  schema: RuntimeStateSchema,
+
+  async execute(args: RuntimeStateArgs, { godot }) {
+    switch (args.action) {
+      case 'digest': {
+        const params: Record<string, unknown> = {};
+        if (args.select !== undefined) params.select = args.select;
+        if (args.group !== undefined) params.group = args.group;
+        if (args.name !== undefined) params.name = args.name;
+        if (args.type !== undefined) params.type = args.type;
+        if (args.max_nodes !== undefined) params.max_nodes = args.max_nodes;
+        if (args.include !== undefined) params.include = args.include;
+
+        const result = await godot.sendCommand<DigestResponse>('get_runtime_state', params);
+        return structured(result);
+      }
+
+      case 'watch_start': {
+        await godot.sendCommand<{ started: boolean }>('watch_start', {
+          specs: args.specs,
+          hz: args.hz ?? 20,
+          duration_ms: args.duration_ms ?? 1000,
+        });
+        return `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`;
+      }
+
+      case 'watch_collect': {
+        const raw = await godot.sendCommand<WatchRawResponse>('watch_collect');
+        const fields = summarizeWatchRaw(raw);
+        return structured({ window_ms: raw.window_ms, sample_count: raw.sample_count, fields });
+      }
+
+      case 'watch_stop': {
+        const raw = await godot.sendCommand<WatchRawResponse>('watch_stop');
+        const fields = summarizeWatchRaw(raw);
+        return structured({ window_ms: raw.window_ms, sample_count: raw.sample_count, fields });
+      }
+    }
+  },
+});
+
+export const runtimeStateTools = [runtimeState] as AnyToolDefinition[];

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -136,9 +136,14 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'Snapshot current game entity state as structured JSON — exact positions, velocities, ' +
         'animation state, and custom game data. Much cheaper than screenshot_game (no vision tokens). ' +
         'Works on any game with no setup; add nodes to the "mcp_watch" group or implement ' +
-        '`func _mcp_state() -> Dictionary` on key nodes to expose custom domain state ' +
-        '(e.g. health, score, puzzle progress). If you are building a game and want richer ' +
-        'state in future digest calls, add _mcp_state() to nodes with interesting custom data.'
+        '`func _mcp_state() -> Dictionary` on key nodes for richer, targeted data. ' +
+        'WHAT TO PUT IN _mcp_state(): include BOTH (1) live runtime values that change during ' +
+        'play (cursor position, health, score, fill counts) AND (2) static definition context ' +
+        'an agent needs to interpret them — e.g. a puzzle node should expose its clue data, ' +
+        'a level node its objective list, a shop its item catalog. Without definition context, ' +
+        'an agent can observe state changes but cannot verify correctness. Also include layout ' +
+        'geometry for renderable nodes (bounds, sizes, offsets) to enable programmatic layout ' +
+        'checks without a screenshot.'
       ),
     select: z
       .enum(['group', 'method', 'auto'])


### PR DESCRIPTION
## Summary

- Adds `godot_runtime_state` MCP tool — a structured alternative to `screenshot_game` that returns exact entity data (positions, velocities, animation state, groups, custom `_mcp_state()` data) as compact JSON. No vision tokens; exact numbers instead of pixel inference.
- Four actions: `digest` (one-shot snapshot), `watch_start` + `watch_collect` (state-over-time sampler with server-side summarization), `watch_stop` (early stop).
- Three selection tiers: `mcp_watch` group → `_mcp_state()` method → visible-CanvasItem fallback. `digest` responses include a hint when falling back, guiding developers/models to opt in for richer data.
- Server-side stats helpers: `summarizeNumericField` (start/end/min/max/mean/slope + sign-change/zero-cross events) and `summarizeStringField` (transition events), keeping raw per-frame arrays out of context.
- `_mcp_state()` guidance: tool descriptions and fallback hint explicitly teach the two-category pattern — live runtime values AND static definition context (puzzle clues, level config, etc.). Discovered via dogfood testing that developers naturally include only live values, leaving agents unable to verify correctness.
- Windows build fix: replaced Unix shell commands in `copy-addon` script with a cross-platform Node.js script. Fixed `dev:cli` single-quoted `--exec` arg.

## New files

| File | What |
|------|------|
| `server/src/tools/runtime-state.ts` | Server tool + stats helpers |
| `server/src/__tests__/tools/runtime-state.test.ts` | 25 tests |
| `server/scripts/copy-addon.ts` | Cross-platform addon copy script |
| `godot/addons/godot_mcp/commands/runtime_state_commands.gd` | Editor-side command handler |
| `godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd` | In-game ring-buffer sampler |

## Modified files

- `game_bridge/mcp_game_bridge.gd` — 4 new message arms + `_collect_runtime_state` tree-walk, per-class field extraction, on-screen detection, `_mcp_state()` guard (1 KB cap enforced)
- `command_router.gd` — registers `MCPRuntimeStateCommands`
- `server/src/tools/index.ts` — registers `runtimeStateTools`
- `server/scripts/generate-docs.ts` — adds Runtime State category
- `server/package.json` — cross-platform scripts

## Context cost comparison

| Method | Typical cost | Precision |
|--------|-------------|-----------|
| `screenshot_game` (1024px JPEG) | ~40-100 KB, vision tokens | Approximate (agent infers from pixels) |
| `runtime_state digest` | ~2-12 KB text, zero vision tokens | Exact (numbers, strings) |

## Edge cases verified during dogfood testing

- `_serialize_mcp_state` 1 KB cap: now actually drops keys and sets `_truncated: true` (was flagging but returning full data)
- `collect()` before `start()`: returns `{window_ms: 0, sample_count: 0, fields: {}}` instead of garbage timestamp
- `watch_start` with invalid node paths: silently skips; `resolved_fields: 0` in response surfaces this to caller
- Fallback tier (no `mcp_watch`, no `_mcp_state()`): returns visible CanvasItems with updated hint
- `window_ms` in `collect()`: now reflects actual sampling duration, not time-to-collect (fixes slope math)
- `_mcp_state()` runtime errors: non-fatal in GDScript; `is Dictionary` guard handles null returns silently (documented)
- Camera2D extraction: confirmed — `camera` field and `onscreen` per-entity flag both appear correctly when a Camera2D is present

## Test plan

- [x] `npm run build` — TypeScript compiles clean, cross-platform copy-addon works on Windows
- [x] `npm test` — 222/222 tests pass (25 new)
- [x] `npm run generate-docs` — 13 tools, `docs/tools/runtime-state.md` generated
- [x] Live: Tessera in Godot — `digest` returns exact entity state (cursor, fill counts, puzzle clues, layout metrics)
- [x] Live: `watch_start` + `watch_collect` — slopes/field summaries correct for cursor movement and cell fills
- [x] Live: fallback tier, 1 KB cap, `collect()` before `start()`, `window_ms` accuracy all verified
- [x] Live: Camera2D extraction — `camera.pos`, `camera.zoom`, and per-entity `onscreen` flag all verified

Closes #194, #195, #196, #197, #200.

Generated with Claude Code
