### PR TITLE
feat: add severity and incremental filtering to editor log messages (#244)

### DIFF
--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -21,8 +21,10 @@ Control the Godot editor: get state, manage selection, run/stop project, restart
 | `scene_path` | string | No | Scene to run (optional, defaults to main scene) |
 | `frozen` | boolean | No | Launch with game time frozen from frame 0 (gameplay never starts racing your latency). Use godot_game_time step/thaw to advance. |
 | `save` | boolean | No | Save the project before restarting (default: true). Set false to discard unsaved editor changes. |
-| `clear` | boolean | No | Clear buffer after reading |
+| `clear` | boolean | No | Clear the editor error buffer after reading |
 | `limit` | integer | No | Maximum number of messages to return (default: 50) |
+| `severity` | `all`, `error`, `warning` | No | Filter by severity: "error" drops warnings (the "did anything actually break?" check), "warning" returns only warnings, "all" (default) returns both. |
+| `since` | integer | No | Return only messages newer than this cursor. Pass back the `cursor` from a prior response to see just what is new since then - the incremental check that avoids re-reading the whole buffer (0/omitted = from the beginning). |
 | `max_width` | integer | No | Maximum width in pixels (default: 900) |
 | `quality` | integer | No | JPEG quality 1-100 (default: 75) |
 | `viewport` | `2d`, `3d` | No | Which editor viewport to capture |

--- a/godot/addons/godot_mcp/commands/debug_commands.gd
+++ b/godot/addons/godot_mcp/commands/debug_commands.gd
@@ -116,24 +116,16 @@ func _on_debug_output_received(output: PackedStringArray) -> void:
 
 func get_log_messages(params: Dictionary) -> Dictionary:
 	var clear: bool = params.get("clear", false)
-	var limit: int = params.get("limit", 50)
+	var limit: int = int(params.get("limit", 50))
+	var severity: String = params.get("severity", "all")
+	var since: int = int(params.get("since", 0))
 
-	var all_messages := MCPLogger.get_errors()
-	var total_count := all_messages.size()
-
-	var limited: Array[Dictionary] = []
-	var start_index := maxi(0, total_count - limit)
-	for i in range(start_index, total_count):
-		limited.append(all_messages[i])
+	var result := MCPLogger.query(since, severity, limit)
 
 	if clear:
 		MCPLogger.clear_errors()
 
-	return _success({
-		"total_count": total_count,
-		"returned_count": limited.size(),
-		"messages": limited,
-	})
+	return _success(result)
 
 
 func get_errors(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/core/mcp_logger.gd
+++ b/godot/addons/godot_mcp/core/mcp_logger.gd
@@ -6,6 +6,11 @@ static var _errors: Array[Dictionary] = []
 static var _max_lines := 1000
 static var _max_errors := 100
 static var _mutex := Mutex.new()
+# Monotonic sequence stamped on every retained error, never reset (not even by
+# clear_errors). It is the cursor for incremental reads: a caller passes the
+# `cursor` from a previous get_log_messages back as `since` to get only what is
+# new. Independent of array index, so trimming the oldest entries is harmless.
+static var _seq := 0
 
 
 static func _static_init() -> void:
@@ -50,6 +55,8 @@ func _log_error(function: String, file: String, line: int, code: String,
 		"frames": frames,
 	}
 	if not _is_duplicate(error_entry):
+		_seq += 1
+		error_entry["seq"] = _seq
 		_errors.append(error_entry)
 		if _errors.size() > _max_errors:
 			_errors.remove_at(0)
@@ -72,6 +79,58 @@ static func get_output() -> PackedStringArray:
 
 static func get_errors() -> Array[Dictionary]:
 	return _errors
+
+
+static func get_seq() -> int:
+	return _seq
+
+
+# Filtered, incremental view of the retained errors. Pure (no side effects) so it
+# can be unit-tested headless.
+#   since    : return only entries with seq > since (0 = from the beginning)
+#   severity : "all" (default), "error" (drops warnings), or "warning" (only warnings)
+#   limit    : keep at most this many of the most recent matches (<= 0 means all)
+# `cursor` is always the highest seq issued so far; pass it back as `since` next
+# time to read only what is new. `total_count` is the whole buffer (unfiltered),
+# `match_count` is what passed the filters, `returned_count` is after the limit.
+static func query(since: int, severity: String, limit: int) -> Dictionary:
+	_mutex.lock()
+	var cursor := _seq
+	var total_count := _errors.size()
+	var matched: Array[Dictionary] = []
+	for entry in _errors:
+		if int(entry.get("seq", 0)) <= since:
+			continue
+		if not _severity_matches(severity, int(entry.get("error_type", 0))):
+			continue
+		matched.append(entry)
+	_mutex.unlock()
+
+	var match_count := matched.size()
+	var start_index := 0
+	if limit > 0 and match_count > limit:
+		start_index = match_count - limit
+	var messages: Array[Dictionary] = matched.slice(start_index)
+
+	return {
+		"total_count": total_count,
+		"match_count": match_count,
+		"returned_count": messages.size(),
+		"cursor": cursor,
+		"messages": messages,
+	}
+
+
+# Logger.ErrorType (inherited): ERROR_TYPE_ERROR=0, ERROR_TYPE_WARNING=1,
+# ERROR_TYPE_SCRIPT=2, ERROR_TYPE_SHADER=3. Only WARNING is not an actual problem.
+static func _severity_matches(severity: String, error_type: int) -> bool:
+	match severity:
+		"error":
+			return error_type != Logger.ERROR_TYPE_WARNING
+		"warning":
+			return error_type == Logger.ERROR_TYPE_WARNING
+		_:
+			return true
 
 
 static func get_last_stack_trace() -> Array[Dictionary]:

--- a/godot/addons/godot_mcp/test/log_query_headless_test.gd
+++ b/godot/addons/godot_mcp/test/log_query_headless_test.gd
@@ -1,0 +1,143 @@
+extends SceneTree
+
+## Headless test for log filtering / incremental reads (core/mcp_logger.gd, #244).
+##
+## Validates MCPLogger.query() — the filter behind godot_editor get_log_messages:
+##   - severity: "all" / "error" (drops warnings) / "warning" (only warnings)
+##   - since: returns only entries newer than a cursor (the incremental read)
+##   - limit: keeps the most recent N matches
+##   - cursor / total_count / match_count / returned_count bookkeeping
+## plus that _log_error stamps a monotonic, never-reset `seq` on each entry.
+##
+## Not wired into CI (CI has no Godot). Run on demand against any project that has
+## the addon copied in:
+##
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/log_query_headless_test.gd"
+##
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const MCPLogger := preload("res://addons/godot_mcp/core/mcp_logger.gd")
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	_test_query_filters()
+	_test_seq_stamping_via_real_errors()
+
+	print("1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+# ── query() over a deterministic, hand-seeded buffer ─────────────────────────
+
+func _test_query_filters() -> void:
+	# Seed the static buffer directly so the test is independent of whatever the
+	# engine logged at startup. seq values are explicit; cursor must equal the
+	# highest seq issued. (0=ERROR, 1=WARNING, 2=SCRIPT, 3=SHADER.)
+	MCPLogger._errors = [
+		_entry(10, 0, "boom"),      # error
+		_entry(11, 1, "careful"),   # warning
+		_entry(12, 2, "nil call"),  # script error
+		_entry(13, 1, "deprecated"),# warning
+		_entry(14, 3, "bad shader"),# shader error
+	]
+	MCPLogger._seq = 14
+
+	var all := MCPLogger.query(0, "all", 0)
+	_check("all: total_count is the whole buffer", all["total_count"], 5)
+	_check("all: match_count counts every severity", all["match_count"], 5)
+	_check("all: returned_count with no limit", all["returned_count"], 5)
+	_check("all: cursor is the highest seq", all["cursor"], 14)
+
+	var errors := MCPLogger.query(0, "error", 0)
+	_check("error: drops the two warnings", errors["match_count"], 3)
+	_check("error: keeps error/script/shader", _seqs(errors["messages"]), [10, 12, 14])
+
+	var warnings := MCPLogger.query(0, "warning", 0)
+	_check("warning: only the two warnings", warnings["match_count"], 2)
+	_check("warning: their seqs", _seqs(warnings["messages"]), [11, 13])
+
+	# Incremental: since a cursor, return only strictly-newer entries.
+	var since := MCPLogger.query(12, "all", 0)
+	_check("since: only entries with seq > 12", _seqs(since["messages"]), [13, 14])
+	_check("since: cursor unchanged (highest seq)", since["cursor"], 14)
+
+	# since composes with severity.
+	var since_errors := MCPLogger.query(11, "error", 0)
+	_check("since + error: seq > 11 and not a warning", _seqs(since_errors["messages"]), [12, 14])
+
+	# At-or-past the cursor: nothing new.
+	var caught_up := MCPLogger.query(14, "all", 0)
+	_check("since == cursor: no new messages", caught_up["match_count"], 0)
+	_check("since == cursor: cursor still reported", caught_up["cursor"], 14)
+
+	# limit keeps the most recent N matches (match_count reflects the full match).
+	var limited := MCPLogger.query(0, "all", 2)
+	_check("limit: returned_count capped", limited["returned_count"], 2)
+	_check("limit: match_count is pre-limit", limited["match_count"], 5)
+	_check("limit: keeps the most recent", _seqs(limited["messages"]), [13, 14])
+
+
+# ── seq stamping through the real _log_error path ────────────────────────────
+
+func _test_seq_stamping_via_real_errors() -> void:
+	# MCPLogger registered itself via _static_init, so push_error reaches
+	# _log_error and a `seq` is stamped. Use distinct messages so the dedup
+	# (file+line+message+type) does not collapse them.
+	MCPLogger.clear_errors()
+	var base := MCPLogger.get_seq()
+	push_error("mcp_log_test_alpha_%d" % base)
+	push_error("mcp_log_test_beta_%d" % base)
+
+	# Read only what we just produced; ignore any incidental engine errors.
+	var mine := MCPLogger.query(base, "all", 0)
+	_check("seq: cursor advanced past baseline", MCPLogger.get_seq() > base, true)
+	var seqs: Array = _seqs(mine["messages"])
+	var monotonic := true
+	for i in range(1, seqs.size()):
+		if int(seqs[i]) <= int(seqs[i - 1]):
+			monotonic = false
+	_check("seq: stamped strictly increasing", monotonic, true)
+	# clear_errors must NOT reset the cursor (held cursors stay valid).
+	var before_clear := MCPLogger.get_seq()
+	MCPLogger.clear_errors()
+	_check("seq: clear_errors does not rewind the cursor", MCPLogger.get_seq() >= before_clear, true)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+func _entry(seq: int, error_type: int, message: String) -> Dictionary:
+	return {
+		"timestamp": 0,
+		"type": "Test",
+		"message": message,
+		"file": "res://test.gd",
+		"line": seq,
+		"function": "_test",
+		"error_type": error_type,
+		"frames": [],
+		"seq": seq,
+	}
+
+
+func _seqs(messages: Array) -> Array:
+	var out: Array = []
+	for m in messages:
+		out.append(int(m.get("seq", -1)))
+	return out
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/log_query_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/log_query_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dx2n420x1va0j

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -118,10 +118,10 @@ describe('editor tool', () => {
   });
 
   describe('get_log_messages', () => {
-    it('returns "No log messages" when empty', async () => {
+    it('returns the cursor even when empty, so a first check can start polling', async () => {
       const ctx = createToolContext(mock);
-      mock.mockResponse({ total_count: 0, returned_count: 0, messages: [] });
-      expect(await editor.execute({ action: 'get_log_messages' }, ctx)).toBe('No log messages');
+      mock.mockResponse({ total_count: 0, match_count: 0, returned_count: 0, cursor: 0, messages: [] });
+      expect(await editor.execute({ action: 'get_log_messages' }, ctx)).toBe('No messages (cursor 0).');
     });
 
     it('returns JSON with messages when present', async () => {
@@ -144,6 +144,53 @@ describe('editor tool', () => {
       mock.mockResponse({ total_count: 0, returned_count: 0, messages: [] });
       await editor.execute({ action: 'get_log_messages', limit: 10 }, ctx);
       expect(mock.calls[0].params.limit).toBe(10);
+    });
+
+    it('defaults severity to "all" and since to 0', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({ total_count: 0, match_count: 0, returned_count: 0, cursor: 0, messages: [] });
+      await editor.execute({ action: 'get_log_messages' }, ctx);
+      expect(mock.calls[0].params.severity).toBe('all');
+      expect(mock.calls[0].params.since).toBe(0);
+    });
+
+    it('passes severity and since filters through to Godot', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({ total_count: 5, match_count: 0, returned_count: 0, cursor: 5, messages: [] });
+      await editor.execute({ action: 'get_log_messages', severity: 'error', since: 3 }, ctx);
+      expect(mock.calls[0].params.severity).toBe('error');
+      expect(mock.calls[0].params.since).toBe(3);
+    });
+
+    it('surfaces cursor and match_count in the structured response', async () => {
+      const ctx = createToolContext(mock);
+      const responseData = {
+        total_count: 7,
+        match_count: 2,
+        returned_count: 2,
+        cursor: 7,
+        messages: [
+          { timestamp: 1, type: 'Error', message: 'boom', file: 'res://a.gd', line: 1, error_type: 0, frames: [] },
+          { timestamp: 2, type: 'Error', message: 'bang', file: 'res://b.gd', line: 2, error_type: 0, frames: [] },
+        ],
+      };
+      mock.mockResponse(responseData);
+      const result = await editor.execute({ action: 'get_log_messages', severity: 'error' }, ctx);
+      expect(structuredOf(result)).toEqual(responseData);
+    });
+
+    it('reports "no new messages" with the cursor when reading incrementally and nothing matched', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({ total_count: 4, match_count: 0, returned_count: 0, cursor: 4, messages: [] });
+      const result = await editor.execute({ action: 'get_log_messages', since: 4 }, ctx);
+      expect(result).toBe('No new messages since cursor 4.');
+    });
+
+    it('names the severity in the "no new messages" reply when filtering', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({ total_count: 4, match_count: 0, returned_count: 0, cursor: 4, messages: [] });
+      const result = await editor.execute({ action: 'get_log_messages', since: 4, severity: 'error' }, ctx);
+      expect(result).toBe('No new error messages since cursor 4.');
     });
   });
 

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -63,9 +63,23 @@ const EditorSchema = z
         .describe('Save the project before restarting (default: true). Set false to discard unsaved editor changes.'),
     }),
     z.object({
-      action: z.literal('get_log_messages').describe('Get editor/game log messages'),
-      clear: z.boolean().optional().describe('Clear buffer after reading'),
+      action: z
+        .literal('get_log_messages')
+        .describe(
+          'Get errors and warnings from the EDITOR process - @tool script runtime errors, import failures, addon errors, and failures from editor-side operations (scene/resource edits, reloads). This is the feedback channel for editor-side changes: run it after a mutation to confirm it did not break the editor. It does NOT include errors from the running game - for those, use minimal-godot-mcp\'s get_console_output (game console via DAP). Filter by severity (errors-only = "did my change break the editor?") and use `since`/`cursor` to read only what is new; every response returns the current `cursor`, even when empty.'
+        ),
+      clear: z.boolean().optional().describe('Clear the editor error buffer after reading'),
       limit: z.number().int().positive().optional().describe('Maximum number of messages to return (default: 50)'),
+      severity: z
+        .enum(['all', 'error', 'warning'])
+        .optional()
+        .describe('Filter by severity: "error" drops warnings (the "did anything actually break?" check), "warning" returns only warnings, "all" (default) returns both.'),
+      since: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Return only messages newer than this cursor. Pass back the `cursor` from a prior response to see just what is new since then - the incremental check that avoids re-reading the whole buffer (0/omitted = from the beginning).'),
     }),
     z.object({ action: z.literal('get_stack_trace').describe('Get the most recent error stack trace') }),
     z.object({
@@ -109,8 +123,10 @@ interface LogMessage {
 }
 
 interface LogMessagesResponse {
-  total_count: number;
-  returned_count: number;
+  total_count: number; // everything in the buffer, before filtering
+  match_count: number; // matched the severity/since filters, before the limit
+  returned_count: number; // after the limit
+  cursor: number; // highest seq issued so far; pass back as `since` for an incremental read
   messages: LogMessage[];
 }
 
@@ -187,10 +203,19 @@ export const editor = defineTool({
           {
             clear: args.clear ?? false,
             limit: args.limit ?? 50,
+            severity: args.severity ?? 'all',
+            since: args.since ?? 0,
           }
         );
         if (result.returned_count === 0) {
-          return 'No log messages';
+          // Nothing matched - but always hand back the cursor so the caller can
+          // start (or continue) incremental reads from here. Without it, the
+          // common "first check after a clean run" case would have no cursor to
+          // poll from and would fall back to re-reading the whole buffer.
+          const sev = args.severity && args.severity !== 'all' ? `${args.severity} ` : '';
+          return args.since !== undefined
+            ? `No new ${sev}messages since cursor ${result.cursor}.`
+            : `No ${sev}messages (cursor ${result.cursor}).`;
         }
         return structured(result);
       }


### PR DESCRIPTION
## What

Adds **severity** and **incremental** filtering to `godot_editor get_log_messages`, scoped to the **editor error stream**. Closes #244.

- **`severity`**: `"error"` drops warnings (the "did my change break the editor?" check), `"warning"`, or `"all"` (default). Each captured error already carries Godot's `error_type`.
- **`since` / `cursor`**: each retained error gets a monotonic `seq`; every response returns the current `cursor` (even when empty). Pass it back as `since` to read only what is new — the incremental check that avoids re-scanning the buffer.

## Scope: editor stream only (and why)

This filters the errors raised in the **editor process** — `@tool` script runtime errors, import-pipeline failures, addon errors, and failures from editor-side operations (scene/resource edits, reloads). That error class is visible **only** to an agent running code inside the editor (this addon, via `OS.add_logger`).

It deliberately does **not** cover the running game's errors. [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) already surfaces the game's console/stderr via DAP (no addon), so capturing game errors here would be unnecessary overlap — the same reason the addon's `get_debug_output` is left unexposed. End-to-end testing confirmed game-process errors never reach this buffer, which is the **correct** boundary, not a defect. The action description points users to `get_console_output` for game-side errors.

Net effect: `get_log_messages` is the **feedback channel for editor-side mutations** — run it after a change to confirm the change didn't break the editor, cheaply and incrementally.

## Verification

- **253** server unit tests (severity/since passthrough, defaults, empty-with-cursor, "no new since cursor N", incremental).
- **19** headless GDScript checks: `MCPLogger.query` severity/since filtering + monotonic `seq` stamping through the real `_log_error` path; clean addon parse-check in a 4.6.3 project.
- Editor-side capture independently confirmed live this session (the tool returned real editor-process driver errors).

## Notes
- Cross-platform: pure GDScript/TypeScript filter logic; built/tested on Windows, CI runs the same vitest on Ubuntu.
- `usage-logger.ts` untouched.

### History
An earlier revision of this branch explored capturing game-side errors too; that was reverted as overlap with minimal-godot-mcp after end-to-end testing clarified the scope boundary.