### PR TITLE
feat: digest reaches autoload singletons via explicit paths

### DIFF
--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -8,7 +8,8 @@ by adopting two small, opt-in conventions:
 - the `mcp_watch` group: tag the nodes that matter, and
 - the `_mcp_state()` method: expose your own domain state (health, ammo, score, ...).
 
-This guide covers both, plus how the tool decides which nodes to report.
+This guide covers both, plus how the tool decides which nodes to report and how to read
+global state held in autoload singletons.
 
 For the raw parameter/action reference, see
 [Tools Reference -> Runtime State](tools/runtime-state.md).
@@ -17,7 +18,7 @@ For the raw parameter/action reference, see
 
 ## Selection tiers and `auto`
 
-`godot_runtime_state` (action `digest`) picks nodes using one of three tiers, controlled by
+`godot_runtime_state` (action `digest`) picks nodes using one of these tiers, controlled by
 the `select` parameter:
 
 | Tier       | What it selects                                                        |
@@ -25,6 +26,7 @@ the `select` parameter:
 | `group`    | Nodes in the `mcp_watch` group (or a custom group via `group`)         |
 | `method`   | Nodes that define `func _mcp_state() -> Dictionary`                     |
 | `fallback` | Visible `CanvasItem`s (`is_visible_in_tree()`), capped at `max_nodes`  |
+| `none`     | No automatic selection -- only the nodes named in `paths` (see below)  |
 
 The default, `select: "auto"`, picks the cheapest useful tier:
 
@@ -123,6 +125,47 @@ func _mcp_state() -> Dictionary:
 
 ---
 
