### PR TITLE
chore: remove dead include-paths from release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "node",
       "package-name": "@satelliteoflove/godot-mcp",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "include-paths": ["godot"]
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
`.github/release-please-config.json` carried `"include-paths": ["godot"]`, which looked like it made addon-only (`godot/`) commits trigger a release. It doesn't — **`include-paths` is not a real release-please option** ([release-please#2339](https://github.com/googleapis/release-please/issues/2339), "has no effect"). It was silently ignored, so the `server` package only ever watched `server/`. That's why the addon-only `execute_input_sequence` fix (#231) produced no release PR.

This removes the dead key so the config reflects actual behavior. **No functional change** (the key was already a no-op); a `chore:` so it doesn't cut a release.

The real fix — the `additional-paths` option ([release-please#2534](https://github.com/googleapis/release-please/pull/2534), still unmerged upstream) — and the alternative `linked-versions` restructure are tracked in #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)