### PR TITLE
fix: use ScriptBacktrace.get_frame_file for error frame capture

### DIFF
--- a/godot/addons/godot_mcp/core/mcp_logger.gd
+++ b/godot/addons/godot_mcp/core/mcp_logger.gd
@@ -34,7 +34,7 @@ func _log_error(function: String, file: String, line: int, code: String,
 	for backtrace in script_backtraces:
 		for i in backtrace.get_frame_count():
 			frames.append({
-				"file": backtrace.get_frame_source(i),
+				"file": backtrace.get_frame_file(i),
 				"line": backtrace.get_frame_line(i),
 				"function": backtrace.get_frame_function(i),
 			})


### PR DESCRIPTION
## Problem

`MCPLogger._log_error` (editor-side error/warning capture) builds each stack frame with `backtrace.get_frame_source(i)`. That method does not exist on `ScriptBacktrace` in Godot 4.5+ — the method is `get_frame_file(i)` (alongside `get_frame_line` / `get_frame_function`, which the code already uses correctly).

So any error or warning that carries a script backtrace throws:

```
SCRIPT ERROR: Invalid call. Nonexistent function 'get_frame_source' in base 'ScriptBacktrace'.
   at: ... core/mcp_logger.gd:37
```

The throw happens **inside `_log_error`, before the error entry is appended to `_errors`** — so the offending error is dropped from the captured log entirely, and `get_log_messages` / `get_stack_trace` silently lose precisely the errors that carry stack traces (the most useful ones). A script error is emitted to the editor output in their place.

Reproduced live: reconnecting a new MCP client triggers the debugger's "Replacing active connection with new client" warning, which carries a backtrace, which hits this path every time.

## Fix

One line: `get_frame_source(i)` → `get_frame_file(i)`.

The game-bridge's own logger (`_MCPGameLogger._log_error`) only formats a message string and never walked frames, so it was unaffected; this is isolated to the editor-side `MCPLogger`.

## Verification

Parse-checked clean (headless import, exit 0). Runtime path is re-exercised by the same "replacing active connection" warning that surfaced it — no script error after the fix.

Closes #246.
