### PR TITLE
fix: ship .uid sidecars so the addon's resource identity is stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,13 @@ godot/.editorconfig
 # Godot
 .godot/
 *.import
+# Ignore .uid files in the throwaway test project, but TRACK the ones inside
+# the distributed addon: Godot expects plugin authors to ship script .uid
+# sidecars so the addon's resource identity is stable across machines (a
+# missing sidecar makes any uid:// reference to an addon script fall back to
+# path with a load warning). See Godot VCS docs / 4.4 release notes.
 *.uid
+!godot/addons/godot_mcp/**/*.uid
 
 # Environment
 .env

--- a/godot/addons/godot_mcp/command_router.gd.uid
+++ b/godot/addons/godot_mcp/command_router.gd.uid
@@ -1,0 +1,1 @@
+uid://bhjejek8ivdv8

--- a/godot/addons/godot_mcp/commands/animation_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/animation_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://dg4xlid3mi2mi

--- a/godot/addons/godot_mcp/commands/debug_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/debug_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://cquyem31g4y4b

--- a/godot/addons/godot_mcp/commands/node_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/node_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://bke2rvqtw381m

--- a/godot/addons/godot_mcp/commands/profiler_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/profiler_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://c17gnisv1uqju

--- a/godot/addons/godot_mcp/commands/project_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/project_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://es4uegishf00

--- a/godot/addons/godot_mcp/commands/resource_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/resource_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://yts2tlf0btx5

--- a/godot/addons/godot_mcp/commands/runtime_state_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/runtime_state_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://bns7tsagruukm

--- a/godot/addons/godot_mcp/commands/scene3d_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/scene3d_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://cniw11jpk5y82

--- a/godot/addons/godot_mcp/commands/scene_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/scene_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://ngt4k3u88sj3

--- a/godot/addons/godot_mcp/commands/screenshot_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/screenshot_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://c578gd4ovecgt

--- a/godot/addons/godot_mcp/commands/script_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/script_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://b1om27ef4rvws

--- a/godot/addons/godot_mcp/commands/selection_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/selection_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://ciy2n67gqdsla

--- a/godot/addons/godot_mcp/commands/tilemap_commands.gd.uid
+++ b/godot/addons/godot_mcp/commands/tilemap_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://cietp5vxfv072

--- a/godot/addons/godot_mcp/core/base_command.gd.uid
+++ b/godot/addons/godot_mcp/core/base_command.gd.uid
@@ -1,0 +1,1 @@
+uid://cwqpmprsn6g2

--- a/godot/addons/godot_mcp/core/mcp_constants.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_constants.gd.uid
@@ -1,0 +1,1 @@
+uid://hkoghrp3us8j

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://daogurpabpiap

--- a/godot/addons/godot_mcp/core/mcp_enums.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_enums.gd.uid
@@ -1,0 +1,1 @@
+uid://b1yx7jiol72rg

--- a/godot/addons/godot_mcp/core/mcp_logger.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://yv8gf1cuf48v

--- a/godot/addons/godot_mcp/core/mcp_utils.gd.uid
+++ b/godot/addons/godot_mcp/core/mcp_utils.gd.uid
@@ -1,0 +1,1 @@
+uid://dckosaj3snxdo

--- a/godot/addons/godot_mcp/game_bridge/mcp_frame_profiler.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/mcp_frame_profiler.gd.uid
@@ -1,0 +1,1 @@
+uid://cihxpb547p4du

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://dj1awl7wmpf65

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd.uid
@@ -1,0 +1,1 @@
+uid://1fhae7bg8bgf

--- a/godot/addons/godot_mcp/game_bridge/onscreen.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/onscreen.gd.uid
@@ -1,0 +1,1 @@
+uid://bn5y5te1ys8sa

--- a/godot/addons/godot_mcp/plugin.gd.uid
+++ b/godot/addons/godot_mcp/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://ddy5vjisb0we

--- a/godot/addons/godot_mcp/test/input_sequence_stuck_held_test.gd.uid
+++ b/godot/addons/godot_mcp/test/input_sequence_stuck_held_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dbwluuv8f6s1e

--- a/godot/addons/godot_mcp/test/onscreen_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/onscreen_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://4evf2b3argxx

--- a/godot/addons/godot_mcp/ui/status_panel.gd.uid
+++ b/godot/addons/godot_mcp/ui/status_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://ccs8jj6mvw2i7

--- a/godot/addons/godot_mcp/websocket_server.gd.uid
+++ b/godot/addons/godot_mcp/websocket_server.gd.uid
@@ -1,0 +1,1 @@
+uid://dcdsm34jvcwgv


### PR DESCRIPTION
## Problem

Godot 4.4+ gives every script a stable `uid://` identity through a sidecar `.uid` file (scenes and `.tres` embed their own; scripts and shaders can't, so they get the sidecar). For a **distributed addon** these are source, not build output:

- A `uid://` reference to an addon script with no shipped sidecar falls back to the path **with a load warning** on the user's machine.
- UIDs are random at first scan, so the file a user's editor generates locally differs from everyone else's — unstable identity across machines and teams.

Godot's own VCS guidance and the 4.4 release notes say to commit them.

This repo ignored `*.uid` wholesale: the rule arrived via a Godot `.gitignore` template in #111, which also deleted the then-tracked sidecars. The result today is an accident, not a decision — the package ships **3** straggler sidecars and **~29** generated-fresh-per-install. `status_panel.tscn` happens to reference its script by path only, which is the sole reason the gap is currently invisible.

## Change

- Scope the ignore: keep `*.uid` ignored (the throwaway `godot/` test project stays clean) but re-include `!godot/addons/godot_mcp/**/*.uid`.
- Commit the complete sidecar set for every addon script (29 new + the 3 already-tracked = the full set), dissolving the straggler inconsistency.

No code changes; identity files only.

## Why now

While the shipped `.tscn` references its script by path, a missing sidecar is harmless. The day a 4.4+ editor resaves that scene — adding embedded `uid://` references — the situation inverts: *not* shipping sidecars would make the shipped scene point at UIDs that don't exist on any user's machine, spamming load warnings. Landing the policy first means the shipped scene and shipped sidecars can never disagree.

## Upgrade impact (existing users)

Replacing the addon folder overwrites locally-generated `.uid` files, so each addon script's UID changes once on the user's machine. Effect by user:

- **Typical user** (never edits addon internals): nothing. Autoload is registered by `res://` path, commands resolve by `class_name`, `plugin.cfg` is path-based, the local UID cache rebuilds on rescan.
- **Vendored-into-VCS**: a one-time diff of ~29 sidecars in the upgrade commit. Benign, never recurs (UIDs are immutable once set).
- **Own scene references an addon script**: one "UID not found, falling back to path" warning, then self-heals on next save.
- **Own code does `preload("uid://…")` of an addon script**: the only hard break — a one-line fix on their side, and only reachable by copy-pasting an addon-internal UID.

The 3 straggler sidecars have shipped in every release since they were committed, so every existing user has already taken this exact overwrite for those files with zero reported issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
