### PR TITLE
fix: protect active bridge client instead of replacing it (#237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Open your Godot project, restart your AI assistant, and start building.
 
 They don't overlap much, and they don't conflict. Run them side by side for the best coverage.
 
+**One godot-mcp client at a time, though.** A Godot editor bridge serves a single godot-mcp connection. If a second godot-mcp client connects - for example, a subagent that inherited the same MCP config - it is rejected while the first is active rather than displacing it, so the original session keeps working. The second client retries and connects automatically once the first disconnects. A client that crashes without closing its socket is taken over after a short idle timeout, so a dead session never permanently blocks new connections.
+
 ## Documentation
 
 - [Installation Guide](INSTALL.md) - MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more

--- a/godot/addons/godot_mcp/websocket_server.gd
+++ b/godot/addons/godot_mcp/websocket_server.gd
@@ -8,10 +8,14 @@ signal client_disconnected()
 
 const DEFAULT_PORT := 6550
 const STALE_CONNECTION_TIMEOUT_MSEC := 45000
+# Upper bound on how long a rejected newcomer is kept around while we hand it a
+# clean 4001 close. Caps the whole reject lifecycle (handshake + close flush) so
+# a peer that never upgrades or never finishes closing can't leak.
+const REJECT_TIMEOUT_MSEC := 5000
 const CLOSE_CODE_STALE := 4002
 const CLOSE_REASON_STALE := "Connection timed out (no activity)"
-const CLOSE_CODE_REPLACED := 4003
-const CLOSE_REASON_REPLACED := "Replaced by new client"
+const CLOSE_CODE_ALREADY_CONNECTED := 4001
+const CLOSE_REASON_ALREADY_CONNECTED := "Another client is already connected"
 
 var _server: TCPServer
 var _peer: StreamPeerTCP
@@ -21,6 +25,10 @@ var _connected_host: String = ""
 var _connected_port: int = 0
 var _last_activity_msec: int = 0
 var _stale_reason: String = ""
+# Newcomers that arrived while a live client already held the bridge. Each entry
+# is { "ws": WebSocketPeer, "tcp": StreamPeerTCP, "since_msec": int, "close_sent": bool }.
+# They are handshaked just far enough to receive a clean 4001 close, then dropped.
+var _rejecting_peers: Array = []
 
 
 func _process(_delta: float) -> void:
@@ -33,6 +41,9 @@ func _process(_delta: float) -> void:
 	if _ws_peer:
 		_ws_peer.poll()
 		_process_websocket()
+
+	if not _rejecting_peers.is_empty():
+		_process_rejecting_peers()
 
 
 func start_server(port: int = DEFAULT_PORT, bind_address: String = "127.0.0.1") -> Error:
@@ -54,6 +65,15 @@ func stop_server() -> void:
 	if _peer:
 		_peer.disconnect_from_host()
 		_peer = null
+
+	for entry in _rejecting_peers:
+		var rej_ws: WebSocketPeer = entry.get("ws")
+		if rej_ws:
+			rej_ws.close()
+		var rej_tcp: StreamPeerTCP = entry.get("tcp")
+		if rej_tcp:
+			rej_tcp.disconnect_from_host()
+	_rejecting_peers.clear()
 
 	if _server:
 		_server.stop()
@@ -89,11 +109,19 @@ func _accept_connection() -> void:
 
 	if _ws_peer != null:
 		if _is_stale_connection():
+			# The incumbent looks dead (TCP dropped, or no activity past the
+			# timeout). Hand the bridge to the newcomer so a crashed client can
+			# never permanently block reconnection.
 			MCPLog.warn("Replacing stale connection with new client (%s)" % _stale_reason)
 			_force_close_connection()
 		else:
-			MCPLog.warn("Replacing active connection with new client (previous server likely exited without closing)")
-			_force_close_connection(CLOSE_CODE_REPLACED, CLOSE_REASON_REPLACED)
+			# A live client already holds the bridge. Protect the incumbent and
+			# reject the newcomer with a clean close code instead of displacing
+			# it. This keeps a transient second client (e.g. a subagent that
+			# inherited the same MCP config) from bricking the active session.
+			MCPLog.warn("Rejecting new connection from %s:%d: another client is already connected" % [incoming.get_connected_host(), incoming.get_connected_port()])
+			_begin_reject(incoming)
+			return
 
 	_peer = incoming
 	_ws_peer = WebSocketPeer.new()
@@ -110,6 +138,64 @@ func _accept_connection() -> void:
 	_last_activity_msec = Time.get_ticks_msec()
 
 	MCPLog.info("TCP connection received from %s:%d, awaiting WebSocket handshake..." % [_connected_host, _connected_port])
+
+
+func _begin_reject(incoming: StreamPeerTCP) -> void:
+	# Complete just enough of the WebSocket handshake on a throwaway peer to send
+	# a proper coded close frame (4001), so the rejected client gets a clear
+	# diagnostic rather than an opaque TCP reset. The incumbent's peer is never
+	# touched. Driven to completion in _process_rejecting_peers().
+	var ws := WebSocketPeer.new()
+	var err := ws.accept_stream(incoming)
+	if err != OK:
+		# Can't speak WebSocket to this peer; just drop the raw TCP connection.
+		incoming.disconnect_from_host()
+		return
+	_rejecting_peers.append({
+		"ws": ws,
+		"tcp": incoming,
+		"since_msec": Time.get_ticks_msec(),
+		"close_sent": false,
+	})
+
+
+func _process_rejecting_peers() -> void:
+	var keep: Array = []
+	var now := Time.get_ticks_msec()
+	for entry in _rejecting_peers:
+		var ws: WebSocketPeer = entry["ws"]
+		ws.poll()
+		var state := ws.get_ready_state()
+
+		# Hard lifecycle cap: a reject peer should resolve in milliseconds.
+		# Anything still around past the timeout (never upgraded, or stuck
+		# mid-close because the client vanished) gets dropped so it can't leak.
+		if now - int(entry["since_msec"]) > REJECT_TIMEOUT_MSEC:
+			_drop_rejecting_peer(entry)
+			continue
+
+		match state:
+			WebSocketPeer.STATE_OPEN:
+				if not entry["close_sent"]:
+					ws.close(CLOSE_CODE_ALREADY_CONNECTED, CLOSE_REASON_ALREADY_CONNECTED)
+					entry["close_sent"] = true
+				# Keep polling so the close frame is actually flushed.
+				keep.append(entry)
+			WebSocketPeer.STATE_CLOSED:
+				_drop_rejecting_peer(entry)
+			_:
+				# STATE_CONNECTING (awaiting handshake) or STATE_CLOSING
+				# (flushing the close frame) - keep polling until the cap.
+				keep.append(entry)
+	_rejecting_peers = keep
+
+
+func _drop_rejecting_peer(entry: Dictionary) -> void:
+	var tcp: StreamPeerTCP = entry.get("tcp")
+	if tcp:
+		tcp.disconnect_from_host()
+	entry["ws"] = null
+	entry["tcp"] = null
 
 
 func _process_websocket() -> void:

--- a/server/src/__tests__/connection/websocket.test.ts
+++ b/server/src/__tests__/connection/websocket.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
+import { GodotConnection } from '../../connection/websocket.js';
+
+// Keep diagnostics hermetic (no WSL detection / no child processes) and quiet.
+vi.mock('../../utils/connection-strategy.js', () => ({
+  getTargetHost: () => '127.0.0.1',
+  getConnectionStrategy: (port: number) => ({
+    environment: 'native' as const,
+    targetHost: '127.0.0.1',
+    wsUrl: `ws://127.0.0.1:${port}`,
+  }),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    notice: vi.fn(),
+    warning: vi.fn(),
+    warningRateLimited: vi.fn(),
+    error: vi.fn(),
+    critical: vi.fn(),
+  },
+}));
+
+// Application close codes the Godot addon uses on the bridge.
+const CLOSE_CODE_ALREADY_CONNECTED = 4001;
+const CLOSE_CODE_REPLACED = 4003;
+
+/**
+ * Stand up a throwaway WebSocket server that plays the role of the Godot bridge.
+ * The supplied handler decides what to do with each incoming client socket.
+ */
+async function startFakeBridge(
+  onConnection: (socket: WsSocket) => void
+): Promise<{ wss: WebSocketServer; port: number }> {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(wss, 'listening');
+  wss.on('connection', onConnection);
+  const port = (wss.address() as AddressInfo).port;
+  return { wss, port };
+}
+
+/** Resolve when `event` fires on `emitter`, reject if it doesn't within `ms`. */
+function waitForEvent(emitter: GodotConnection, event: string, ms = 3000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      emitter.off(event, handler);
+      reject(new Error(`Timed out waiting for "${event}" event`));
+    }, ms);
+    const handler = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    emitter.once(event, handler);
+  });
+}
+
+describe('GodotConnection contention handling (#237)', () => {
+  let connection: GodotConnection | null = null;
+  let wss: WebSocketServer | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    // Tear the client down first so its reconnect timer is cleared before the
+    // bridge goes away (otherwise it would reconnect to a dead port).
+    connection?.disconnect();
+    connection = null;
+    if (wss) {
+      await new Promise<void>((resolve) => wss!.close(() => resolve()));
+      wss = null;
+    }
+  });
+
+  it('reconnects after being replaced by a newer client (4003), instead of latching dead', async () => {
+    // Bridge replaces whoever connects: closes the socket with the REPLACED code.
+    const bridge = await startFakeBridge((socket) => {
+      socket.on('message', () => socket.close(CLOSE_CODE_REPLACED, 'Replaced by new client'));
+    });
+    wss = bridge.wss;
+
+    connection = new GodotConnection({ host: '127.0.0.1', port: bridge.port });
+    const reconnecting = waitForEvent(connection, 'reconnecting');
+
+    await connection.connect().catch(() => {});
+    // The whole point of #237: a replaced client must schedule a reconnect.
+    await expect(reconnecting).resolves.toBeUndefined();
+    expect(connection.getDiagnostics().lastDisconnectReason).toBe('replaced_by_new_client');
+  });
+
+  it('keeps retrying when rejected because another client is connected (4001)', async () => {
+    const bridge = await startFakeBridge((socket) => {
+      socket.on('message', () => socket.close(CLOSE_CODE_ALREADY_CONNECTED, 'Another client is already connected'));
+    });
+    wss = bridge.wss;
+
+    connection = new GodotConnection({ host: '127.0.0.1', port: bridge.port });
+    const reconnecting = waitForEvent(connection, 'reconnecting');
+
+    await connection.connect().catch(() => {});
+    await expect(reconnecting).resolves.toBeUndefined();
+    expect(connection.getDiagnostics().lastDisconnectReason).toBe('rejected_another_client');
+    expect(connection.getDiagnostics().rejectionCount).toBe(1);
+  });
+
+  it('no longer tells a replaced client to restart; reports automatic recovery', async () => {
+    const bridge = await startFakeBridge((socket) => {
+      socket.on('message', () => socket.close(CLOSE_CODE_REPLACED, 'Replaced by new client'));
+    });
+    wss = bridge.wss;
+
+    connection = new GodotConnection({ host: '127.0.0.1', port: bridge.port });
+    const reconnecting = waitForEvent(connection, 'reconnecting');
+    await connection.connect().catch(() => {});
+    await reconnecting;
+
+    const message = connection.getDiagnosticMessage();
+    expect(message).not.toMatch(/no longer active/i);
+    expect(message).toMatch(/reconnect/i);
+  });
+});

