### PR TITLE
feat: game time control for high-latency agents

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -22,6 +22,7 @@ func setup(plugin: EditorPlugin) -> void:
 	_register_handler(MCPInputCommands.new(), plugin)
 	_register_handler(MCPProfilerCommands.new(), plugin)
 	_register_handler(MCPRuntimeStateCommands.new(), plugin)
+	_register_handler(MCPGameTimeCommands.new(), plugin)
 
 
 func _register_handler(handler: MCPBaseCommand, plugin: EditorPlugin) -> void:

--- a/godot/addons/godot_mcp/commands/debug_commands.gd
+++ b/godot/addons/godot_mcp/commands/debug_commands.gd
@@ -3,6 +3,8 @@ extends MCPBaseCommand
 class_name MCPDebugCommands
 
 const DEBUG_OUTPUT_TIMEOUT := 5.0
+# Keep in sync with LAUNCH_FROZEN_ENV in mcp_game_bridge.gd.
+const LAUNCH_FROZEN_ENV := "GODOT_MCP_LAUNCH_FROZEN"
 
 var _debug_output_result: PackedStringArray = []
 var _debug_output_pending: bool = false
@@ -21,15 +23,32 @@ func get_commands() -> Dictionary:
 
 func run_project(params: Dictionary) -> Dictionary:
 	var scene_path: String = params.get("scene_path", "")
+	var frozen: bool = params.get("frozen", false)
 
 	MCPLogger.clear()
+
+	# Launch-frozen: the spawned game inherits the editor's environment, so
+	# setting this before play makes the bridge freeze the tree in _ready —
+	# before the first process frame. Deterministic, unlike sending a freeze
+	# message after the debug session comes up (which races the game's first
+	# frames against the agent's latency).
+	if frozen:
+		OS.set_environment(LAUNCH_FROZEN_ENV, "1")
 
 	if scene_path.is_empty():
 		EditorInterface.play_main_scene()
 	else:
 		EditorInterface.play_custom_scene(scene_path)
 
-	return _success({})
+	if frozen:
+		# The child captured its environment at spawn; clear promptly so a
+		# manual F5 run doesn't inherit the freeze. Two frames covers a
+		# deferred spawn. (Godot has no unset; empty fails the == "1" check.)
+		await Engine.get_main_loop().process_frame
+		await Engine.get_main_loop().process_frame
+		OS.set_environment(LAUNCH_FROZEN_ENV, "")
+
+	return _success({"frozen": frozen})
 
 
 func stop_project(_params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/commands/game_time_commands.gd
+++ b/godot/addons/godot_mcp/commands/game_time_commands.gd
@@ -1,0 +1,78 @@
+@tool
+extends MCPBaseCommand
+class_name MCPGameTimeCommands
+
+# Game-time control relay: freeze / step / thaw / status execute in the game
+# bridge (see mcp_game_bridge.gd); this side only forwards over the debugger
+# channel and waits. Timeout cascade: the step request is capped at 20s of
+# game time and the bridge's wall budget returns by 25s, so the 28s relay
+# timeout below fires only if the bridge is gone — and stays under the
+# server's 30s command timeout so errors surface typed instead of generic.
+const BASE_TIMEOUT := 10.0
+const STEP_TIMEOUT := 28.0
+
+var _last_error: Dictionary = {}
+
+
+func get_commands() -> Dictionary:
+	return {
+		"game_time_freeze": game_time_freeze,
+		"game_time_step": game_time_step,
+		"game_time_thaw": game_time_thaw,
+		"game_time_status": game_time_status,
+	}
+
+
+func game_time_freeze(params: Dictionary) -> Dictionary:
+	return await _relay("game_time_freeze", [params], BASE_TIMEOUT)
+
+
+func game_time_step(params: Dictionary) -> Dictionary:
+	return await _relay("game_time_step", [params], STEP_TIMEOUT)
+
+
+func game_time_thaw(params: Dictionary) -> Dictionary:
+	return await _relay("game_time_thaw", [params], BASE_TIMEOUT)
+
+
+func game_time_status(params: Dictionary) -> Dictionary:
+	return await _relay("game_time_status", [params], BASE_TIMEOUT)
+
+
+func _relay(msg_type: String, args: Array, timeout: float) -> Dictionary:
+	var response = await _send_and_wait(msg_type, args, timeout)
+	if response == null:
+		return _last_error
+	if response is Dictionary and response.has("error"):
+		return _error("GAME_TIME_ERROR", str(response["error"]))
+	if response is Dictionary:
+		return _success(response)
+	return _success({"data": response})
+
+
+func _send_and_wait(msg_type: String, args: Array, timeout: float):
+	if not EditorInterface.is_playing_scene():
+		_last_error = _error("NOT_RUNNING", "No game is currently running")
+		return null
+
+	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
+	if debugger_plugin == null or not debugger_plugin.has_active_session():
+		_last_error = _error("NO_SESSION", "No active debug session")
+		return null
+
+	var sent: bool = debugger_plugin.send_game_message(msg_type, args)
+	if not sent:
+		_last_error = _error("SEND_FAILED", "Failed to send message to game")
+		return null
+
+	var start_time := Time.get_ticks_msec()
+	while not debugger_plugin.has_response(msg_type):
+		await Engine.get_main_loop().process_frame
+		if (Time.get_ticks_msec() - start_time) / 1000.0 > timeout:
+			debugger_plugin.clear_response(msg_type)
+			_last_error = _error("TIMEOUT", "Timed out waiting for %s response" % msg_type)
+			return null
+
+	var response = debugger_plugin.get_response(msg_type)
+	debugger_plugin.clear_response(msg_type)
+	return response

--- a/godot/addons/godot_mcp/commands/game_time_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/game_time_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://c2pfjqe2yv0c4

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1179,7 +1179,8 @@ func _handle_game_time_thaw(_data: Array) -> void:
 	var was_frozen := _frozen
 	var result: Dictionary = {"frozen": false, "was_frozen": was_frozen}
 	if was_frozen:
-		result["frozen_for_ms"] = Time.get_ticks_msec() - _freeze_started_ticks
+		# Real wall-clock the freeze was held; game time did not advance while frozen.
+		result["frozen_wall_ms"] = Time.get_ticks_msec() - _freeze_started_ticks
 		_frozen = false
 		get_tree().paused = _game_paused
 		_update_processing()
@@ -1197,10 +1198,14 @@ func _handle_game_time_status(_data: Array) -> void:
 		"engine_time_scale": Engine.time_scale,
 		"physics_ticks_per_second": Engine.physics_ticks_per_second,
 	}
