### PR TITLE
feat: add editor restart action to godot_editor (#250)

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -18,7 +18,7 @@ Node manipulation and script attachment tools
 
 Editor control, debugging, and screenshot tools
 
-- `godot_editor` - Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
+- `godot_editor` - Control the Godot editor: get state, manage selection, run/stop project, restart the editor, capture screenshots, read log messages and stack traces, control 2D viewport
 
 ## [Project](project.md)
 

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -10,16 +10,17 @@ Editor control, debugging, and screenshot tools
 
 ## godot_editor
 
-Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport
+Control the Godot editor: get state, manage selection, run/stop project, restart the editor, capture screenshots, read log messages and stack traces, control 2D viewport
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes |  |
+| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `restart`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes |  |
 | `node_path` | string | No | Path to node to select |
 | `scene_path` | string | No | Scene to run (optional, defaults to main scene) |
 | `frozen` | boolean | No | Launch with game time frozen from frame 0 (gameplay never starts racing your latency). Use godot_game_time step/thaw to advance. |
+| `save` | boolean | No | Save the project before restarting (default: true). Set false to discard unsaved editor changes. |
 | `clear` | boolean | No | Clear buffer after reading |
 | `limit` | integer | No | Maximum number of messages to return (default: 50) |
 | `max_width` | integer | No | Maximum width in pixels (default: 900) |
@@ -40,6 +41,8 @@ Control the Godot editor: get state, manage selection, run/stop project, capture
 #### `run`
 
 #### `stop`
+
+#### `restart`
 
 #### `get_log_messages`
 
@@ -74,7 +77,7 @@ Control the Godot editor: get state, manage selection, run/stop project, capture
 }
 ```
 
-*7 more actions available: `run`, `stop`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d`*
+*8 more actions available: `run`, `stop`, `restart`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d`*
 
 ---
 

--- a/godot/addons/godot_mcp/commands/system_commands.gd
+++ b/godot/addons/godot_mcp/commands/system_commands.gd
@@ -3,10 +3,14 @@ extends MCPBaseCommand
 class_name MCPSystemCommands
 
 
+const RESTART_ACK_GRACE_SEC := 0.3
+
+
 func get_commands() -> Dictionary:
 	return {
 		"mcp_handshake": mcp_handshake,
 		"heartbeat": heartbeat,
+		"restart_editor": restart_editor,
 	}
 
 
@@ -27,6 +31,25 @@ func mcp_handshake(params: Dictionary) -> Dictionary:
 
 func heartbeat(_params: Dictionary) -> Dictionary:
 	return _success({"status": "ok"})
+
+
+func restart_editor(params: Dictionary) -> Dictionary:
+	var save: bool = params.get("save", true)
+
+	# Restarting tears down this websocket along with the editor, so defer the
+	# actual restart by a short grace period. That lets this acknowledgement
+	# flush to the client first; the MCP server then auto-reconnects once the
+	# editor is back. (EditorInterface.restart_editor itself defers the quit to
+	# end-of-frame, which alone is too early for the response to make it out.)
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree:
+		tree.create_timer(RESTART_ACK_GRACE_SEC).timeout.connect(
+			func() -> void: EditorInterface.restart_editor(save)
+		)
+	else:
+		EditorInterface.restart_editor(save)
+
+	return _success({"restarting": true, "save": save})
 
 
 func _get_addon_version() -> String:

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -76,6 +76,47 @@ describe('editor tool', () => {
     });
   });
 
+  describe('restart', () => {
+    it('sends restart_editor with save=true by default and confirms reconnect', async () => {
+      mock.mockResponse({ restarting: true, save: true });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'restart' }, ctx);
+
+      expect(mock.calls[0].command).toBe('restart_editor');
+      expect(mock.calls[0].params.save).toBe(true);
+      expect(result).toContain('restarting');
+      expect(result).toContain('reconnect');
+    });
+
+    it('passes save=false through and says it will not save', async () => {
+      mock.mockResponse({ restarting: true, save: false });
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'restart', save: false }, ctx);
+
+      expect(mock.calls[0].params.save).toBe(false);
+      expect(result).toContain('without saving');
+    });
+
+    it('treats a dropped connection as success (fire-and-forget)', async () => {
+      // The editor tears the bridge down as it restarts; sendCommand rejects
+      // with "Connection closed" mid-flight. That is the expected success path.
+      mock.mockError(new Error('Connection closed'));
+      const ctx = createToolContext(mock);
+
+      const result = await editor.execute({ action: 'restart' }, ctx);
+      expect(result).toContain('restarting');
+    });
+
+    it('rethrows a real error (e.g. command unknown to an older addon)', async () => {
+      mock.mockError(new Error('Unknown command: restart_editor'));
+      const ctx = createToolContext(mock);
+
+      await expect(editor.execute({ action: 'restart' }, ctx)).rejects.toThrow('Unknown command');
+    });
+  });
+
   describe('get_log_messages', () => {
     it('returns "No log messages" when empty', async () => {
       const ctx = createToolContext(mock);

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -52,6 +52,17 @@ const EditorSchema = z
     }),
     z.object({ action: z.literal('stop').describe('Stop the running project') }),
     z.object({
+      action: z
+        .literal('restart')
+        .describe(
+          'Restart the editor, reloading project.godot (autoloads, input map), addon code, and plugins from disk. Use after external edits the running editor would otherwise keep stale. Fire-and-forget: the bridge drops and auto-reconnects within a few seconds. Does not start a cold editor - the editor must already be running.'
+        ),
+      save: z
+        .boolean()
+        .optional()
+        .describe('Save the project before restarting (default: true). Set false to discard unsaved editor changes.'),
+    }),
+    z.object({
       action: z.literal('get_log_messages').describe('Get editor/game log messages'),
       clear: z.boolean().optional().describe('Clear buffer after reading'),
       limit: z.number().int().positive().optional().describe('Maximum number of messages to return (default: 50)'),
@@ -107,7 +118,7 @@ export const editor = defineTool({
   name: 'godot_editor',
   annotations: { title: 'Editor Control', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
-    'Control the Godot editor: get state, manage selection, run/stop project, capture screenshots, read log messages and stack traces, control 2D viewport',
+    'Control the Godot editor: get state, manage selection, run/stop project, restart the editor, capture screenshots, read log messages and stack traces, control 2D viewport',
   schema: EditorSchema,
   async execute(args: EditorArgs, { godot }) {
     switch (args.action) {
@@ -150,6 +161,24 @@ export const editor = defineTool({
       case 'stop': {
         await godot.sendCommand('stop_project');
         return 'Stopped project';
+      }
+
+      case 'restart': {
+        const save = args.save ?? true;
+        // Restarting tears down the bridge, so this is fire-and-forget: send the
+        // request and tolerate the connection dropping before the ack returns.
+        // The connection auto-reconnects once the editor is back. A drop here is
+        // the expected outcome; anything else (not connected to begin with, or an
+        // older addon that doesn't know the command) is a real failure.
+        try {
+          await godot.sendCommand('restart_editor', { save });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (!message.includes('Connection closed')) {
+            throw err;
+          }
+        }
+        return `Editor is restarting${save ? ' (project saved first)' : ' without saving'}. The bridge reconnects automatically in a few seconds - retry your next command then.`;
       }
 
       case 'get_log_messages': {


### PR DESCRIPTION
## Problem

Fixes #250. When a change requires the editor to reload/restart, the toolset dead-ends — no MCP tool could cycle the editor. The class of changes needing it is exactly what agents do constantly: external edits to `project.godot` (autoloads, input map), addon code changes, plugin enable/disable. The only workaround was a destructive shell process kill (discards unsaved state, unavailable to MCP clients without shell access). The maintainer estimated a graceful in-editor reload covers **>90%** of the restarts hit in regular Godot + Claude Code work.

## Fix

Adds `godot_editor` action **`restart`**, backed by `EditorInterface.restart_editor(save)` (confirmed present in 4.6.3).

Restarting tears the bridge down along with the editor, so the semantics are **fire-and-forget**:
- **Addon** defers the actual `restart_editor()` call by a short grace period (`create_timer(0.3).timeout`) so its acknowledgement can flush over the websocket first. `restart_editor` alone defers the quit only to end-of-frame, too early for the ack to make it out.
- **Server** sends `restart_editor` and tolerates the connection dropping mid-call (`Connection closed`), treating it as the expected success. Any other error (not connected to begin with, or an older addon that doesn't know the command) is rethrown as a real failure.
- The existing auto-reconnect reattaches once the editor is back; the fresh editor has no incumbent, so reattach is clean (composes with the #237 connection work).

Optional `save` flag (default `true`) saves before restarting; `false` discards unsaved editor changes.

**Out of scope:** cold start, crash recovery, opening a *different* project (no live editor/bridge) — that's the separate capability class in #251.

## Testing
- `npm test` **248/248** (4 new editor-tool cases: `save` default/override, dropped-connection-as-success, real-error rethrow).
- Addon GDScript parse/compile-clean via headless editor load.
- Tool docs regenerated (`docs/tools/editor.md`, `docs/tools/README.md`).
- Not done: a live restart against a real editor (server side fully unit-tested; addon uses a verified API + standard timer pattern, parse-clean).
