### PR TITLE
fix(game-bridge): keep processing while the scene tree is paused

### DIFF
--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -11,6 +11,13 @@ var _sampler: MCPRuntimeStateSampler
 
 
 func _ready() -> void:
+	# The bridge must keep processing while the scene tree is paused. Input
+	# sequences are driven from _process, so without this a press that toggles
+	# `paused = true` freezes the runner mid-sequence: the paired release never
+	# fires and the editor-side wait times out (~30s) — pause menus, a primary
+	# injection target, become undrivable. The bridge answers to the debugger,
+	# not the game's pause state. Children (the sampler) inherit this mode.
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	if not EngineDebugger.is_active():
 		return
 	_logger = _MCPGameLogger.new()


### PR DESCRIPTION
## Problem

The game bridge's input-sequence runner lives in `_process`. An injected press that toggles `get_tree().paused = true` froze the bridge on that exact frame: the paired release never fired, the sequence never completed, and the editor-side wait surfaced `[TIMEOUT]` after ~30s. From an agent's seat: any input that *causes* a pause hangs for 30 seconds, and pause menus cannot be driven at all.

Fixes #238

## Fix

`process_mode = Node.PROCESS_MODE_ALWAYS` on the bridge node in `_ready()` — the bridge answers to the debugger, not the game's pause state.

Scope audit — this one line covers the whole pause surface:

- the runtime-state sampler is a child with default `PROCESS_MODE_INHERIT`, so it inherits ALWAYS (digests/watches keep working against a paused game)
- `type_text`'s `SceneTreeTimer`s already default to `process_always = true`
- screenshots await `RenderingServer.frame_post_draw`, which keeps firing while paused since rendering continues

## Acceptance evidence

Machine-checked pre/post flip via the e2e apparatus prototype (#252) — same declarative scenario file, zero edits, against a frame-counter canary fixture (server+addon 3.7.0, Godot 4.6.3-stable, Windows 11):

| Bridge | Verdict | Duration | Failure |
|---|---|---|---|
| stock | **FAIL** | 36.1s | `[TIMEOUT] Timed out waiting for input sequence to complete` (on the pause tap itself) |
| this branch | **PASS** | 7.1s | — |

Key asserts in the passing run: pausable `physics_calls` Δ == 0 across a 500ms `fire` hold injected *into the paused game* (the world stays exactly frozen); `always_fire_held_frames` 0→30 (an ALWAYS-mode node observed the held action during pause — the pause-menu-driving use case); `when_paused_calls` 7→42 (the pause genuinely persisted across the window); clean unpause afterward.

Full pre/post detail with raw run-ledger lines: https://github.com/satelliteoflove/godot-mcp/issues/238#issuecomment-4644332098

🤖 Generated with [Claude Code](https://claude.com/claude-code)