+	# `frozen` is the authoritative current state. `launched_frozen` is a historical
+	# fact (this run booted frozen via GODOT_MCP_LAUNCH_FROZEN) and stays true after
+	# thaw, so it must not be read as the present freeze state.
 	if _launched_frozen:
-		result["launch_frozen"] = true
+		result["launched_frozen"] = true
 	if _frozen:
-		result["frozen_for_ms"] = Time.get_ticks_msec() - _freeze_started_ticks
+		# Real wall-clock since freeze engaged, not game time (which is stopped).
+		result["frozen_wall_ms"] = Time.get_ticks_msec() - _freeze_started_ticks
 		result["freeze_transitions"] = _freeze_transition_count
 		if _freeze_transition_count >= FREEZE_CONTESTED_THRESHOLD:
 			# Something (an ALWAYS-mode node?) is repeatedly unpausing under

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -27,7 +27,17 @@ func _ready() -> void:
 	_sampler = MCPRuntimeStateSampler.new()
 	add_child(_sampler)
 	EngineDebugger.register_message_capture("godot_mcp", _on_debugger_message)
+	set_physics_process(false)  # only counts ticks during a step window
 	MCPLog.info("Game bridge initialized")
+
+	# Launch-frozen: the editor sets this env var just before spawning the game
+	# (godot_editor run with frozen=true), so the freeze lands before the first
+	# process frame — agent latency between run and the first input costs the
+	# game nothing. Scene _ready callbacks still run; processing does not start.
+	if OS.get_environment(LAUNCH_FROZEN_ENV) == "1":
+		_launched_frozen = true
+		_engage_freeze()
+		MCPLog.info("Game bridge: launched frozen")
 
 
 func _exit_tree() -> void:
@@ -40,7 +50,19 @@ func _exit_tree() -> void:
 			EngineDebugger.unregister_profiler("mcp_frame_profiler")
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
+	_game_time_process(delta)
+	_sequence_process()
+
+
+# Processing is needed by three independent features; only switch it off when
+# none of them is active (the frozen monitor must run every frame, so the old
+# "disable after the sequence" shortcut no longer applies unconditionally).
+func _update_processing() -> void:
+	set_process(_sequence_running or _frozen or _step_active)
+
+
+func _sequence_process() -> void:
 	if not _sequence_running or _sequence_events.is_empty():
 		return
 
@@ -61,7 +83,7 @@ func _process(_delta: float) -> void:
 
 	if _sequence_events.is_empty():
 		_sequence_running = false
-		set_process(false)
+		_update_processing()
 		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
 			"completed": true,
 			"actions_executed": _actions_completed,
@@ -141,6 +163,18 @@ func _on_debugger_message(message: String, data: Array) -> bool:
 			return true
 		"watch_stop":
 			_handle_watch_stop()
+			return true
+		"game_time_freeze":
+			_handle_game_time_freeze(data)
+			return true
+		"game_time_step":
+			_handle_game_time_step(data)
+			return true
+		"game_time_thaw":
+			_handle_game_time_thaw(data)
+			return true
+		"game_time_status":
+			_handle_game_time_status(data)
 			return true
 	return false
 
@@ -965,7 +999,7 @@ func _handle_execute_input_sequence(data: Array) -> void:
 
 	_sequence_start_time = Time.get_ticks_msec()
 	_sequence_running = true
-	set_process(true)
+	_update_processing()
 
 
 func _handle_type_text(data: Array) -> void:
@@ -1022,3 +1056,319 @@ func _type_text_async(text: String, delay_ms: int, submit: bool) -> void:
 		"chars_typed": text.length(),
 		"submitted": submit,
 	}])