+## Reading global state in autoloads
+
+The tiers above all walk the **current scene**. Autoload singletons live at `/root` as
+siblings of the scene, so global state held in an autoload (cash, score, settings) is **not
+reachable** by `group` / `method` / `fallback` -- and tagging an autoload into `mcp_watch`
+or giving it `_mcp_state()` will not help on its own, because tier discovery never visits it.
+
+Read singletons (or any node outside the current scene) by naming them explicitly with
+`paths`:
+
+```json
+{ "action": "digest", "select": "none", "paths": ["/root/GameState"] }
+```
+
+- `select: "none"` skips the tier walk entirely and returns only the nodes you name -- a
+  clean singleton read with no scene-walk noise. You can also pass `paths` alongside a normal
+  tier; the named nodes are appended to the result.
+- Each path returns `_mcp_state()` if the node defines it, otherwise a snapshot of the node's
+  **script variables** (the `var`s declared in its script), so it works with no
+  instrumentation at all. The snapshot follows the `_mcp_state()` rules: JSON-able
+  scalars/arrays only, private (`_`-prefixed) vars skipped, ~1 KB cap.
+- Paths that do not resolve come back in `unresolved_paths`.
+
+You do not need to know the paths in advance: every `digest` response includes
+`available_autoloads`, listing the singletons you can read.
+
+`digest` with `select: "none"` and `paths: ["/root/GameState"]` returns:
+
+```json
+{
+  "path": "/root/GameState",
+  "type": "Node",
+  "state": { "cash": 25000, "tick_count": 20, "total_population": 3 }
+}
+```
+
+For a curated view instead of every script var, give the autoload its own `_mcp_state()` --
+it takes precedence over the raw snapshot.
+
+---
+
 ## Worked example: a Player node
 
 ```gdscript
@@ -166,7 +209,9 @@ and gets back an entity like:
 ## Watching state over time
 
 Keys you expose from `_mcp_state()` are also valid `watch_start` field keys, alongside the
-built-ins (`pos.x`, `pos.y`, `pos.z`, `vel.x`, `vel.y`, `vel.z`, `rot`, `anim`, ...):
+built-ins (`pos.x`, `pos.y`, `pos.z`, `vel.x`, `vel.y`, `vel.z`, `rot`, `anim`, ...).
+Absolute paths work here too, so you can watch an autoload's fields the same way you read
+them in a digest (e.g. `/root/GameState`):
 
 ```json
 {
@@ -192,3 +237,5 @@ length. See [Tools Reference -> Runtime State](tools/runtime-state.md) for the f
 - Add `_mcp_state()` to those nodes; return live values AND the context to interpret them.
 - Keep each `_mcp_state()` cheap, side-effect-free, JSON-able, and under ~1 KB.
 - Let agents call `digest` for a snapshot and `watch_start` / `watch_collect` for motion.
+- For global state in autoload singletons, read them with `select="none"` and `paths`
+  (every response lists them in `available_autoloads`).

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -17,8 +17,9 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | `digest`, `watch_start`, `watch_collect`, `watch_stop` | Yes |  |
-| `select` | `group`, `method`, `auto` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → visible CanvasItems) |
+| `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → visible CanvasItems), "none" = no automatic selection; return only the nodes named in paths |
 | `group` | string | No | Group name to use when select="group" or "auto" (default: "mcp_watch") |
+| `paths` | string[] | No | Explicit absolute node paths to include in addition to tier selection, e.g. ["/root/GameState"]. The digest walks the current scene only, so autoload singletons — where global game state often lives (cash, score, settings) — are otherwise unreachable. Each path returns _mcp_state() if present, else a snapshot of the node's script variables (scalars/arrays, ~1 KB cap). Paths that do not resolve are returned in unresolved_paths. |
 | `name` | string | No | Glob filter on node name (e.g. "Player*") |
 | `type` | string | No | Class filter (e.g. "CharacterBody2D") |
 | `max_nodes` | integer | No | Maximum nodes in result (default: 40) |

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -430,11 +430,36 @@ func _handle_get_runtime_state(data: Array) -> void:
 		else:
 			actual_selection = "fallback"
 
-	# Collect entities
+	# Collect entities (skipped entirely when select="none" — explicit paths only)
 	var entities: Array = []
-	_collect_runtime_state(scene_root, scene_root, actual_selection, group_name,
-		name_filter, type_filter, include_fields, camera_2d, camera_viewport_rect,
-		max_nodes, entities)
+	if actual_selection != "none":
+		_collect_runtime_state(scene_root, scene_root, actual_selection, group_name,
+			name_filter, type_filter, include_fields, camera_2d, camera_viewport_rect,
+			max_nodes, entities)
+
+	# Explicit paths: include nodes the scene walk cannot reach (e.g. autoload
+	# singletons under /root). For each, return _mcp_state() if present, else a
+	# snapshot of the node's script variables (scalars/arrays, capped). Deduped
+	# against tier-selected entities and each other by absolute path.
+	var explicit_paths: Array = params.get("paths", [])
+	var unresolved_paths: Array = []
+	if not explicit_paths.is_empty():
+		var seen_paths := {}
+		for e in entities:
+			seen_paths[str(e.get("path", ""))] = true
+		for p in explicit_paths:
+			var pstr: String = str(p)
+			var n := _resolve_node_abs(pstr)
+			if n == null:
+				unresolved_paths.append(pstr)
+				continue
+			var abs_path := str(n.get_path())
+			if seen_paths.has(abs_path):
+				continue
+			seen_paths[abs_path] = true
+			var ent := _extract_node_state(n, scene_root, include_fields, camera_2d, camera_viewport_rect, true)
+			ent["path"] = abs_path
+			entities.append(ent)
 
 	# Extract camera entity separately if present
 	var camera_entity = null
@@ -447,6 +472,8 @@ func _handle_get_runtime_state(data: Array) -> void:
 			"camera": true,
 		}
 
+	var autoloads := _list_autoload_paths(scene_root)
+
 	var hint := ""
 	if actual_selection == "fallback":
 		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected. " +
@@ -455,6 +482,11 @@ func _handle_get_runtime_state(data: Array) -> void:
 			"In _mcp_state(), include both live runtime values (position, health, score) " +
 			"AND static definition context (puzzle clues, level config, item data) — " +
 			"an agent needs both to understand and verify game state.") % [group_name, group_name]
+		if not autoloads.is_empty():
+			hint += (" Global game state often lives in autoload singletons (see " +
+				"available_autoloads), which this scene walk does not reach — read them " +
+				"with select=\"none\" and paths: [...]; each returns _mcp_state() if " +
+				"present, else a snapshot of its script variables.")
 
 	var result: Dictionary = {
 		"scene": scene_root.scene_file_path,
@@ -462,10 +494,14 @@ func _handle_get_runtime_state(data: Array) -> void:
 		"entity_count": entities.size(),
 		"entities": entities,
 	}
+	if not autoloads.is_empty():
+		result["available_autoloads"] = autoloads
 	if camera_entity:
 		result["camera"] = camera_entity
 	if not hint.is_empty():
 		result["hint"] = hint
+	if not unresolved_paths.is_empty():
+		result["unresolved_paths"] = unresolved_paths
 
 	EngineDebugger.send_message("godot_mcp:game_response", ["get_runtime_state", result])
 
@@ -529,7 +565,7 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 # Error handling: _mcp_state() runtime errors are non-fatal in GDScript (Godot prints them
 # and the call returns null); the `is Dictionary` check below handles that silently.
 func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
-		camera_2d: Camera2D, viewport_rect: Rect2) -> Dictionary:
+		camera_2d: Camera2D, viewport_rect: Rect2, allow_var_snapshot: bool = false) -> Dictionary:
 	var want := include_fields.is_empty()
 	var want_transform := want or include_fields.has("transform")
 	var want_velocity := want or include_fields.has("velocity")
@@ -600,12 +636,17 @@ func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 		var pos := (node as Node2D).global_position
 		entity["onscreen"] = viewport_rect.has_point(pos)
 
-	if want_state and node.has_method("_mcp_state"):
-		var raw_state = node._mcp_state()
-		if raw_state is Dictionary:
-			var serialized := _serialize_mcp_state(raw_state)
-			if not serialized.is_empty():
-				entity["state"] = serialized
+	if want_state:
+		if node.has_method("_mcp_state"):
+			var raw_state = node._mcp_state()
+			if raw_state is Dictionary:
+				var serialized := _serialize_mcp_state(raw_state)
+				if not serialized.is_empty():
+					entity["state"] = serialized
+		elif allow_var_snapshot:
+			var snap := _snapshot_script_vars(node)
+			if not snap.is_empty():
+				entity["state"] = snap
 
 	return entity
 
@@ -638,6 +679,89 @@ func _serialize_mcp_state(state: Dictionary) -> Dictionary:
 			result["_truncated"] = true
 			break
 	return result
+
+
+# Snapshot a node's own script variables (PROPERTY_USAGE_SCRIPT_VARIABLE) as
+# JSON-able scalars/arrays. Used for explicitly-requested nodes (e.g. autoload
+# singletons) that do not implement _mcp_state(). Private vars (leading "_") are
+# skipped; dictionaries/objects/non-serializable values are dropped; total size
+# is capped like _serialize_mcp_state.
+func _snapshot_script_vars(node: Node) -> Dictionary:
+	var result: Dictionary = {}
+	for prop in node.get_property_list():
+		if not (int(prop.get("usage", 0)) & PROPERTY_USAGE_SCRIPT_VARIABLE):
+			continue
+		var key: String = str(prop.get("name", ""))
+		if key.is_empty() or key.begins_with("_"):
+			continue
+		var serializable = _to_serializable_scalar(node.get(key))
+		if serializable == null:
+			continue
+		result[key] = serializable
+		if JSON.stringify(result).length() > _MCP_STATE_MAX_BYTES:
+			result.erase(key)
+			result["_truncated"] = true
+			break
+	return result
+
+
+# Convert a value to a JSON-able scalar (or array of scalars). Returns null to
+# signal "skip" — dictionaries, objects, vectors, and arrays containing any of
+# those are intentionally dropped to keep the snapshot small and safe.
+func _to_serializable_scalar(val) -> Variant:
+	match typeof(val):
+		TYPE_BOOL, TYPE_STRING:
+			return val
+		TYPE_STRING_NAME:
+			return str(val)
+		TYPE_INT:
+			return int(val)
+		TYPE_FLOAT:
+			return snapped(float(val), 0.01)
+		TYPE_ARRAY:
+			var arr: Array = []
+			for e in val:
+				var s = _to_serializable_scalar(e)
+				if s == null:
+					return null
+				arr.append(s)
+			return arr
+	return null
+
+
+# Resolve an absolute ("/root/Name/...") or scene-relative node path. Unlike the
+# digest tree walk (rooted at current_scene), this reaches autoload singletons
+# and anything else under the SceneTree root.
+func _resolve_node_abs(path: String) -> Node:
+	var tree := get_tree()
+	if tree == null:
+		return null
+	var root := tree.root
+	if root == null:
+		return null
+	if path == "/root" or path == "/root/":
+		return root
+	if path.begins_with("/root/"):
+		return root.get_node_or_null(path.substr(6))
+	if path.begins_with("/"):
+		return root.get_node_or_null(path.substr(1))
+	var scene_root := tree.current_scene
+	return scene_root.get_node_or_null(path) if scene_root else null
+
+
+# List autoload singleton paths (direct children of /root, excluding the current
+# scene and this bridge node). Used to guide callers to global state the scene
+# walk cannot reach.
+func _list_autoload_paths(scene_root: Node) -> Array:
+	var out: Array = []
+	var tree := get_tree()
+	if tree == null or tree.root == null:
+		return out
+	for child in tree.root.get_children():
+		if child == scene_root or child == self:
+			continue
+		out.append("/root/" + str(child.name))
+	return out
 
 
 func _find_camera_2d() -> Camera2D:

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -31,6 +31,7 @@ describe('runtimeState tool', () => {
           action: 'digest',
           select: 'group',
           group: 'my_watch',
+          paths: ['/root/GameState', '/root/SimulationClock'],
           name: 'Player*',
           type: 'CharacterBody2D',
           max_nodes: 10,
@@ -41,6 +42,12 @@ describe('runtimeState tool', () => {
 
     it('rejects digest with invalid select value', () => {
       expect(runtimeState.schema.safeParse({ action: 'digest', select: 'invalid' }).success).toBe(false);
+    });
+
+    it('accepts select="none" with explicit paths', () => {
+      expect(
+        runtimeState.schema.safeParse({ action: 'digest', select: 'none', paths: ['/root/GameState'] }).success
+      ).toBe(true);
     });
 
     it('rejects digest with max_nodes out of range', () => {
@@ -116,6 +123,7 @@ describe('runtimeState tool', () => {
           action: 'digest',
           select: 'group',
           group: 'my_watch',
+          paths: ['/root/GameState'],
           name: 'Player',
           type: 'CharacterBody2D',
           max_nodes: 10,
@@ -127,10 +135,36 @@ describe('runtimeState tool', () => {
       const params = mock.calls[0].params;
       expect(params.select).toBe('group');
       expect(params.group).toBe('my_watch');
+      expect(params.paths).toEqual(['/root/GameState']);
       expect(params.name).toBe('Player');
       expect(params.type).toBe('CharacterBody2D');
       expect(params.max_nodes).toBe(10);
       expect(params.include).toEqual(['transform', 'velocity']);
+    });
+
+    it('passes through state snapshot, available_autoloads, and unresolved_paths', async () => {
+      const response = {
+        scene: 'res://scenes/main.tscn',
+        selection: 'none',
+        entity_count: 1,
+        entities: [
+          { path: '/root/GameState', type: 'Node', state: { cash: 25000, tick_count: 8 } },
+        ],
+        available_autoloads: ['/root/GameState', '/root/SimulationClock'],
+        unresolved_paths: ['/root/Nope'],
+      };
+      mock.mockResponse(response);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        { action: 'digest', select: 'none', paths: ['/root/GameState', '/root/Nope'] },
+        ctx
+      );
+      const data = structuredOf(result);
+
+      expect(data.entities[0].state).toEqual({ cash: 25000, tick_count: 8 });
+      expect(data.available_autoloads).toEqual(['/root/GameState', '/root/SimulationClock']);
+      expect(data.unresolved_paths).toEqual(['/root/Nope']);
     });
 
     it('includes hint field in fallback selection result', async () => {

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -31,6 +31,8 @@ interface DigestResponse {
   camera?: EntitySnapshot;
   entities: EntitySnapshot[];
   hint?: string;
+  unresolved_paths?: string[];
+  available_autoloads?: string[];
 }
 
 interface WatchRawSample {
@@ -146,16 +148,28 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'checks without a screenshot.'
       ),
     select: z
-      .enum(['group', 'method', 'auto'])
+      .enum(['group', 'method', 'auto', 'none'])
       .optional()
       .describe(
         'Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), ' +
-        '"auto" = best available (default: auto picks group → method → visible CanvasItems)'
+        '"auto" = best available (default: auto picks group → method → visible CanvasItems), ' +
+        '"none" = no automatic selection; return only the nodes named in paths'
       ),
     group: z
       .string()
       .optional()
       .describe('Group name to use when select="group" or "auto" (default: "mcp_watch")'),
+    paths: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Explicit absolute node paths to include in addition to tier selection, e.g. ' +
+        '["/root/GameState"]. The digest walks the current scene only, so autoload ' +
+        'singletons — where global game state often lives (cash, score, settings) — are ' +
+        'otherwise unreachable. Each path returns _mcp_state() if present, else a snapshot ' +
+        'of the node\'s script variables (scalars/arrays, ~1 KB cap). Paths that do not ' +
+        'resolve are returned in unresolved_paths.'
+      ),
     name: z.string().optional().describe('Glob filter on node name (e.g. "Player*")'),
     type: z.string().optional().describe('Class filter (e.g. "CharacterBody2D")'),
     max_nodes: z
@@ -253,6 +267,7 @@ export const runtimeState = defineTool({
         const params: Record<string, unknown> = {};
         if (args.select !== undefined) params.select = args.select;
         if (args.group !== undefined) params.group = args.group;
+        if (args.paths !== undefined) params.paths = args.paths;
         if (args.name !== undefined) params.name = args.name;
         if (args.type !== undefined) params.type = args.type;
         if (args.max_nodes !== undefined) params.max_nodes = args.max_nodes;


### PR DESCRIPTION
## Summary

`godot_runtime_state`'s `digest` walks the current scene only, so **autoload singletons** under `/root` — where global game state (cash, score, settings) typically lives — were completely unreachable. This makes the one-shot digest near-useless for whole genres (sims, anything with state centralized in singletons).

This adds a `paths` parameter so callers can read those nodes directly, plus the ergonomics and discovery to make it actually used.

## What's added

- **`paths: string[]`** — explicit absolute node paths included alongside tier selection. Each returns `_mcp_state()` if present, else a snapshot of the node's **script variables** (`PROPERTY_USAGE_SCRIPT_VARIABLE`) so it works with **zero game-side changes**. Snapshot is restricted to JSON-able scalars/arrays, skips private (`_`) vars and non-serializable values (Objects/NodePaths/dicts), and is ~1 KB capped (`_truncated`). Unresolved paths come back in `unresolved_paths`.
- **`select: "none"`** — return only the explicitly named `paths`, no tier walk. Clean singleton reads with no fallback noise.
- **`available_autoloads`** on every digest response — the digest is now self-describing: every call lists the singletons readable via `paths`, so an agent never has to guess. The fallback hint points at it.
- **Dedup** — explicit-path entities are deduped against the tier walk and each other by absolute path.

## Dogfooded on a real game

Validated live against a running city-builder sim whose state lives in a `GameState` autoload:

Before — bare `digest` returned 32 UI-scaffold nodes, zero sim state, missed `GameState` entirely.

After — `digest select="none" paths=["/root/GameState"]`:
```json
{ "path": "/root/GameState", "type": "Node",
  "state": { "cash": 25000, "tick_count": 20, "total_population": 0, "total_happiness": 0,
             "occupied_residential": 0, "city_name": "Gridtown", "loan_active": false, ... } }
