### PR TITLE
feat: step_until predicate stepping for godot_game_time

### DIFF
--- a/godot/addons/godot_mcp/commands/game_time_commands.gd
+++ b/godot/addons/godot_mcp/commands/game_time_commands.gd
@@ -2,11 +2,11 @@
 extends MCPBaseCommand
 class_name MCPGameTimeCommands
 
-# Game-time control relay: freeze / step / thaw / status execute in the game
-# bridge (see mcp_game_bridge.gd); this side only forwards over the debugger
-# channel and waits. Timeout cascade: the step request is capped at 20s of
-# game time and the bridge's wall budget returns by 25s, so the 28s relay
-# timeout below fires only if the bridge is gone — and stays under the
+# Game-time control relay: freeze / step / step_until / thaw / status execute in
+# the game bridge (see mcp_game_bridge.gd); this side only forwards over the
+# debugger channel and waits. Timeout cascade: a step/step_until request is
+# capped at 20s of game time and the bridge's wall budget returns by 25s, so the
+# 28s relay timeout below fires only if the bridge is gone — and stays under the
 # server's 30s command timeout so errors surface typed instead of generic.
 const BASE_TIMEOUT := 10.0
 const STEP_TIMEOUT := 28.0
@@ -18,6 +18,7 @@ func get_commands() -> Dictionary:
 	return {
 		"game_time_freeze": game_time_freeze,
 		"game_time_step": game_time_step,
+		"game_time_step_until": game_time_step_until,
 		"game_time_thaw": game_time_thaw,
 		"game_time_status": game_time_status,
 	}
@@ -29,6 +30,10 @@ func game_time_freeze(params: Dictionary) -> Dictionary:
 
 func game_time_step(params: Dictionary) -> Dictionary:
 	return await _relay("game_time_step", [params], STEP_TIMEOUT)
+
+
+func game_time_step_until(params: Dictionary) -> Dictionary:
+	return await _relay("game_time_step_until", [params], STEP_TIMEOUT)
 
 
 func game_time_thaw(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -170,6 +170,9 @@ func _on_debugger_message(message: String, data: Array) -> bool:
 		"game_time_step":
 			_handle_game_time_step(data)
 			return true
+		"game_time_step_until":
+			_handle_game_time_step_until(data)
+			return true
 		"game_time_thaw":
 			_handle_game_time_thaw(data)
 			return true
@@ -1117,6 +1120,18 @@ var _step_events_fired := 0
 var _step_transitions: Array = []
 var _step_last_tree_paused := false
 
+# step_until adds a predicate evaluated each frame. _step_predicate is null for a
+# fixed-budget step, set for step_until; _step_response_type routes _finish_step's
+# reply to the matching command (the relay correlates by message type). _step_report
+# is the optional readings the agent wants back at stop time (in one round-trip,
+# instead of a separate observation call) — each is [{src: String, expr: Expression}].
+var _step_predicate: Expression = null
+var _step_predicate_inputs: Array = []
+var _step_predicate_met := false
+var _step_predicate_error := ""
+var _step_report: Array = []
+var _step_response_type := "game_time_step"
+
 
 func _send_game_time_response(msg_type: String, result: Dictionary) -> void:
 	EngineDebugger.send_message("godot_mcp:game_response", [msg_type, result])
@@ -1235,22 +1250,10 @@ func _handle_game_time_step(data: Array) -> void:
 	# from window start). Inputs must ride inside the step: an event injected
 	# while frozen lands on a frame gameplay never processes, so its
 	# is_action_just_pressed edge would be silently missed.
-	var inputs: Array = params.get("inputs", [])
-	var events: Array = []
-	for input in inputs:
-		var action_name: String = input.get("action_name", "")
-		if action_name.is_empty():
-			continue
-		if not InputMap.has_action(action_name):
-			_send_game_time_response("game_time_step", {"error": "Unknown action: %s" % action_name})
-			return
-		var start_ms: int = int(input.get("start_ms", 0))
-		var dur: int = int(input.get("duration_ms", 0))
-		events.append({"time": start_ms, "action": action_name, "is_press": true})
-		events.append({"time": start_ms + dur, "action": action_name, "is_press": false})
-	events.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
-		return a.time < b.time
-	)
+	var compiled := _compile_step_events(params.get("inputs", []))
+	if compiled.has("error"):
+		_send_game_time_response("game_time_step", {"error": compiled["error"]})
+		return
 
 	# Step from a running game is allowed — it freezes first, so "advance
 	# 500ms then wait for me" is a single atomic call.
