### PR TITLE
fix: reduce default screenshot max_width from 1024 to 900

### DIFF
--- a/godot/addons/godot_mcp/commands/screenshot_commands.gd
+++ b/godot/addons/godot_mcp/commands/screenshot_commands.gd
@@ -2,7 +2,7 @@
 extends MCPBaseCommand
 class_name MCPScreenshotCommands
 
-const DEFAULT_MAX_WIDTH := 1024
+const DEFAULT_MAX_WIDTH := 900
 const DEFAULT_JPEG_QUALITY := 75
 const SCREENSHOT_TIMEOUT := 5.0
 

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -55,13 +55,13 @@ const EditorSchema = z
     z.object({ action: z.literal('get_stack_trace').describe('Get the most recent error stack trace') }),
     z.object({
       action: z.literal('screenshot_game').describe('Capture a JPEG screenshot of the running game'),
-      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 1024)'),
+      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 900)'),
       quality: z.number().int().min(1).max(100).optional().describe('JPEG quality 1-100 (default: 75)'),
     }),
     z.object({
       action: z.literal('screenshot_editor').describe('Capture a JPEG screenshot of an editor viewport'),
       viewport: z.enum(['2d', '3d']).optional().describe('Which editor viewport to capture'),
-      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 1024)'),
+      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 900)'),
       quality: z.number().int().min(1).max(100).optional().describe('JPEG quality 1-100 (default: 75)'),
     }),
     z.object({


### PR DESCRIPTION
## Summary

- Drops `DEFAULT_MAX_WIDTH` in `screenshot_commands.gd` from 1024 to 900
- Updates both `screenshot_game` and `screenshot_editor` description strings in `editor.ts` to match

## Why

For 1920×1080 content (the most common game resolution), `max_width=1024` produces a 1024×576 image. The height of 576px exceeds the 512px tile boundary, so Claude's vision API uses **4 tiles** (2×2). Dropping to `max_width=900` produces 900×506 — height stays under 512, so only **2 tiles** are needed. This halves the vision token cost per screenshot with no meaningful loss of detail for the primary use case (layout/rendering verification; exact state values come from the digest tool).

## Test plan

- [ ] Run a Godot project, call `screenshot_game` without specifying `max_width` — confirm returned image is 900px wide
- [ ] Call `screenshot_game` with explicit `max_width=1024` — confirm override still works
- [ ] Same checks for `screenshot_editor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)