+
+
+# ---------------------------------------------------------------------------
+# Game-time control (freeze / step / thaw / status)
+#
+# Real-time games race ahead of high-latency agents: 10-40s of consequences
+# land between every observation and the action it informs. These primitives
+# make game time answer to the agent's clock instead: freeze the tree, think
+# arbitrarily long (all observation tools work while frozen — rendering
+# continues during pause), then step forward a bounded slice of game time
+# with inputs riding inside the window.
+#
+# tree.paused is a single bit that two parties now write: the game's own
+# pause menu and this freeze. The bridge layers them — effective state is
+# (game_paused OR frozen) — by observing and re-asserting: it cannot
+# intercept writes, but it processes every frame (PROCESS_MODE_ALWAYS, and
+# as an autoload it runs BEFORE the scene), so a game-code flip is caught on
+# the next frame, recorded as the game layer's new intent, and overridden
+# while frozen. step/thaw restore the game's wish, not whatever we found.
+#
+# What freeze means: exactly what runs during the game's own pause menu runs
+# during freeze (WHEN_PAUSED/ALWAYS nodes, process_always timers). A game
+# with a correct pause menu has already partitioned pause-immune from
+# pausable code; freeze rides that contract. Games that "pause" by writing
+# Engine.time_scale = 0 instead are frozen solid too, but their pause is
+# invisible to the layer model (it looks like gameplay state, not pause
+# state) — documented limitation.
+# ---------------------------------------------------------------------------
+
+const LAUNCH_FROZEN_ENV := "GODOT_MCP_LAUNCH_FROZEN"
+# Timeout cascade: step request <= 20s game time, wall budget 25s, editor
+# relay 28s, server command timeout 30s. Each layer answers before the one
+# above it gives up.
+const STEP_MAX_MS := 20000
+const STEP_MAX_FRAMES := 1200
+const STEP_WALL_BUDGET_MS := 25000
+const STEP_MAX_TRANSITIONS := 50
+const FREEZE_CONTESTED_THRESHOLD := 10
+
+var _frozen := false
+var _game_paused := false  # the game layer's own pause intent, inferred by observation
+var _launched_frozen := false
+var _freeze_started_ticks := 0
+var _freeze_transition_count := 0
+
+var _step_active := false
+var _step_finish_pending := false
+var _step_needs_settle := false
+var _step_wall_exceeded := false
+var _step_target_ms := 0.0
+var _step_target_frames := 0
+var _step_elapsed_ms := 0.0  # accumulated scaled delta = game time (wall-of-step, includes game-paused stretches)
+var _step_gameplay_ms := 0.0  # the unpaused portion: what gameplay actually experienced
+var _step_frames := 0
+var _step_physics_ticks := 0
+var _step_wall_start := 0
+var _step_events: Array = []  # in-step input timeline, scheduled on the game-time clock
+var _step_events_fired := 0
+var _step_transitions: Array = []
+var _step_last_tree_paused := false
+
+
+func _send_game_time_response(msg_type: String, result: Dictionary) -> void:
+	EngineDebugger.send_message("godot_mcp:game_response", [msg_type, result])
+
+
+func _engage_freeze() -> void:
+	if _frozen:
+		return
+	var tree := get_tree()
+	_game_paused = tree.paused
+	_frozen = true
+	_freeze_started_ticks = Time.get_ticks_msec()
+	_freeze_transition_count = 0
+	tree.paused = true
+	_update_processing()
+
+
+# Per-frame monitor: dispatches to the step runner during a window, otherwise
+# holds the freeze against game-code writes.
+func _game_time_process(delta: float) -> void:
+	if _step_active:
+		_step_process(delta)
+		return
+	if not _frozen:
+		return
+	var tree := get_tree()
+	if not tree.paused:
+		# Game code unpaused under the freeze (a WHEN_PAUSED resume button, an
+		# auto-unpausing cutscene). Record the game layer's new intent and
+		# re-assert — the freeze answers to the agent; the game's wish is
+		# restored on step/thaw. Only unpause flips are observable here: while
+		# frozen, tree.paused is already true.
+		_game_paused = false
+		_freeze_transition_count += 1
+		tree.paused = true
+
+
+func _physics_process(_delta: float) -> void:
+	if _step_active and not _step_finish_pending and not get_tree().paused:
+		_step_physics_ticks += 1
+
+
+func _handle_game_time_freeze(_data: Array) -> void:
+	if _step_active:
+		_send_game_time_response("game_time_freeze", {"error": "Step in progress"})
+		return
+	var was_frozen := _frozen
+	_engage_freeze()
+	_send_game_time_response("game_time_freeze", {
+		"frozen": true,
+		"was_frozen": was_frozen,
+		"game_paused": _game_paused,
+	})
+
+
+func _handle_game_time_thaw(_data: Array) -> void:
+	if _step_active:
+		_send_game_time_response("game_time_thaw", {"error": "Step in progress"})
+		return
+	var was_frozen := _frozen
+	var result: Dictionary = {"frozen": false, "was_frozen": was_frozen}
+	if was_frozen:
+		result["frozen_for_ms"] = Time.get_ticks_msec() - _freeze_started_ticks
+		_frozen = false
+		get_tree().paused = _game_paused
+		_update_processing()
+	result["game_paused"] = _game_paused if was_frozen else get_tree().paused
+	_send_game_time_response("game_time_thaw", result)
+
+
+func _handle_game_time_status(_data: Array) -> void:
+	var tree := get_tree()
+	var tree_paused: bool = tree.paused if tree else false
+	var result: Dictionary = {
+		"frozen": _frozen,
+		"game_paused": _game_paused if _frozen else tree_paused,
+		"tree_paused": tree_paused,
+		"engine_time_scale": Engine.time_scale,
+		"physics_ticks_per_second": Engine.physics_ticks_per_second,
+	}
+	if _launched_frozen:
+		result["launch_frozen"] = true
+	if _frozen:
+		result["frozen_for_ms"] = Time.get_ticks_msec() - _freeze_started_ticks
+		result["freeze_transitions"] = _freeze_transition_count
+		if _freeze_transition_count >= FREEZE_CONTESTED_THRESHOLD:
+			# Something (an ALWAYS-mode node?) is repeatedly unpausing under
+			# the freeze. Each re-assert can leak up to one frame; report the
+			# contest rather than pretend the freeze is airtight.
+			result["freeze_contested"] = true
+	if _step_active:
+		result["step_active"] = true
+	_send_game_time_response("game_time_status", result)
+
+
+func _handle_game_time_step(data: Array) -> void:
+	var params: Dictionary = data[0] if data.size() > 0 and data[0] is Dictionary else {}
+	if _step_active:
+		_send_game_time_response("game_time_step", {"error": "Step already in progress"})
+		return
+
+	var duration_ms: int = int(params.get("duration_ms", 0))
+	var frames: int = int(params.get("frames", 0))
+	if duration_ms <= 0 and frames <= 0:
+		_send_game_time_response("game_time_step", {"error": "step requires duration_ms or frames"})
+		return
+	duration_ms = mini(duration_ms, STEP_MAX_MS)
+	frames = mini(frames, STEP_MAX_FRAMES)
+
+	# Validate and schedule the in-step input timeline (start_ms is game-time
+	# from window start). Inputs must ride inside the step: an event injected
+	# while frozen lands on a frame gameplay never processes, so its
+	# is_action_just_pressed edge would be silently missed.
+	var inputs: Array = params.get("inputs", [])
+	var events: Array = []
+	for input in inputs:
+		var action_name: String = input.get("action_name", "")
+		if action_name.is_empty():
+			continue
+		if not InputMap.has_action(action_name):
+			_send_game_time_response("game_time_step", {"error": "Unknown action: %s" % action_name})
+			return
+		var start_ms: int = int(input.get("start_ms", 0))
+		var dur: int = int(input.get("duration_ms", 0))
+		events.append({"time": start_ms, "action": action_name, "is_press": true})
+		events.append({"time": start_ms + dur, "action": action_name, "is_press": false})
+	events.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return a.time < b.time
+	)
+
+	# Step from a running game is allowed — it freezes first, so "advance
+	# 500ms then wait for me" is a single atomic call.
+	_engage_freeze()
+
+	_step_target_ms = float(duration_ms)
+	_step_target_frames = frames
+	_step_elapsed_ms = 0.0
+	_step_gameplay_ms = 0.0
+	_step_frames = 0
+	_step_physics_ticks = 0
+	_step_events = events
+	_step_events_fired = 0
+	_step_transitions = []
+	_step_needs_settle = false
+	_step_finish_pending = false
+	_step_wall_exceeded = false
+	_step_wall_start = Time.get_ticks_msec()
+	_step_active = true
+
+	# Open the window: restore the game layer's own pause wish for the
+	# duration. If the game's menu is holding it paused, the window still
+	# elapses (and reports gameplay_ms ~0) — never deadlock waiting for
+	# gameplay time that cannot come.
+	var tree := get_tree()
+	tree.paused = _game_paused
+	_step_last_tree_paused = tree.paused
+	set_physics_process(true)
+	_update_processing()
+
+
+func _step_process(delta: float) -> void:
+	var tree := get_tree()
+
+	# The bridge processes before the scene, so a frame is counted here BEFORE
+	# gameplay runs it. Ending the window therefore always defers one frame:
+	# pausing in the same _process call would steal the frame just counted.
+	if _step_finish_pending:
+		_finish_step()
+		return
+
+	# Game-layer pause flips during the window are the game's own doing (a
+	# stepped input opened the menu, an auto-pausing cutscene). Track intent
+	# and report; never fight it mid-window.
+	if tree.paused != _step_last_tree_paused:
+		_step_last_tree_paused = tree.paused
+		_game_paused = tree.paused
+		if _step_transitions.size() < STEP_MAX_TRANSITIONS:
+			_step_transitions.append({"at_ms": roundi(_step_elapsed_ms), "paused": tree.paused})
+
+	_step_frames += 1
+	_step_elapsed_ms += delta * 1000.0
+	if not tree.paused:
+		_step_gameplay_ms += delta * 1000.0
+
+	while _step_events.size() > 0 and _step_events[0].time <= _step_elapsed_ms:
+		var ev: Dictionary = _step_events.pop_front()
+		var input_event := InputEventAction.new()
+		input_event.action = ev.action
+		input_event.pressed = ev.is_press
+		input_event.strength = 1.0 if ev.is_press else 0.0
+		Input.parse_input_event(input_event)
+		_step_events_fired += 1
+		_step_needs_settle = true
+		if ev.is_press:
+			_held_actions[ev.action] = true
+		else:
+			_held_actions.erase(ev.action)
+
+	var done := false
+	if _step_target_frames > 0:
+		done = _step_frames >= _step_target_frames
+	else:
+		done = _step_elapsed_ms >= _step_target_ms
+	if Time.get_ticks_msec() - _step_wall_start > STEP_WALL_BUDGET_MS:
+		# Slow-mo, Engine.time_scale = 0, or a pause-held window can starve
+		# the game-time clock; the wall budget guarantees the call returns
+		# (partial, honestly reported) before the editor relay gives up.
+		_step_wall_exceeded = true
+		done = true
+
+	if done:
+		if _step_needs_settle:
+			# Injected events flush at the top of the NEXT frame; gameplay
+			# needs that frame unpaused or the final just_pressed edge is
+			# lost. Run exactly one settle frame, then finish.
+			_step_needs_settle = false
+		else:
+			_step_finish_pending = true
+
+
+func _finish_step() -> void:
+	# Releases are guaranteed cleanup, never queued steps: no holds survive
+	# across the freeze boundary (cross-step holds are a deliberate non-goal).
+	var forced := _held_actions.size()
+	_release_held_actions()
+	var dropped := _step_events.size()
+	_step_events.clear()
+
+	get_tree().paused = true  # the freeze layer re-engages
+	_step_last_tree_paused = true
+	_step_active = false
+	_step_finish_pending = false
+	set_physics_process(false)
+	_update_processing()
+
+	var result: Dictionary = {
+		"completed": true,
+		"frozen": true,
+		"elapsed_ms": roundi(_step_elapsed_ms),
+		"gameplay_ms": roundi(_step_gameplay_ms),
+		"frames": _step_frames,
+		"physics_ticks": _step_physics_ticks,
+		"game_paused": _game_paused,
+	}
+	if _step_events_fired > 0:
+		result["events_fired"] = _step_events_fired
+	if forced > 0:
+		result["forced_releases"] = forced
+	if dropped > 0:
+		result["events_dropped"] = dropped
+	if not _step_transitions.is_empty():
+		result["pause_transitions"] = _step_transitions
+	if _step_wall_exceeded:
+		result["wall_budget_exceeded"] = true
+	_send_game_time_response("game_time_step", result)

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -64,6 +64,16 @@ describe('editor tool', () => {
         .toBe('Running scene: res://test.tscn');
       expect(await editor.execute({ action: 'stop' }, ctx)).toBe('Stopped project');
     });