@@ -1262,19 +1265,202 @@ func _handle_game_time_step(data: Array) -> void:
 	_step_gameplay_ms = 0.0
 	_step_frames = 0
 	_step_physics_ticks = 0
-	_step_events = events
+	_step_events = compiled["events"]
 	_step_events_fired = 0
 	_step_transitions = []
 	_step_needs_settle = false
 	_step_finish_pending = false
 	_step_wall_exceeded = false
 	_step_wall_start = Time.get_ticks_msec()
+	_step_predicate = null
+	_step_response_type = "game_time_step"
 	_step_active = true
 
 	# Open the window: restore the game layer's own pause wish for the
 	# duration. If the game's menu is holding it paused, the window still
 	# elapses (and reports gameplay_ms ~0) — never deadlock waiting for
 	# gameplay time that cannot come.
+	var tree := get_tree()
+	tree.paused = _game_paused
+	_step_last_tree_paused = tree.paused
+	set_physics_process(true)
+	_update_processing()
+
+
+func _compile_step_events(inputs: Array) -> Dictionary:
+	# Builds the press/release timeline shared by step and step_until. start_ms
+	# is game time from window start; returns {"error": ...} on an unknown action.
+	var events: Array = []
+	for input in inputs:
+		var action_name: String = input.get("action_name", "")
+		if action_name.is_empty():
+			continue
+		if not InputMap.has_action(action_name):
+			return {"error": "Unknown action: %s" % action_name}
+		var start_ms: int = int(input.get("start_ms", 0))
+		var dur: int = int(input.get("duration_ms", 0))
+		events.append({"time": start_ms, "action": action_name, "is_press": true})
+		events.append({"time": start_ms + dur, "action": action_name, "is_press": false})
+	events.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return a.time < b.time
+	)
+	return {"events": events}
+
+
+func _build_predicate_context() -> Dictionary:
+	# Exposes the running game to a step_until predicate: every autoload by its
+	# own name (so `G.wave > 1` just works), plus `tree` (SceneTree) and `root`
+	# (root Window) for tree queries like
+	# `tree.get_nodes_in_group("enemies").size() >= 1`. Chained calls must run on
+	# these input objects, not the Expression base instance, so they are inputs.
+	var names: Array = []
+	var inputs: Array = []
+	var tree := get_tree()
+	for prop in ProjectSettings.get_property_list():
+		var key: String = prop.get("name", "")
+		if not key.begins_with("autoload/"):
+			continue
+		var autoload_name := key.substr("autoload/".length())
+		var node := tree.root.get_node_or_null(NodePath(autoload_name))
+		if node == null or node == self:
+			continue  # skip the bridge's own autoload and any unresolved entry
+		names.append(autoload_name)
+		inputs.append(node)
+	if not names.has("tree"):
+		names.append("tree")
+		inputs.append(tree)
+	if not names.has("root"):
+		names.append("root")
+		inputs.append(tree.root)
+	return {"names": PackedStringArray(names), "inputs": inputs}
+
+
+func _sanitize_value(v: Variant) -> Variant:
+	# Report values ride back over the debugger channel. Pass primitives through;
+	# never try to serialize Objects/containers — a short string stand-in is
+	# enough for the agent to see what an expression evaluated to.
+	match typeof(v):
+		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
+			return v
+		_:
+			return str(v).substr(0, 200)
+
+
+func _compile_report(report: Array, names: PackedStringArray, inputs: Array) -> Dictionary:
+	# Compile + validate each report expression in the predicate context. Returns
+	# {"error": ...} if any fails up front, else {"report": [{src, expr}, ...]}.
+	var compiled: Array = []
+	for item in report:
+		var s := str(item).strip_edges()
+		if s.is_empty():
+			continue
+		var e := Expression.new()
+		if e.parse(s, names) != OK:
+			return {"error": "report expression parse error (%s): %s" % [s, e.get_error_text()]}
+		e.execute(inputs, self)
+		if e.has_execute_failed():
+			return {"error": "report expression failed to evaluate (%s): %s" % [s, e.get_error_text()]}
+		compiled.append({"src": s, "expr": e})
+	return {"report": compiled}
+
+
+func _evaluate_report(report_exprs: Array, inputs: Array) -> Dictionary:
+	# Evaluate the compiled report expressions at stop time into {src: value}.
+	var out: Dictionary = {}
+	for item in report_exprs:
+		var e: Expression = item["expr"]
+		var v: Variant = e.execute(inputs, self)
+		if e.has_execute_failed():
+			out[item["src"]] = "<error: %s>" % e.get_error_text()
+		else:
+			out[item["src"]] = _sanitize_value(v)
+	return out
+
+
+func _handle_game_time_step_until(data: Array) -> void:
+	var params: Dictionary = data[0] if data.size() > 0 and data[0] is Dictionary else {}
+	if _step_active:
+		_send_game_time_response("game_time_step_until", {"error": "Step already in progress"})
+		return
+
+	var src: String = str(params.get("until", "")).strip_edges()
+	if src.is_empty():
+		_send_game_time_response("game_time_step_until", {"error": "step_until requires a non-empty `until` expression"})
+		return
+
+	var max_ms: int = int(params.get("max_ms", STEP_MAX_MS))
+	if max_ms <= 0:
+		max_ms = STEP_MAX_MS
+	max_ms = mini(max_ms, STEP_MAX_MS)
+
+	# Compile and validate the predicate against the live tree before committing
+	# to a step. Expression.parse() is lenient (a malformed string can parse
+	# clean), so a dry-run execute is what actually catches unknown identifiers
+	# and bad member access.
+	var ctx := _build_predicate_context()
+	var ctx_names: PackedStringArray = ctx["names"]
+	var ctx_inputs: Array = ctx["inputs"]
+	var expr := Expression.new()
+	if expr.parse(src, ctx_names) != OK:
+		_send_game_time_response("game_time_step_until", {"error": "predicate parse error: %s" % expr.get_error_text()})
+		return
+	var first_value: Variant = expr.execute(ctx_inputs, self)
+	if expr.has_execute_failed():
+		_send_game_time_response("game_time_step_until", {"error": "predicate failed to evaluate: %s" % expr.get_error_text()})
+		return
+
+	# Optional readings to return at stop time, validated up front in the same context.
+	var report_result := _compile_report(params.get("report", []), ctx_names, ctx_inputs)
+	if report_result.has("error"):
+		_send_game_time_response("game_time_step_until", {"error": report_result["error"]})
+		return
+	var report_compiled: Array = report_result["report"]
+
+	var compiled := _compile_step_events(params.get("inputs", []))
+	if compiled.has("error"):
+		_send_game_time_response("game_time_step_until", {"error": compiled["error"]})
+		return
+
+	_engage_freeze()
+
+	# Predicate already holds: advance nothing, stay frozen, report it.
+	if bool(first_value):
+		var sc_result: Dictionary = {
+			"completed": true,
+			"frozen": true,
+			"elapsed_ms": 0,
+			"gameplay_ms": 0,
+			"frames": 0,
+			"physics_ticks": 0,
+			"game_paused": _game_paused,
+			"predicate_met": true,
+		}
+		if not report_compiled.is_empty():
+			sc_result["report"] = _evaluate_report(report_compiled, ctx_inputs)
+		_send_game_time_response("game_time_step_until", sc_result)
+		return
+
+	_step_target_ms = float(max_ms)
+	_step_target_frames = 0
+	_step_elapsed_ms = 0.0
+	_step_gameplay_ms = 0.0
+	_step_frames = 0
+	_step_physics_ticks = 0
+	_step_events = compiled["events"]
+	_step_events_fired = 0
+	_step_transitions = []
+	_step_needs_settle = false
+	_step_finish_pending = false
+	_step_wall_exceeded = false
+	_step_wall_start = Time.get_ticks_msec()
+	_step_predicate = expr
+	_step_predicate_inputs = ctx_inputs
+	_step_predicate_met = false
+	_step_predicate_error = ""
+	_step_report = report_compiled
+	_step_response_type = "game_time_step_until"
+	_step_active = true
+
 	var tree := get_tree()
 	tree.paused = _game_paused
 	_step_last_tree_paused = tree.paused
