### PR TITLE
fix: on-screen detection for 3D frustum, 2D camera transforms, and SubViewports

### DIFF
--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -65,7 +65,8 @@ For each selected node the digest returns the fields that apply to it:
 - `pos`, `rot`, `scale` for `Node2D` / `Node3D`
 - `vel` (and `angvel` for rigid bodies) for `CharacterBody2D/3D` and `RigidBody2D/3D`
 - `anim` / `anim_pos` / `anim_frame` / `playing` for `AnimationPlayer` / `AnimatedSprite2D`
-- `onscreen` for a `Node2D` when a `Camera2D` is active
+- `onscreen` for `Node2D` (against the active `Camera2D`'s visible world rect) and
+  `Node3D` (against the active `Camera3D` frustum) -- see "On-screen detection" below
 - `state` -- whatever your `_mcp_state()` returns (see below)
 
 Use a different group name with the `group` parameter; `mcp_watch` is just the default.
@@ -122,6 +123,26 @@ func _mcp_state() -> Dictionary:
         "grid_size": { "w": grid.width, "h": grid.height },
     }
 ```
+
+---
+
+## On-screen detection
+
+The `onscreen` flag reports whether a node's position is within the current view.
+The camera is resolved from the node's **own viewport**, so a node inside a
+`SubViewport` is tested against that SubViewport's camera, not the main window's.
+
+- **3D** (`Node3D`): true when the position is inside the active `Camera3D` frustum
+  (`is_position_in_frustum`), honoring perspective/orthographic projection and the
+  near/far planes.
+- **2D** (`Node2D`): true when the position is inside the active `Camera2D`'s visible
+  **world** rect -- derived from the viewport's canvas transform, so camera offset and
+  zoom are accounted for. A `VisibleOnScreenNotifier2D` is queried directly when the
+  node is one.
+- The flag is **omitted** (not reported as `false`) when it cannot be decided -- e.g. a
+  3D node with no active `Camera3D`, or a 2D node with no active `Camera2D`.
+- Boundary: the 2D rect test is inclusive of the top/left edge and exclusive of the
+  bottom/right edge (Godot `Rect2.has_point` semantics).
 
 ---
 

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -3,6 +3,7 @@ class_name MCPGameBridge
 
 const DEFAULT_MAX_WIDTH := 1024
 const DEFAULT_JPEG_QUALITY := 0.75
+const Onscreen := preload("onscreen.gd")
 
 var _logger: _MCPGameLogger
 var _profiler: MCPFrameProfiler
@@ -414,11 +415,11 @@ func _handle_get_runtime_state(data: Array) -> void:
 	var include_fields: Array = params.get("include", [])
 	max_nodes = clampi(max_nodes, 1, 200)
 
-	# Resolve camera for on-screen checks
+	# Resolve a 2D camera for the optional camera entity. On-screen checks no
+	# longer use this — they resolve the camera per-node from the node's own
+	# viewport (see Onscreen.compute), which is what makes SubViewport cameras
+	# work correctly.
 	var camera_2d: Camera2D = _find_camera_2d()
-	var camera_viewport_rect := Rect2()
-	if camera_2d:
-		camera_viewport_rect = camera_2d.get_viewport_rect()
 
 	# Determine which selection tier to use
 	var actual_selection: String = select_mode
@@ -434,7 +435,7 @@ func _handle_get_runtime_state(data: Array) -> void:
 	var entities: Array = []
 	if actual_selection != "none":
 		_collect_runtime_state(scene_root, scene_root, actual_selection, group_name,
-			name_filter, type_filter, include_fields, camera_2d, camera_viewport_rect,
+			name_filter, type_filter, include_fields,
 			max_nodes, entities)
 
 	# Explicit paths: include nodes the scene walk cannot reach (e.g. autoload
@@ -457,18 +458,17 @@ func _handle_get_runtime_state(data: Array) -> void:
 			if seen_paths.has(abs_path):
 				continue
 			seen_paths[abs_path] = true
-			var ent := _extract_node_state(n, scene_root, include_fields, camera_2d, camera_viewport_rect, true)
+			var ent := _extract_node_state(n, scene_root, include_fields, true)
 			ent["path"] = abs_path
 			entities.append(ent)
 
 	# Extract camera entity separately if present
 	var camera_entity = null
-	var cam_node := _find_camera_2d() if actual_selection != "fallback" else camera_2d
-	if cam_node:
+	if camera_2d:
 		camera_entity = {
 			"type": "Camera2D",
-			"pos": {"x": snapped(cam_node.global_position.x, 0.01), "y": snapped(cam_node.global_position.y, 0.01)},
-			"zoom": {"x": snapped(cam_node.zoom.x, 0.01), "y": snapped(cam_node.zoom.y, 0.01)},
+			"pos": {"x": snapped(camera_2d.global_position.x, 0.01), "y": snapped(camera_2d.global_position.y, 0.01)},
+			"zoom": {"x": snapped(camera_2d.zoom.x, 0.01), "y": snapped(camera_2d.zoom.y, 0.01)},
 			"camera": true,
 		}
 
@@ -524,7 +524,6 @@ func _has_mcp_state_nodes(node: Node) -> bool:
 
 func _collect_runtime_state(node: Node, scene_root: Node, selection: String, group_name: String,
 		name_filter: String, type_filter: String, include_fields: Array,
-		camera_2d: Camera2D, viewport_rect: Rect2,
 		max_nodes: int, results: Array) -> void:
 	if results.size() >= max_nodes:
 		return
@@ -545,7 +544,7 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 			include_node = false
 
 	if include_node:
-		var entity := _extract_node_state(node, scene_root, include_fields, camera_2d, viewport_rect)
+		var entity := _extract_node_state(node, scene_root, include_fields)
 		if entity != null:
 			results.append(entity)
 
@@ -553,7 +552,7 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 		if results.size() >= max_nodes:
 			return
 		_collect_runtime_state(child, scene_root, selection, group_name,
-			name_filter, type_filter, include_fields, camera_2d, viewport_rect,
+			name_filter, type_filter, include_fields,
 			max_nodes, results)
 
 
@@ -565,7 +564,7 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 # Error handling: _mcp_state() runtime errors are non-fatal in GDScript (Godot prints them
 # and the call returns null); the `is Dictionary` check below handles that silently.
 func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
-		camera_2d: Camera2D, viewport_rect: Rect2, allow_var_snapshot: bool = false) -> Dictionary:
+		allow_var_snapshot: bool = false) -> Dictionary:
 	var want := include_fields.is_empty()
 	var want_transform := want or include_fields.has("transform")
 	var want_velocity := want or include_fields.has("velocity")
@@ -632,9 +631,13 @@ func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 			entity["anim"] = asp.animation
 			entity["anim_frame"] = asp.frame
 
-	if want_onscreen and camera_2d and node is Node2D:
-		var pos := (node as Node2D).global_position
-		entity["onscreen"] = viewport_rect.has_point(pos)
+	if want_onscreen:
+		# Resolve the camera from the node's own viewport (handles SubViewport
+		# cameras) and use the correct geometry per dimension — 3D frustum, 2D
+		# visible world rect. Returns null when undeterminable; omit the field.
+		var onscreen = Onscreen.compute(node)
+		if onscreen != null:
+			entity["onscreen"] = onscreen
 
 	if want_state:
 		if node.has_method("_mcp_state"):

--- a/godot/addons/godot_mcp/game_bridge/onscreen.gd
+++ b/godot/addons/godot_mcp/game_bridge/onscreen.gd
@@ -1,0 +1,50 @@
+extends RefCounted
+
+## On-screen / in-frustum detection for the runtime-state digest.
+##
+## Each entity in a `digest` can carry an `onscreen` bool. Getting that geometry
+## right across 2D, 3D and SubViewport cameras is the fiddly part, so it lives
+## here as pure, side-effect-free static helpers shared by MCPGameBridge and the
+## headless test (test/onscreen_headless_test.gd).
+##
+## The camera is always resolved from the NODE'S OWN viewport, so a node that
+## lives inside a SubViewport is tested against that SubViewport's camera rather
+## than the main window camera.
+
+# Visible world-space Rect2 for a 2D viewport. Maps the viewport's screen rect
+# back through the inverse canvas transform, so camera offset, zoom, position
+# and drag margins are all accounted for. (Under a rotated camera this is the
+# axis-aligned bounds of the visible region, which is the right approximation
+# for a coarse on-screen flag.)
+static func visible_world_rect_2d(viewport: Viewport) -> Rect2:
+	return viewport.get_canvas_transform().affine_inverse() * viewport.get_visible_rect()
+
+# Whether `node` is on screen. Returns a bool when it can be decided, or null
+# when it cannot (no camera of the matching dimension, or the node is neither
+# 2D nor 3D) so the caller can omit the field rather than report a guess.
+static func compute(node: Node) -> Variant:
+	var viewport := node.get_viewport()
+	if viewport == null:
+		return null
+
+	# 3D: the engine's frustum test is authoritative (handles perspective and
+	# orthographic projections plus the near/far planes).
+	if node is Node3D:
+		var cam3d := viewport.get_camera_3d()
+		if cam3d == null or not cam3d.is_inside_tree():
+			return null
+		return cam3d.is_position_in_frustum((node as Node3D).global_position)
+
+	# 2D: an opted-in notifier is the most accurate signal when the game has one.
+	if node is VisibleOnScreenNotifier2D:
+		return (node as VisibleOnScreenNotifier2D).is_on_screen()
+
+	# 2D fallback: test the world position against the camera's visible world
+	# rect. Requires an active Camera2D; without one "on screen" is ambiguous so
+	# we omit the field.
+	if node is Node2D:
+		if viewport.get_camera_2d() == null:
+			return null
+		return visible_world_rect_2d(viewport).has_point((node as Node2D).global_position)
+
+	return null

--- a/godot/addons/godot_mcp/test/onscreen_headless_test.gd
+++ b/godot/addons/godot_mcp/test/onscreen_headless_test.gd
@@ -1,0 +1,207 @@
+extends SceneTree
+
+## Headless test for on-screen / in-frustum detection (addons/godot_mcp/game_bridge/onscreen.gd).
+##
+## Validates the `onscreen` flag geometry the digest reports, across the three
+## camera setups called out in the perception spike (godot-mcp #200):
+##   - 3D camera: positions inside / behind / beside / beyond the frustum.
+##   - 2D camera with offset + zoom: the visible *world* rect (not the screen
+##     rect), including the boundary (min edge inclusive, max edge exclusive)
+##     and the regression where the old screen-rect test inverted the result.
+##   - SubViewport: a node is judged against ITS OWN viewport's camera, so the
+##     same world coordinate is on-screen in one SubViewport and off in another.
+##
+## This is not wired into CI (CI has no Godot). Run it on demand against any
+## project that has the addon copied in (e.g. the city-builder dev project):
+##
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/onscreen_headless_test.gd"
+##
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const Onscreen := preload("res://addons/godot_mcp/game_bridge/onscreen.gd")
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	# Run as a coroutine so we can await a few frames for cameras to apply their
+	# transforms before sampling.
+	_run()
+
+
+func _run() -> void:
+	# Let autoloads settle and cameras register / apply canvas transforms.
+	for i in 3:
+		await process_frame
+
+	# The 3D test is synchronous; the 2D tests await a frame for the camera to
+	# apply its canvas transform, so each must be awaited to run to completion
+	# before the next starts and before we report.
+	_test_3d_frustum()
+	await _test_2d_offset_and_boundary()
+	await _test_2d_zoom()
+	await _test_subviewport_isolation()
+	await _test_notifier_path()
+
+	print("1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+# ── Tiny TAP-ish harness ──────────────────────────────────────────────────────
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+func _check_rect(label: String, got: Rect2, expected: Rect2) -> void:
+	_count += 1
+	if got.position.is_equal_approx(expected.position) and got.size.is_equal_approx(expected.size):
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+# ── 3D frustum ────────────────────────────────────────────────────────────────
+
+func _test_3d_frustum() -> void:
+	# Camera at origin looking down -Z (identity transform), default perspective.
+	var cam := Camera3D.new()
+	root.add_child(cam)
+	cam.current = true
+
+	var inside := _node3d_at(Vector3(0, 0, -10))
+	var behind := _node3d_at(Vector3(0, 0, 10))
+	var beside := _node3d_at(Vector3(1000, 0, -10))
+	var beyond_far := _node3d_at(Vector3(0, 0, -5000)) # past the 4000 far plane
+
+	_check("3D: in front is on-screen", Onscreen.compute(inside), true)
+	_check("3D: behind camera is off-screen", Onscreen.compute(behind), false)
+	_check("3D: far to the side is off-screen", Onscreen.compute(beside), false)
+	_check("3D: beyond far plane is off-screen", Onscreen.compute(beyond_far), false)
+
+
+# ── 2D offset + boundary (the core regression) ────────────────────────────────
+
+func _test_2d_offset_and_boundary() -> void:
+	# 200x200 SubViewport, camera centered on world (1000, 1000), no zoom.
+	# Visible world rect is therefore Rect2(900, 900, 200, 200).
+	var sv := _make_subviewport(Vector2i(200, 200))
+	_make_camera2d(sv, Vector2(1000, 1000), Vector2.ONE)
+	for i in 2:
+		await process_frame
+
+	_check_rect("2D: visible world rect tracks camera offset",
+		Onscreen.visible_world_rect_2d(sv), Rect2(900, 900, 200, 200))
+
+	var center := _node2d_at(sv, Vector2(1000, 1000))
+	var origin := _node2d_at(sv, Vector2(0, 0))
+	var min_edge := _node2d_at(sv, Vector2(900, 900))
+	var max_edge := _node2d_at(sv, Vector2(1100, 1100))
+
+	# Under the camera offset these are the right answers. The old code tested the
+	# world position against the SCREEN rect Rect2(0,0,200,200), which inverted
+	# them: it reported the centered node off-screen and the origin node on.
+	_check("2D: node at camera center is on-screen", Onscreen.compute(center), true)
+	_check("2D: distant node (world origin) is off-screen", Onscreen.compute(origin), false)
+	_check("2D: min-edge corner is on-screen (inclusive)", Onscreen.compute(min_edge), true)
+	_check("2D: max-edge corner is off-screen (exclusive)", Onscreen.compute(max_edge), false)
+
+
+# ── 2D zoom ───────────────────────────────────────────────────────────────────
+
+func _test_2d_zoom() -> void:
+	# Zoom (2,2) halves the visible world extent: Rect2(950, 950, 100, 100).
+	var sv := _make_subviewport(Vector2i(200, 200))
+	_make_camera2d(sv, Vector2(1000, 1000), Vector2(2, 2))
+	for i in 2:
+		await process_frame
+
+	_check_rect("2D zoom: visible world rect shrinks with zoom",
+		Onscreen.visible_world_rect_2d(sv), Rect2(950, 950, 100, 100))
+
+	var inside := _node2d_at(sv, Vector2(960, 960))
+	var outside := _node2d_at(sv, Vector2(940, 940)) # inside the old (zoom-ignoring) rect, outside this one
+	_check("2D zoom: node inside zoomed rect is on-screen", Onscreen.compute(inside), true)
+	_check("2D zoom: node outside zoomed rect is off-screen", Onscreen.compute(outside), false)
+
+
+# ── SubViewport isolation ─────────────────────────────────────────────────────
+
+func _test_subviewport_isolation() -> void:
+	# Two SubViewports with cameras centered on different world points. A node at
+	# world (1000,1000) is on-screen only in the viewport whose camera is there —
+	# proving the camera is resolved per-node from the node's own viewport.
+	var sv_here := _make_subviewport(Vector2i(200, 200))
+	_make_camera2d(sv_here, Vector2(1000, 1000), Vector2.ONE)
+	var sv_far := _make_subviewport(Vector2i(200, 200))
+	_make_camera2d(sv_far, Vector2(5000, 5000), Vector2.ONE)
+	for i in 2:
+		await process_frame
+
+	var here := _node2d_at(sv_here, Vector2(1000, 1000))
+	var far := _node2d_at(sv_far, Vector2(1000, 1000))
+	_check("SubViewport: on-screen under the camera that frames it", Onscreen.compute(here), true)
+	_check("SubViewport: same world coord off-screen under a different viewport's camera",
+		Onscreen.compute(far), false)
+
+
+# ── VisibleOnScreenNotifier2D path ────────────────────────────────────────────
+
+func _test_notifier_path() -> void:
+	# When the node is a VisibleOnScreenNotifier2D we defer to is_on_screen().
+	# Headless has no real rendering-server visibility, so we assert only that the
+	# path is taken and returns a bool (never null), not a specific value.
+	var sv := _make_subviewport(Vector2i(200, 200))
+	_make_camera2d(sv, Vector2(0, 0), Vector2.ONE)
+	var notifier := VisibleOnScreenNotifier2D.new()
+	sv.add_child(notifier)
+	notifier.global_position = Vector2.ZERO
+	for i in 2:
+		await process_frame
+
+	_check("Notifier: compute() returns a bool via is_on_screen()",
+		typeof(Onscreen.compute(notifier)), TYPE_BOOL)
+
+
+# ── Builders ──────────────────────────────────────────────────────────────────
+
+func _node3d_at(pos: Vector3) -> Node3D:
+	var n := Node3D.new()
+	root.add_child(n)
+	n.global_position = pos
+	return n
+
+
+func _make_subviewport(size: Vector2i) -> SubViewport:
+	var sv := SubViewport.new()
+	sv.size = size
+	root.add_child(sv)
+	return sv
+
+
+func _make_camera2d(sv: SubViewport, world_pos: Vector2, zoom: Vector2) -> Camera2D:
+	var cam := Camera2D.new()
+	cam.zoom = zoom
+	sv.add_child(cam)
+	cam.global_position = world_pos
+	cam.make_current()
+	return cam
+
+
+func _node2d_at(sv: SubViewport, world_pos: Vector2) -> Node2D:
+	var n := Node2D.new()
+	sv.add_child(n)
+	n.global_position = world_pos
+	return n

--- a/server/scripts/copy-addon.ts
+++ b/server/scripts/copy-addon.ts
@@ -1,9 +1,17 @@
 import { rmSync, cpSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, relative, sep } from 'node:path';
 
 const src = resolve(process.cwd(), '../godot/addons/godot_mcp');
 const dest = resolve(process.cwd(), 'addon');
 
 rmSync(dest, { recursive: true, force: true });
-cpSync(src, dest, { recursive: true });
+// Ship everything except the dev-only headless test fixtures
+// (godot/addons/godot_mcp/test/), which consumers don't need.
+cpSync(src, dest, {
+  recursive: true,
+  filter: (source) => {
+    const rel = relative(src, source);
+    return rel === '' || rel.split(sep)[0] !== 'test';
+  },
+});
 console.log(`addon copied: ${src} → ${dest}`);


### PR DESCRIPTION
Closes #200.

## Problem

The digest's per-entity `onscreen` flag had two gaps (per the issue + owner's review):

1. **3D missing entirely** — there was no `Camera3D.is_position_in_frustum()` path, so 3D nodes never got an `onscreen` flag.
2. **2D geometrically wrong** — it tested a world `global_position` against the *screen-space* `get_viewport_rect()`, which only agrees when the camera has no offset/zoom.

## Fix

New shared helper `godot/addons/godot_mcp/game_bridge/onscreen.gd` (`Onscreen.compute(node)`), used by `_extract_node_state`:

- Resolves the camera from **the node's own viewport**, so nodes inside a `SubViewport` are tested against that SubViewport's camera (not the main window's).
- **3D** (`Node3D`): `Camera3D.is_position_in_frustum()`.
- **2D** (`Node2D`): the active `Camera2D`'s visible **world** rect, derived via `get_canvas_transform().affine_inverse() * get_visible_rect()` (accounts for offset + zoom); `VisibleOnScreenNotifier2D.is_on_screen()` when the node is one.
- Omits the flag (rather than reporting `false`) when undeterminable — e.g. no camera of the matching dimension.

Removes the now-dead `camera_2d`/`viewport_rect` params threaded through the digest walk (`camera_2d` is kept only for the 2D camera entity).

## Tests

`godot/addons/godot_mcp/test/onscreen_headless_test.gd` — a `SceneTree --script` headless test, **15 checks, all pass**:

- 3D frustum: in front / behind / beside / beyond far plane.
- 2D offset + boundary: visible world rect tracks camera offset; min edge inclusive, max edge exclusive; the old screen-rect test inverted these.
- 2D zoom: visible world rect shrinks with zoom.
- SubViewport isolation: the same world coordinate is on-screen under the camera that frames it and off-screen under a different viewport's camera.
- `VisibleOnScreenNotifier2D` path returns a bool.

Run it (not in CI — CI has no Godot):

```
<godot> --headless --path <project-with-addon> \
  --script res://addons/godot_mcp/test/onscreen_headless_test.gd
```

The `test/` dir is excluded from the shipped addon bundle via `copy-addon.ts`.

## Live dogfood (3D)

Ran against the city-builder 3D project. With the fix, `digest` now returns frustum-based `onscreen` flags for 3D nodes (it previously returned none):

- `DirectionalLight3D` at `(-22.36, 32.84, 19.12)` (up high, off to the side) → `onscreen: false`
- `Ground/GridMap` at `(0, 0, 0)` (ground center, in view) → `onscreen: true`

Both match the engine's own `is_position_in_frustum` for the active camera.

Server build + the full vitest suite (224 tests) pass.