```
Exact live state, ~250 bytes, no vision tokens, no game changes. `available_autoloads` and dedup verified live too (a path already in the tier walk and a duplicate path each collapse to one entry).

## Docs

- `docs/runtime-state-guide.md`: new "Reading global state in autoloads" section (`paths` / `select="none"` / `available_autoloads` / script-var snapshot), the `none` tier added to the selection table, and a note that absolute paths work for `watch` too. (The guide previously implied `mcp_watch`/`_mcp_state()` was the only path to good data, which would mislead someone into instrumenting an autoload the digest never visits.)
- `docs/tools/runtime-state.md`: regenerated for the new `paths` param and `select="none"`.

## Tests

224 passing (added schema/passthrough/response-shape coverage for `paths`, `select="none"`, `state`, `available_autoloads`, `unresolved_paths`). Server-only + addon; no protocol break. The addon GDScript has no unit-test harness, so that side was verified by the live dogfood above.

## Follow-ups (not in this PR)

- **Auto-discovery of opt-in autoloads** — let `auto`/`method`/`group` tiers also scan `/root` for autoloads in `mcp_watch` or implementing `_mcp_state()`, so a zero-arg digest finds them without explicit paths. Deferred because it needs a policy call on which autoloads qualify (avoid dumping `EventBus`/`AudioManager` noise).
- **`godot_input` has no mouse/coordinate support** — surfaced while dogfooding (couldn't script mouse-driven zone placement). Separate, larger gap worth its own issue.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
