### PR TITLE
docs: recommend minimal-godot-mcp as a companion server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This MCP gives Claude direct access to your Godot editor. It can see your scene 
 
 Add godot-mcp to your MCP client. See the [Installation Guide](INSTALL.md) for config examples (Claude Desktop, Claude Code, VSCode/Copilot, and more).
 
+While you're at it, add [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) too — it's a complementary server that covers static GDScript diagnostics and the running game's console output. See [Works Well With](#works-well-with).
+
 ### 2. Install the Godot addon
 
 ```bash
@@ -28,7 +30,7 @@ Open your Godot project, restart your AI assistant, and start building.
 
 ## What Claude Can Do
 
-- **See** your editor, scenes, running game, errors, and performance
+- **See** your editor, scenes, running game, editor errors, and performance
 - **Inspect** nodes, resources, animations, tilemaps, 3D spatial data
 - **Modify** scenes, nodes, scripts, animations, tilemaps directly
 - **Test** by running the game and injecting input
@@ -36,9 +38,9 @@ Open your Godot project, restart your AI assistant, and start building.
 
 ## Works Well With
 
-[minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) by [@ryanmazzolini](https://github.com/ryanmazzolini) is another MCP server for Godot. It focuses on language server diagnostics and console output via DAP, with no addon required. This project focuses on runtime control, scene manipulation, and everything that needs a direct line into the editor.
+[minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) by [@ryanmazzolini](https://github.com/ryanmazzolini) is another MCP server for Godot, and it's worth running alongside this one. This server drives the editor through an addon — scene and node manipulation, running the game, input injection, runtime state, screenshots, and editor-side errors (`@tool`, import, and addon failures). minimal-godot-mcp needs no addon and provides exactly the functionality this server does not implement: LSP diagnostics for fast static `.gd` checking, and the running game's console output and stderr over DAP.
 
-They don't overlap much, and they don't conflict. Run them side by side for the best coverage.
+Neither duplicates the other, and they don't conflict. Install both and you get static analysis and the live game console alongside full editor and runtime control.
 
 **One godot-mcp client at a time, though.** A Godot editor bridge serves a single godot-mcp connection. If a second godot-mcp client connects - for example, a subagent that inherited the same MCP config - it is rejected while the first is active rather than displacing it, so the original session keeps working. The second client retries and connects automatically once the first disconnects. A client that crashes without closing its socket is taken over after a short idle timeout, so a dead session never permanently blocks new connections.
 

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -2,6 +2,8 @@
 
 Add a `CLAUDE.md` file to your Godot project root so Claude Code knows when to use MCP tools vs direct file editing.
 
+While you're setting up, add [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) to your MCP config alongside godot-mcp. The two are complementary: godot-mcp handles editor, scene, and runtime control; minimal-godot-mcp handles static GDScript diagnostics (LSP) and the running game's console output, with no addon. See [Works Well With](../README.md#works-well-with).
+
 ## Recommended CLAUDE.md Template
 
 ```markdown
@@ -27,7 +29,7 @@ This project uses godot-mcp for AI-assisted development.
 
 ### Companion Server
 
-For language server diagnostics and raw console output, use [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) alongside this server. They complement each other without overlap.
+This project also uses [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp). Use it for static GDScript diagnostics (LSP) and the running game's console output and stderr; use godot-mcp for editor and scene control, runtime state, input injection, and editor-side errors.
 ```
 
 Adjust to fit your project. The model already has access to tool descriptions and will figure out workflows on its own - this template just covers the non-obvious stuff.


### PR DESCRIPTION
## What

Turns the README's passive "works well with" into an actual recommendation to run [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) alongside this server, and states the functional split plainly instead of implying this project graciously "leaves" territory to it:

- **This server** drives the editor through an addon — scene/node manipulation, running the game, input injection, runtime state, screenshots, and editor-side errors (`@tool`, import, addon failures).
- **minimal-godot-mcp** provides exactly the functionality this server does not implement — LSP diagnostics for fast static `.gd` checking, and the running game's console output and stderr over DAP, no addon.

## Why

When an agent sets up a Godot project with godot-mcp, nothing it reads tells it to also wire up the complementary server — so it doesn't. This adds that nudge where setup actually happens:

- **README Quick Start**: a line to add minimal-godot-mcp too, with a pointer to the reasoning.
- **`docs/claude-code-setup.md`**: a setup-time directive to add both to the MCP config, plus sharper routing inside the CLAUDE.md template so the project's own instructions tell the agent which server handles what.

## Also

Tightens the "What Claude Can Do" bullet from "errors" to "editor errors" — this server captures editor-process errors, not the running game's (those are minimal-godot-mcp's, via DAP). Removes the only line that could be read as overclaiming.

Docs-only; no code or tool changes.