@@ -1325,6 +1511,19 @@ func _step_process(delta: float) -> void:
 		done = _step_frames >= _step_target_frames
 	else:
 		done = _step_elapsed_ms >= _step_target_ms
+
+	# step_until: re-evaluate the predicate each frame against the advancing
+	# game. A truthy result stops the window early; a runtime failure (e.g. a
+	# watched node was freed mid-window) ends it honestly with the error attached.
+	if _step_predicate != null:
+		var v: Variant = _step_predicate.execute(_step_predicate_inputs, self)
+		if _step_predicate.has_execute_failed():
+			_step_predicate_error = _step_predicate.get_error_text()
+			done = true
+		elif bool(v):
+			_step_predicate_met = true
+			done = true
+
 	if Time.get_ticks_msec() - _step_wall_start > STEP_WALL_BUDGET_MS:
 		# Slow-mo, Engine.time_scale = 0, or a pause-held window can starve
 		# the game-time clock; the wall budget guarantees the call returns
@@ -1376,4 +1575,19 @@ func _finish_step() -> void:
 		result["pause_transitions"] = _step_transitions
 	if _step_wall_exceeded:
 		result["wall_budget_exceeded"] = true
-	_send_game_time_response("game_time_step", result)
+	if _step_predicate != null:
+		# step_until: predicate_met is the headline. report carries the readings the
+		# agent asked for (the "what advanced" hint, so it need not re-observe). A
+		# non-met return means the cap or wall budget ran out first.
+		result["predicate_met"] = _step_predicate_met
+		if not _step_report.is_empty():
+			result["report"] = _evaluate_report(_step_report, _step_predicate_inputs)
+		if not _step_predicate_error.is_empty():
+			result["predicate_error"] = _step_predicate_error
+
+	# Route the reply to the originating command — the relay correlates by type.
+	var response_type := _step_response_type
+	_step_predicate = null
+	_step_predicate_inputs = []
+	_step_report = []
+	_send_game_time_response(response_type, result)

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -33,6 +33,25 @@ describe('game_time tool', () => {
       }).success).toBe(true);
     });
 
