### PR TITLE
fix(game-bridge): release held actions before clearing the input-sequence queue

### DIFF
--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -24,6 +24,9 @@ func _ready() -> void:
 
 
 func _exit_tree() -> void:
+	# Guaranteed cleanup: never leave an action latched when the bridge node
+	# leaves the tree (game shutdown / scene change). Safe if nothing is held.
+	_release_held_actions()
 	if EngineDebugger.is_active():
 		EngineDebugger.unregister_message_capture("godot_mcp")
 		if _profiler:
@@ -43,7 +46,10 @@ func _process(_delta: float) -> void:
 		input_event.pressed = seq_event.is_press
 		input_event.strength = 1.0 if seq_event.is_press else 0.0
 		Input.parse_input_event(input_event)
-		if not seq_event.is_press:
+		if seq_event.is_press:
+			_held_actions[seq_event.action] = true
+		else:
+			_held_actions.erase(seq_event.action)
 			_actions_completed += 1
 
 	if _sequence_events.is_empty():
@@ -60,6 +66,29 @@ var _sequence_start_time: int = 0
 var _sequence_running: bool = false
 var _actions_completed: int = 0
 var _actions_total: int = 0
+# Actions whose press has been injected but whose paired release has not yet
+# fired. Used to guarantee a release even if the queue is cleared mid-flight
+# (new sequence) or the node leaves the tree — otherwise the dropped release
+# latches the action "pressed" in the Input singleton (the stuck-held bug).
+var _held_actions: Dictionary = {}
+
+
+# Release any action still held from an interrupted sequence. A release here is a
+# guaranteed cleanup, never a queued step that a clear could drop. Safe to call
+# when nothing is held.
+func _release_held_actions() -> void:
+	if _held_actions.is_empty():
+		return
+	for action in _held_actions.keys():
+		var release := InputEventAction.new()
+		release.action = action
+		release.pressed = false
+		release.strength = 0.0
+		Input.parse_input_event(release)
+	# Flush so the release takes effect immediately — _exit_tree may not get
+	# another frame, and a cleanup should be deterministic, not deferred.
+	Input.flush_buffered_events()
+	_held_actions.clear()
 
 
 func _on_debugger_message(message: String, data: Array) -> bool:
@@ -890,6 +919,10 @@ func _handle_execute_input_sequence(data: Array) -> void:
 		}])
 		return
 
+	# Release anything still held from a prior, interrupted sequence BEFORE
+	# clearing the queue — otherwise that sequence's unfired releases are dropped
+	# and its actions stay latched (stuck-held bug).
+	_release_held_actions()
 	_sequence_events.clear()
 	_actions_completed = 0
 	_actions_total = inputs.size()

--- a/godot/addons/godot_mcp/test/input_sequence_stuck_held_test.gd
+++ b/godot/addons/godot_mcp/test/input_sequence_stuck_held_test.gd
@@ -1,0 +1,103 @@
+extends SceneTree
+
+## Regression guard for a stuck-held bug in the execute_input_sequence engine.
+## Drives the REAL MCPGameBridge node.
+##
+## THE BUG: MCPGameBridge._handle_execute_input_sequence() begins each call with
+## `_sequence_events.clear()`. If a prior sequence is still mid-flight (e.g. the
+## editor side hit its INPUT_TIMEOUT and the agent retried, or a second call
+## overlapped), any already-fired press whose paired RELEASE is still queued has
+## that release dropped by the clear — latching the action "pressed" in the Input
+## singleton with nothing left to release it, so it never lifts until restart.
+##
+## THE FIX: track actions whose press has fired in `_held_actions` and release
+## them before clearing / on tree exit, so a clear can never strand a release.
+## This test asserts the FIXED invariant: starting a new sequence while one is
+## mid-flight must NOT leave the earlier action latched.
+##
+## Pre-fix this test FAILS check "A not latched after overlapping start"; post-fix
+## it PASSES. Runs HEADLESS or windowed (Input action singleton is drivable on
+## both). The bridge's _ready() early-returns without a debugger session, which is
+## fine — the sequence engine and its EngineDebugger.send_message replies are
+## inert/no-ops here; only the _process drain + held tracking are under test.
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/input_sequence_stuck_held_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const ACTION_A := "mcp_probe_seq_a"
+const ACTION_B := "mcp_probe_seq_b"
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+	for a in [ACTION_A, ACTION_B]:
+		if not InputMap.has_action(a):
+			InputMap.add_action(a)
+
+	print("\n===================== INPUT-SEQUENCE STUCK-HELD TEST =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var bridge := MCPGameBridge.new()
+	root.add_child(bridge)
+	for i in 3:
+		await process_frame
+
+	# First sequence: a LONG hold of A (release scheduled far in the future).
+	bridge._handle_execute_input_sequence([[
+		{"action_name": ACTION_A, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame  # one frame: press at t=0 fires, release at t=100000 stays queued
+	_check("A pressed after first sequence starts its hold", Input.is_action_pressed(ACTION_A), true)
+
+	# Second sequence STARTS while A's hold is still mid-flight. The shipped code
+	# clears the queue here, dropping A's pending release. The fix releases A first.
+	bridge._handle_execute_input_sequence([[
+		{"action_name": ACTION_B, "start_ms": 0, "duration_ms": 10},
+	]])
+	await process_frame
+	_check("A NOT latched after an overlapping sequence start (the bug guard)",
+		Input.is_action_pressed(ACTION_A), false)
+
+	# And the second sequence itself should run and release B cleanly.
+	await create_timer(0.06).timeout
+	for i in 4:
+		await process_frame
+	_check("B released after its short hold completes", Input.is_action_pressed(ACTION_B), false)
+
+	# Tree-exit must not strand a held action either: start a hold, then remove.
+	bridge._handle_execute_input_sequence([[
+		{"action_name": ACTION_A, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	_check("A pressed again for the exit-tree case", Input.is_action_pressed(ACTION_A), true)
+	root.remove_child(bridge)
+	_check("A released when the bridge leaves the tree", Input.is_action_pressed(ACTION_A), false)
+	bridge.free()
+
+	for a in [ACTION_A, ACTION_B]:
+		if InputMap.has_action(a):
+			InputMap.erase_action(a)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])


### PR DESCRIPTION
## Problem

`MCPGameBridge._handle_execute_input_sequence()` begins every call with `_sequence_events.clear()`. If a prior sequence is still mid-flight — the editor side hit its 30s `INPUT_TIMEOUT` and the agent retried, or two `execute_input_sequence` calls overlapped — any already-fired press whose paired **release** is still queued has that release dropped by the clear. The action stays latched `pressed` in the `Input` singleton with nothing left to release it, so it never lifts until the game restarts.

## Fix

Track actions whose press has fired in `_held_actions` and release them — flushed immediately — before clearing the queue and on `_exit_tree`. A release becomes a guaranteed cleanup, never a queued step a clear can drop.

## Test

Adds `input_sequence_stuck_held_test.gd`, which drives the real `MCPGameBridge` node:
- **fails** on the pre-fix code (action latched after an overlapping start, and after the node leaves the tree)
- **passes** after the fix — verified 5/5 headless and windowed.

```
& "<godot.exe>" [--headless] --path "<project-with-addon>" \
    --script "res://addons/godot_mcp/test/input_sequence_stuck_held_test.gd"
```

## Scope

Self-contained bug fix to the existing keyboard/action input path — no new feature, no API change, addon-only (release-please will pick up the `fix:` as a patch). It surfaced during a mouse-input research spike but is independent of it; the spike concluded separately (see the forthcoming mouse-input decision doc and issue #228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)