--- a/server/src/connection/websocket.ts
+++ b/server/src/connection/websocket.ts
@@ -146,19 +146,20 @@ export class GodotConnection extends EventEmitter {
 
     switch (diag.lastDisconnectReason) {
       case 'rejected_another_client':
-        lines.push('Status: Connection rejected (another client already connected)');
+        lines.push('Status: Another client is already connected to Godot');
         if (diag.rejectionCount > 1) {
           lines.push(`Details: ${diag.rejectionCount} connection attempts rejected`);
         }
-        lines.push('Suggestion: Multiple MCP server processes may be running.');
-        lines.push('  Check: ps aux | grep godot-mcp (macOS/Linux)');
-        lines.push('  Check: Get-Process -Name node | ? CommandLine -Like "*godot-mcp*" (Windows)');
-        lines.push('  Fix: Kill all godot-mcp processes and restart your MCP client');
+        lines.push('Suggestion: Only one client can drive the Godot bridge at a time.');
+        lines.push('  This client keeps retrying and will connect once the other disconnects.');
+        lines.push('  If you did not expect another client, check for duplicate godot-mcp processes:');
+        lines.push('    macOS/Linux: ps aux | grep godot-mcp');
+        lines.push('    Windows: Get-Process -Name node | ? CommandLine -Like "*godot-mcp*"');
         break;
 
       case 'replaced_by_new_client':
-        lines.push('Status: Another MCP server connected and replaced this one');
-        lines.push('Suggestion: This server is no longer active. Restart it or close this session.');
+        lines.push('Status: Another client took over the Godot bridge');
+        lines.push('Suggestion: Reconnecting automatically; this recovers once the other client disconnects.');
         break;
 
       case 'connection_refused':
@@ -238,23 +239,33 @@ export class GodotConnection extends EventEmitter {
         if (code === CLOSE_CODE_ALREADY_CONNECTED) {
           this.lastDisconnectReason = 'rejected_another_client';
           this.rejectionCount++;
+          // Back off in proportion to how many times we've been rejected so a
+          // lingering second client doesn't busy-loop reconnecting every second
+          // (each brief 'open' resets reconnectAttempt before this close fires).
+          this.reconnectAttempt = Math.min(this.rejectionCount - 1, RECONNECT_DELAYS.length - 1);
           const reasonStr = reason?.toString() || 'Another client is already connected';
-          logger.critical('Connection rejected: another client already connected', {
-            reason: reasonStr,
-            suggestion: 'Multiple MCP server processes may be running',
-            diagnostics: {
-              macLinux: 'ps aux | grep godot-mcp',
-              windows: 'Get-Process -Name node | ? CommandLine -Like "*godot-mcp*"',
-            },
-          });
+          logger.warningRateLimited(
+            'rejected-another-client',
+            'Another client holds the Godot bridge; will keep retrying',
+            {
+              reason: reasonStr,
+              rejectionCount: this.rejectionCount,
+            }
+          );
         } else if (code === CLOSE_CODE_REPLACED) {
+          // A newer client took over the bridge. Don't latch this connection
+          // dead - keep reconnecting so it recovers automatically once the
+          // other client disconnects (or is itself replaced).
           this.lastDisconnectReason = 'replaced_by_new_client';
-          this.isClosing = true;
           const reasonStr = reason?.toString() || 'Replaced by new client';
-          logger.warning('Another MCP server connected to Godot, this server will not reconnect', {
-            reason: reasonStr,
-            suggestion: 'This is normal when reconnecting. If unexpected, check for duplicate MCP server configurations.',
-          });
+          logger.warningRateLimited(
+            'replaced-by-new-client',
+            'Connection was replaced by another client; will attempt to reconnect',
+            {
+              reason: reasonStr,
+              suggestion: 'This client reconnects when the Godot bridge is free again.',
+            }
+          );
         } else if (code === CLOSE_CODE_STALE) {
           this.lastDisconnectReason = 'connection_lost';
           const reasonStr = reason?.toString() || 'Connection timed out (no activity)';


### PR DESCRIPTION
## Problem

Fixes #237. The editor bridge serves a single client, but any new connection **always displaced** the current one (WebSocket close `4003`), and the displaced server then **latched itself dead** and never reconnected. In multi-agent workflows a subagent that inherits the same MCP config connects, replaces the parent's connection, and the parent stays broken **even after the subagent exits** — requiring a session restart.

Root cause was a mismatch between the two sides: the server has a full `rejected_another_client` handler for close code `4001`, but the addon **never emitted `4001`** — it only ever replaced (`4003`/`4002`). The "reject a second client" intent (#76) was silently overridden by "replace zombie processes" (#161).

## Fix (incumbent-protect + recovery)

**Addon (`websocket_server.gd`)**
- A live, healthy incumbent is now **protected**: a newcomer is rejected with a clean `4001` close via a throwaway peer — the incumbent's socket is never touched.
- The reject peer is bounded by a hard 5s lifecycle cap so it can't leak (handshake stall or stuck mid-close).
- **Stale-takeover preserved**: if the incumbent looks dead (TCP dropped, or idle past the 45s timeout) the newcomer still takes over (`4002`), so a crashed client can never permanently block reconnection. This is why newest-wins existed (#161); stale-detection now covers it.

**Server (`connection/websocket.ts`)**
- Stop setting `isClosing` on `4003` so a displaced client reconnects automatically once the bridge frees up (also correct against an older addon).
- On `4001`, advance reconnect backoff by `rejectionCount` so a lingering second client doesn't busy-loop reconnecting every second.
- Diagnostics for both cases now describe automatic retry instead of "This server is no longer active. Restart it."

**Docs:** README now documents the single-client policy and graceful recovery.

## Testing
- `npm run build` clean; `npm test` **244/244** (3 new in `__tests__/connection/websocket.test.ts`, driving a real `ws` bridge to assert the `4003`→reconnect and `4001`→retry paths).
- Addon GDScript parse/compile-clean via headless editor load.
- Not done: a live two-client integration run against a real editor (the addon reject path is reviewed + parse-verified, not runtime-exercised).