+    it('step_until requires a non-empty until expression', () => {
+      expect(gameTime.schema.safeParse({ action: 'step_until' }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: '' }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'G.wave > 1' }).success).toBe(true);
+    });
+
+    it('step_until caps max_ms and accepts report expressions and an input timeline', () => {
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 20000 }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 20001 }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 0 }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', report: ['G.wave', 'G.score'] }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', report: [''] }).success).toBe(false);
+      expect(gameTime.schema.safeParse({
+        action: 'step_until',
+        until: 'true',
+        inputs: [{ action_name: 'move_up', start_ms: 0, duration_ms: 500 }],
+      }).success).toBe(true);
+    });
+
     it('freeze, thaw, and status take no extra arguments', () => {
       expect(gameTime.schema.safeParse({ action: 'freeze' }).success).toBe(true);
       expect(gameTime.schema.safeParse({ action: 'thaw' }).success).toBe(true);
@@ -107,6 +126,68 @@ describe('game_time tool', () => {
       expect(data.pause_transitions).toHaveLength(1);
       expect(data.game_paused).toBe(true);
       expect(data.gameplay_ms).toBe(120);
+    });
+  });
+
+  describe('step_until', () => {
+    it('forwards the predicate and report, and surfaces a met result with its readings', async () => {
+      mock.mockResponse({
+        completed: true,
+        frozen: true,
+        elapsed_ms: 4317,
+        gameplay_ms: 4317,
+        frames: 259,
+        physics_ticks: 259,
+        game_paused: false,
+        predicate_met: true,
+        report: { 'G.wave': 1 },
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({
+        action: 'step_until',
+        until: 'tree.get_nodes_in_group("enemies").size() >= 1',
+        max_ms: 8000,
+        report: ['G.wave'],
+      }, ctx);
+
+      expect(mock.calls[0].command).toBe('game_time_step_until');
+      expect(mock.calls[0].params.until).toBe('tree.get_nodes_in_group("enemies").size() >= 1');
+      expect(mock.calls[0].params.max_ms).toBe(8000);
+      expect(mock.calls[0].params.report).toEqual(['G.wave']);
+      const data = structuredOf(result);
+      expect(data.predicate_met).toBe(true);
+      expect(data.report).toEqual({ 'G.wave': 1 });
+      expect(data.elapsed_ms).toBe(4317);
+    });
+
+    it('reports predicate_met false when the cap is hit first', async () => {
+      mock.mockResponse({
+        completed: true,
+        frozen: true,
+        elapsed_ms: 8000,
+        gameplay_ms: 8000,
+        frames: 480,
+        physics_ticks: 480,
+        game_paused: false,
+        predicate_met: false,
+        report: { 'G.wave': 3 },
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({ action: 'step_until', until: 'G.wave > 5', max_ms: 8000, report: ['G.wave'] }, ctx);
+      const data = structuredOf(result);
+      expect(data.predicate_met).toBe(false);
+      expect(data.report).toEqual({ 'G.wave': 3 });
+    });
+
+    it('propagates a bridge-side predicate rejection', async () => {
+      mock.mockError(new Error('predicate failed to evaluate: Invalid named index'));
+      const ctx = createToolContext(mock);
+
+      await expect(
+        gameTime.execute({ action: 'step_until', until: 'Bogus.foo > 1' }, ctx),
+      ).rejects.toThrow('predicate failed to evaluate');
     });
   });
 

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -42,6 +42,30 @@ const GameTimeSchema = z
     }),
     z.object({
       action: z
+        .literal('step_until')
+        .describe('Advance game time until a GDScript predicate becomes true (or a safety cap is hit), then re-freeze. Freezes first if the game is running, so it is a safe first call. Use this instead of step when you do not know how long to advance to reach the state worth observing.'),
+      until: z
+        .string()
+        .min(1)
+        .describe('A GDScript boolean expression, re-evaluated against the running game every frame; stepping stops the frame it is truthy. Autoloads are in scope by name (e.g. `G.wave > 1`, `GameState.tick_count % 12 == 11`), plus `tree` (the SceneTree) and `root` (the root Window) for tree queries (e.g. `tree.get_nodes_in_group("enemies").size() >= 1`). Must parse and evaluate without error against the current state or the call is rejected up front.'),
+      max_ms: z
+        .number()
+        .int()
+        .min(1)
+        .max(STEP_MAX_MS)
+        .optional()
+        .describe(`Safety cap on game time to advance while waiting (max ${STEP_MAX_MS}, default ${STEP_MAX_MS}). If the predicate never holds within this budget (or the wall-clock budget), the call returns with predicate_met: false instead of hanging.`),
+      report: z
+        .array(z.string().min(1))
+        .optional()
+        .describe('Optional GDScript expressions (same scope as `until`) evaluated when stepping stops and returned as a { expression: value } map — e.g. ["G.wave", "tree.get_nodes_in_group(\\"enemies\\").size()"]. Use this to read the state you care about in the same call instead of a separate observation round-trip. Each must parse and evaluate without error up front.'),
+      inputs: z
+        .array(InputActionSchema)
+        .optional()
+        .describe('Optional input timeline driven inside the window, exactly like step (e.g. hold "move forward" while waiting for an enemy to appear). Holds are released by window end.'),
+    }),
+    z.object({
+      action: z
         .literal('thaw')
         .describe('Resume real-time play, restoring the game\'s own pause state (an open pause menu stays open).'),
     }),
@@ -71,13 +95,17 @@ interface StepResult {
   events_dropped?: number;
   pause_transitions?: Array<{ at_ms: number; paused: boolean }>;
   wall_budget_exceeded?: boolean;
+  // step_until only:
+  predicate_met?: boolean;
+  report?: Record<string, unknown>;
+  predicate_error?: string;
 }
 
 export const gameTime = defineTool({
   name: 'godot_game_time',
   annotations: { title: 'Game Time Control', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
-    'Make game time answer to your clock instead of racing ahead between tool calls: freeze the running game, observe it at leisure (screenshots and state digests work while frozen), then step forward a bounded slice of game time with inputs riding inside the window. The game\'s own pause menu is layered correctly: freezing over it, stepping under it, and thawing back to it all preserve the game\'s pause intent.',
+    'Make game time answer to your clock instead of racing ahead between tool calls: freeze the running game, observe it at leisure (screenshots and state digests work while frozen), then step forward a bounded slice of game time (step) — or until a condition you specify holds (step_until) — with inputs riding inside the window. The game\'s own pause menu is layered correctly: freezing over it, stepping under it, and thawing back to it all preserve the game\'s pause intent.',
   schema: GameTimeSchema,
   async execute(args: GameTimeArgs, { godot }) {
     switch (args.action) {
@@ -96,6 +124,16 @@ export const gameTime = defineTool({
         const result = await godot.sendCommand<StepResult>('game_time_step', {
           duration_ms: args.duration_ms,
           frames: args.frames,
+          inputs: args.inputs,
+        });
+        return structured(result);
+      }
+
+      case 'step_until': {
+        const result = await godot.sendCommand<StepResult>('game_time_step_until', {
+          until: args.until,
+          max_ms: args.max_ms,
+          report: args.report,
           inputs: args.inputs,
         });
         return structured(result);

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -47,7 +47,7 @@ const GameTimeSchema = z
       until: z
         .string()
         .min(1)
-        .describe('A GDScript boolean expression, re-evaluated against the running game every frame; stepping stops the frame it is truthy. Autoloads are in scope by name (e.g. `G.wave > 1`, `GameState.tick_count % 12 == 11`), plus `tree` (the SceneTree) and `root` (the root Window) for tree queries (e.g. `tree.get_nodes_in_group("enemies").size() >= 1`). Must parse and evaluate without error against the current state or the call is rejected up front.'),
+        .describe('A GDScript boolean expression, re-evaluated against the running game every frame; stepping stops the frame it is truthy. Autoloads are in scope by name (e.g. `G.wave > 1`, `GameState.tick_count % 12 == 11`), plus `tree` (the SceneTree) and `root` (the root Window) for tree queries (e.g. `tree.get_nodes_in_group("enemies").size() >= 1`). Must parse and evaluate without error against the current state or the call is rejected up front. Expressions do NOT short-circuit (`and`/`or` evaluate both operands), so to read a node that may not exist yet, do not guard with `arr.size() > 0 and arr[0].x` — sequence two calls instead: step_until the node exists (`tree.get_nodes_in_group("boss").size() >= 1`), then step_until reading it (`tree.get_nodes_in_group("boss")[0].state == 4`).'),
       max_ms: z
         .number()
         .int()


### PR DESCRIPTION
## Problem

`godot_game_time` `step` (#256) advances a fixed budget — `duration_ms` or `frames` — so an agent with no source knowledge has to guess how far to advance to reach a state worth observing (#260), then issue a separate observation call to learn what changed (#261). The #256 dogfood hit both: a 1.5s step "looked like nothing happened" because NEON RAMPAGE's wave intro is ~4.3s, and deciding "step again?" always cost a digest round-trip.

## What this adds

A `step_until` action: advance game time until a GDScript predicate holds (or a safety cap), then re-freeze. Freezes first if running, so it is a safe first call.

- **`until`** — a GDScript boolean expression, re-evaluated each frame against the running game; stops the frame it is truthy. Autoloads are in scope by name (`G.wave > 1`); `tree` (SceneTree) and `root` (Window) are provided for tree queries (`tree.get_nodes_in_group("enemies").size() >= 1`).
- **`max_ms`** — safety cap on game time to advance (default/max 20s). If the predicate never holds within the cap (or the wall-clock budget), it returns `predicate_met: false` instead of hanging.
- **`report`** — optional expressions evaluated at stop and returned as a `{ expression: value }` map, so the readings you need come back in the same call instead of a separate observation round-trip (closes #261).
- **`inputs`** — the same in-window input timeline as `step` (e.g. hold "move forward" until an enemy appears).

```
step_until(
  until  = "tree.get_nodes_in_group(\"enemies\").size() >= 1",
  report = ["G.wave", "tree.get_nodes_in_group(\"enemies\").size()"]
)
=> { predicate_met: true, elapsed_ms: 4383,
     report: { "G.wave": 1, "tree.get_nodes_in_group(\"enemies\").size()": 1 } }
```

## Why an expression, not structured primitives

A cross-game study (twin-stick shooter, city-builder sim, nonogram puzzle, dungeon RPG) found the only stop-condition primitive that worked in every genre was "a property on an autoload/tree path" — but a small fixed set (property + node-count + node-appears) failed the long tail in every game: modulo (`tick_count % 12 == 11`), array index (`party.members[0].is_dead`), collection size, computed values, and off-tree state. A single sandboxed `Expression` covers them all in one field, and the common autoload-property case (`G.wave > 1`) is just its simplest form. The study also showed `step_until` is a real-time / tick-game tool: in input-driven and turn-based-combat modes nothing advances without input, which is why the `inputs` timeline matters there.

## How it composes

Reuses the existing step machinery untouched — settle-frame protocol, wall budget, layered pause model. The predicate and every `report` expression are parsed and dry-run validated up front (Godot's `Expression.parse()` is lenient, so a dry-run `execute()` is what actually catches unknown identifiers and bad member access), so a malformed expression is rejected before any stepping begins, naming the offending expression. A predicate already true at call time advances nothing and stays frozen. `report` values are sanitized to primitives before crossing the debugger channel. It is not a new privilege surface — the agent already has full read/write via `godot_node` / `godot_runtime_state`.

## Validation

Dogfooded against NEON RAMPAGE (real, uninstrumented, juice-heavy):

| Scenario | Result |
|---|---|
| Step until first enemy (`...group("enemies").size() >= 1`) | met @ `elapsed_ms` 4383 — exactly the wave-intro boundary |
| `report` readings in the same call | `{ G.wave: 1, G.score: 0, enemies: 1 }`, matched a digest exactly |
| Already-true short-circuit | met, `0ms` / `0 frames`, stays frozen |
| Cap-not-met (`G.wave > 999`, 2s) | `predicate_met: false`, capped, `report` still returned |
| Inputs riding the wait (hold aim until `G.shots >= 5`) | met @ 650ms, held input released cleanly |
| Bad predicate / report expression | rejected up front, names the offending expression |

Zero new runtime errors across the run. Server build clean, 241 unit tests pass (+5 for `step_until`), addon parse-checks clean (33 files).

Closes #260
Closes #261