+
+    it('passes frozen through to run_project and says so', async () => {
+      mock.mockResponse({});
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'run', frozen: true }, ctx);
+      expect(result).toContain('frozen from frame 0');
+      expect(mock.calls[0].command).toBe('run_project');
+      expect(mock.calls[0].params.frozen).toBe(true);
+    });
   });
 
   describe('get_log_messages', () => {

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -112,7 +112,7 @@ describe('game_time tool', () => {
 
   describe('thaw', () => {
     it('reports the frozen duration', async () => {
-      mock.mockResponse({ frozen: false, was_frozen: true, game_paused: false, frozen_for_ms: 42000 });
+      mock.mockResponse({ frozen: false, was_frozen: true, game_paused: false, frozen_wall_ms: 42000 });
       const ctx = createToolContext(mock);
 
       const result = await gameTime.execute({ action: 'thaw' }, ctx);
@@ -137,8 +137,9 @@ describe('game_time tool', () => {
         tree_paused: true,
         engine_time_scale: 1.0,
         physics_ticks_per_second: 60,
-        frozen_for_ms: 12345,
+        frozen_wall_ms: 12345,
         freeze_transitions: 0,
+        launched_frozen: true,
       });
       const ctx = createToolContext(mock);
 
@@ -146,7 +147,8 @@ describe('game_time tool', () => {
       expect(mock.calls[0].command).toBe('game_time_status');
       const data = structuredOf(result);
       expect(data.frozen).toBe(true);
-      expect(data.frozen_for_ms).toBe(12345);
+      expect(data.frozen_wall_ms).toBe(12345);
+      expect(data.launched_frozen).toBe(true);
     });
   });
 });

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
+import { gameTime } from '../../tools/game-time.js';
+
+describe('game_time tool', () => {
+  let mock: MockGodotConnection;
+
+  beforeEach(() => {
+    mock = createMockGodot();
+  });
+
+  describe('schema validation', () => {
+    it('step requires exactly one of duration_ms or frames', () => {
+      expect(gameTime.schema.safeParse({ action: 'step' }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 500, frames: 10 }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 500 }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step', frames: 1 }).success).toBe(true);
+    });
+
+    it('step enforces the bridge-side caps', () => {
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 20000 }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 20001 }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step', frames: 1200 }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step', frames: 1201 }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 0 }).success).toBe(false);
+    });
+
+    it('step accepts an input timeline', () => {
+      expect(gameTime.schema.safeParse({
+        action: 'step',
+        duration_ms: 500,
+        inputs: [{ action_name: 'fire', start_ms: 100, duration_ms: 200 }],
+      }).success).toBe(true);
+    });
+
+    it('freeze, thaw, and status take no extra arguments', () => {
+      expect(gameTime.schema.safeParse({ action: 'freeze' }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'thaw' }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'status' }).success).toBe(true);
+    });
+  });
+
+  describe('freeze', () => {
+    it('reports a fresh freeze', async () => {
+      mock.mockResponse({ frozen: true, was_frozen: false, game_paused: false });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'freeze' }, ctx);
+      expect(result).toContain('Frozen');
+      expect(result).not.toContain('already frozen');
+      expect(mock.calls[0].command).toBe('game_time_freeze');
+    });
+
+    it('notes idempotent re-freeze and an open pause menu', async () => {
+      mock.mockResponse({ frozen: true, was_frozen: true, game_paused: true });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'freeze' }, ctx);
+      expect(result).toContain('already frozen');
+      expect(result).toContain('pause menu is open');
+    });
+  });
+
+  describe('step', () => {
+    it('forwards window parameters and inputs, returns structured result', async () => {
+      mock.mockResponse({
+        completed: true,
+        frozen: true,
+        elapsed_ms: 517,
+        gameplay_ms: 517,
+        frames: 31,
+        physics_ticks: 31,
+        game_paused: false,
+        events_fired: 2,
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({
+        action: 'step',
+        duration_ms: 500,
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      expect(mock.calls[0].command).toBe('game_time_step');
+      expect(mock.calls[0].params.duration_ms).toBe(500);
+      expect(mock.calls[0].params.inputs).toHaveLength(1);
+      const data = structuredOf(result);
+      expect(data.elapsed_ms).toBe(517);
+      expect(data.events_fired).toBe(2);
+    });
+
+    it('surfaces pause transitions from the game layer', async () => {
+      mock.mockResponse({
+        completed: true,
+        frozen: true,
+        elapsed_ms: 500,
+        gameplay_ms: 120,
+        frames: 30,
+        physics_ticks: 7,
+        game_paused: true,
+        pause_transitions: [{ at_ms: 120, paused: true }],
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'step', duration_ms: 500 }, ctx);
+      const data = structuredOf(result);
+      expect(data.pause_transitions).toHaveLength(1);
+      expect(data.game_paused).toBe(true);
+      expect(data.gameplay_ms).toBe(120);
+    });
+  });
+
+  describe('thaw', () => {
+    it('reports the frozen duration', async () => {
+      mock.mockResponse({ frozen: false, was_frozen: true, game_paused: false, frozen_for_ms: 42000 });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'thaw' }, ctx);
+      expect(result).toContain('42000ms');
+      expect(mock.calls[0].command).toBe('game_time_thaw');
+    });
+
+    it('is idempotent when not frozen', async () => {
+      mock.mockResponse({ frozen: false, was_frozen: false, game_paused: false });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'thaw' }, ctx);
+      expect(result).toContain('Was not frozen');
+    });
+  });
+
+  describe('status', () => {
+    it('returns the structured freeze state', async () => {
+      mock.mockResponse({
+        frozen: true,
+        game_paused: false,
+        tree_paused: true,
+        engine_time_scale: 1.0,
+        physics_ticks_per_second: 60,
+        frozen_for_ms: 12345,
+        freeze_transitions: 0,
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'status' }, ctx);
+      expect(mock.calls[0].command).toBe('game_time_status');
+      const data = structuredOf(result);
+      expect(data.frozen).toBe(true);
+      expect(data.frozen_for_ms).toBe(12345);
+    });
+  });
+});

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -45,6 +45,10 @@ const EditorSchema = z
     z.object({
       action: z.literal('run').describe('Run the project'),
       scene_path: z.string().optional().describe('Scene to run (optional, defaults to main scene)'),
+      frozen: z
+        .boolean()
+        .optional()
+        .describe('Launch with game time frozen from frame 0 (gameplay never starts racing your latency). Use godot_game_time step/thaw to advance.'),
     }),
     z.object({ action: z.literal('stop').describe('Stop the running project') }),
     z.object({
@@ -136,8 +140,11 @@ export const editor = defineTool({
       }
 
       case 'run': {
-        await godot.sendCommand('run_project', { scene_path: args.scene_path });
-        return args.scene_path ? `Running scene: ${args.scene_path}` : 'Running project';
+        await godot.sendCommand('run_project', { scene_path: args.scene_path, frozen: args.frozen });
+        const target = args.scene_path ? `scene: ${args.scene_path}` : 'project';
+        return args.frozen
+          ? `Running ${target} frozen from frame 0 — use godot_game_time step/thaw to advance`
+          : `Running ${target}`;
       }
 
       case 'stop': {

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import { defineTool } from '../core/define-tool.js';
+import { structured } from '../core/structured.js';
+import { InputActionSchema } from './input.js';
+import type { AnyToolDefinition } from '../core/types.js';
+
+// Bridge-side step caps (see mcp_game_bridge.gd). The editor relay times out
+// at 28s and the server command timeout is 30s, so a step request must stay
+// well inside both.
+const STEP_MAX_MS = 20000;
+const STEP_MAX_FRAMES = 1200;
+
+const GameTimeSchema = z
+  .discriminatedUnion('action', [
+    z.object({
+      action: z
+        .literal('freeze')
+        .describe('Pause the game under agent control. All observation tools (screenshots, runtime state, find_nodes) keep working while frozen — take as long as you need.'),
+    }),
+    z.object({
+      action: z
+        .literal('step')
+        .describe('Advance a bounded slice of game time, then re-freeze. Freezes first if the game is running, so step is always a safe first call.'),
+      duration_ms: z
+        .number()
+        .int()
+        .min(1)
+        .max(STEP_MAX_MS)
+        .optional()
+        .describe(`Game time to advance in milliseconds (max ${STEP_MAX_MS}; loop steps for longer). Scaled by Engine.time_scale like normal play.`),
+      frames: z
+        .number()
+        .int()
+        .min(1)
+        .max(STEP_MAX_FRAMES)
+        .optional()
+        .describe(`Frames to advance instead of a duration (max ${STEP_MAX_FRAMES}). frames: 1 is a single-frame advance.`),
+      inputs: z
+        .array(InputActionSchema)
+        .optional()
+        .describe('Input timeline executed inside the window; start_ms is game time from window start. Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end.'),
+    }),
+    z.object({
+      action: z
+        .literal('thaw')
+        .describe('Resume real-time play, restoring the game\'s own pause state (an open pause menu stays open).'),
+    }),
+    z.object({
+      action: z
+        .literal('status')
+        .describe('Report the freeze state: frozen, the game\'s own pause intent, time scale, and whether game code is contesting the freeze.'),
+    }),
+  ])
+  // Constraint a discriminated union can't express on its own, so it lives here:
+  .refine((data) => (data.action === 'step' ? (data.duration_ms !== undefined) !== (data.frames !== undefined) : true), {
+    message: 'step requires exactly one of duration_ms or frames',
+  });
+
+type GameTimeArgs = z.infer<typeof GameTimeSchema>;
+
+interface StepResult {
+  completed: boolean;
+  frozen: boolean;
+  elapsed_ms: number;
+  gameplay_ms: number;
+  frames: number;
+  physics_ticks: number;
+  game_paused: boolean;
+  events_fired?: number;
+  forced_releases?: number;
+  events_dropped?: number;
+  pause_transitions?: Array<{ at_ms: number; paused: boolean }>;
+  wall_budget_exceeded?: boolean;
+}
+
+export const gameTime = defineTool({
+  name: 'godot_game_time',
+  annotations: { title: 'Game Time Control', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+  description:
+    'Make game time answer to your clock instead of racing ahead between tool calls: freeze the running game, observe it at leisure (screenshots and state digests work while frozen), then step forward a bounded slice of game time with inputs riding inside the window. The game\'s own pause menu is layered correctly: freezing over it, stepping under it, and thawing back to it all preserve the game\'s pause intent.',
+  schema: GameTimeSchema,
+  async execute(args: GameTimeArgs, { godot }) {
+    switch (args.action) {
+      case 'freeze': {
+        const result = await godot.sendCommand<{
+          frozen: boolean;
+          was_frozen: boolean;
+          game_paused: boolean;
+        }>('game_time_freeze');
+        const note = result.was_frozen ? ' (was already frozen)' : '';
+        const paused = result.game_paused ? ' Game\'s own pause menu is open; step will not advance gameplay until it is dismissed.' : '';
+        return `Frozen${note}. Game time is stopped; observe freely, then step or thaw.${paused}`;
+      }
+
+      case 'step': {
+        const result = await godot.sendCommand<StepResult>('game_time_step', {
+          duration_ms: args.duration_ms,
+          frames: args.frames,
+          inputs: args.inputs,
+        });
+        return structured(result);
+      }
+
+      case 'thaw': {
+        const result = await godot.sendCommand<{
+          frozen: boolean;
+          was_frozen: boolean;
+          game_paused: boolean;
+          frozen_for_ms?: number;
+        }>('game_time_thaw');
+        if (!result.was_frozen) {
+          return 'Was not frozen; game continues in real time.';
+        }
+        const pausedNote = result.game_paused ? ' (game\'s own pause menu still open)' : '';
+        return `Thawed after ${result.frozen_for_ms}ms frozen. Real-time play resumed${pausedNote}.`;
+      }
+
+      case 'status': {
+        const result = await godot.sendCommand<Record<string, unknown>>('game_time_status');
+        return structured(result);
+      }
+    }
+  },
+});
+
+export const gameTimeTools = [gameTime] as AnyToolDefinition[];

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -48,7 +48,7 @@ const GameTimeSchema = z
     z.object({
       action: z
         .literal('status')
-        .describe('Report the freeze state: frozen, the game\'s own pause intent, time scale, and whether game code is contesting the freeze.'),
+        .describe('Report the freeze state: `frozen` is authoritative for the current state; `frozen_wall_ms` is real wall-clock held (not game time); `launched_frozen` is a historical flag (this run booted frozen) and stays true after thaw. Also reports the game\'s own pause intent, time scale, and whether game code is contesting the freeze.'),
     }),
   ])
   // Constraint a discriminated union can't express on its own, so it lives here:
@@ -106,13 +106,13 @@ export const gameTime = defineTool({
           frozen: boolean;
           was_frozen: boolean;
           game_paused: boolean;
-          frozen_for_ms?: number;
+          frozen_wall_ms?: number;
         }>('game_time_thaw');
         if (!result.was_frozen) {
           return 'Was not frozen; game continues in real time.';
         }
         const pausedNote = result.game_paused ? ' (game\'s own pause menu still open)' : '';
-        return `Thawed after ${result.frozen_for_ms}ms frozen. Real-time play resumed${pausedNote}.`;
+        return `Thawed after ${result.frozen_wall_ms}ms (wall-clock) frozen. Real-time play resumed${pausedNote}.`;
       }
 
       case 'status': {

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -11,6 +11,7 @@ import { docsTools } from './docs.js';
 import { inputTools } from './input.js';
 import { profilerTools } from './profiler.js';
 import { runtimeStateTools } from './runtime-state.js';
+import { gameTimeTools } from './game-time.js';
 
 export function registerAllTools(): void {
   registry.registerTools(sceneTools);
@@ -25,6 +26,7 @@ export function registerAllTools(): void {
   registry.registerTools(inputTools);
   registry.registerTools(profilerTools);
   registry.registerTools(runtimeStateTools);
+  registry.registerTools(gameTimeTools);
 }
 
 export { sceneTools } from './scene.js';
@@ -39,3 +41,4 @@ export { docsTools } from './docs.js';
 export { inputTools } from './input.js';
 export { profilerTools } from './profiler.js';
 export { runtimeStateTools } from './runtime-state.js';
+export { gameTimeTools } from './game-time.js';

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
-const InputActionSchema = z.object({
+export const InputActionSchema = z.object({
   action_name: z.string().describe('The input action name from the project Input Map'),
   start_ms: z.number().int().min(0).optional().default(0).describe('When to start the input (milliseconds from sequence start)'),
   duration_ms: z.number().int().min(0).optional().default(0).describe('How long to hold the input (0 = instant tap)'),


### PR DESCRIPTION
## Problem

An MCP-driven agent cannot test a real-time game in real time: the game advances 10–40 seconds of consequences between every observation and the action it informs (#247, the anchor finding of the high-latency spike). Every workaround observed in the field — mega-sequences, god mode, game-side autofire — was the game under test absorbing the toolset's architectural gap.

## Change

New `godot_game_time` tool: game time answers to the agent's clock.

- **`freeze`** — tree-pause owned by the bridge. Rendering continues during pause, so every existing observation tool (screenshots, digests, find_nodes, watch) works while frozen, unchanged.
- **`step`** — advance a bounded slice of game time (`duration_ms` or `frames`), then re-freeze. Returns honest accounting: `elapsed_ms` / `gameplay_ms` (the unpaused portion) / `frames` / `physics_ticks` / `pause_transitions`.
- **`thaw`** — back to real-time play.
- **`status`** — freeze state, the game's own pause intent, `freeze_contested` detection.
- **`godot_editor run frozen=true`** — freeze from frame 0 via an inherited env var. The original field failure (player died between `run` and the first input) is structurally impossible, not mitigated: the acceptance scenario asserts `process_calls == 0` — exactly zero — after 10s of simulated agent latency.

**Inputs ride inside the step.** An event injected while frozen lands on a frame gameplay never processes, so its `is_action_just_pressed` edge is silently missed (machine-checked in the scenario: a frozen-injected tap leaves the pausable edge counter unchanged; an in-step tap lands **exactly one** edge). Step input timelines are scheduled on the game-time clock, and one settle frame after the last event protects the final edge — the bridge is an autoload and processes before the scene, so re-pausing on the event's own frame would eat it. Holds never survive the freeze boundary (forced releases are counted and reported).

**Layered pause model.** `tree.paused` is one bit written by two parties: the game's pause menu and the freeze. The bridge layers them by observation + re-assertion (it cannot intercept writes, but it processes every frame): a Resume pressed under the freeze is recorded as the game's intent and overridden; a step opens the window with the game's own pause wish restored and reports any mid-window flips as `pause_transitions`; thaw restores the game's intent — an open pause menu stays open. Stepping under the game's own menu elapses honestly (`gameplay_ms: 0`, never deadlocks). Known limitation, documented: games that "pause" via `Engine.time_scale = 0` freeze fine but their pause is invisible to the layer model.

**Timeout cascade.** Step requests cap at 20s game time < bridge wall-clock budget 25s (survives `time_scale = 0`, slow-mo, and menu-held windows) < editor relay 28s < server command timeout 30s. Every layer answers before the one above it gives up; long advances are loops of bounded steps.

Out of scope by design (issue hypotheses, deliberately deferred): fast-forward (`time_scale > 1` reopens the juice-system ownership conflict), cross-step holds, in-bridge drift reports (the agent-side digest-diff pattern covers it; #248 will document it), networked multiplayer.

## Evidence

Acceptance scenario `247-agent-clock` (e2e suite, #252 apparatus): launch-frozen exact zeros, freeze-holds-across-latency (`physics_calls Δ == 0` over a 5s sleep), in-step edge exactness, edge-miss contrast, and all four pause-menu orderings (resume-under-freeze, self-pause-mid-step, step-under-menu, dismiss-through-freeze). Same scenario, zero edits, both sides:

| side | result |
|---|---|
| `main` (3.7.1) | **FAIL** 5.7s — `Unknown tool: godot_game_time` |
| this branch | **PASS** 25.0s — all asserts across 14 steps |

Full suite on the branch — no regressions, #238's scenario still guards the bridge's pause survival (which this feature is built on):

```
[PASS] 238-bridge-survives-pause × canary (7.0s)
[PASS] 247-agent-clock × canary (25.2s)
[PASS] canary-baseline × canary (7.3s)
[PASS] smoke-run-digest-stop × canary (6.1s)
```

Server: 236/236 unit tests pass (13 new). Generated docs sync on the release PR as usual.

Closes #247. Unblocks the pause-hygiene portion of #248.
