### PR TITLE
fix: wait for game bridge readiness before injecting input

### DIFF
--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -3,6 +3,11 @@ extends MCPBaseCommand
 class_name MCPInputCommands
 
 const INPUT_TIMEOUT := 30.0
+# How long to wait for the game bridge to report it is ready to receive input
+# before giving up. The natural workflow is run -> immediately drive the game;
+# the session connects before the scene loads, so this short wait absorbs that
+# gap (usually under a second) instead of dispatching input into a void (#241).
+const READY_TIMEOUT := 10.0
 
 var _input_map_result: Dictionary = {}
 var _input_map_pending: bool = false
@@ -15,12 +20,32 @@ var _type_text_result: Dictionary = {}
 var _type_text_pending: bool = false
 
 
+const _BRIDGE_NOT_READY_MSG := "Game is running but its MCP bridge is not ready to receive input yet (no scene up, or the game just launched). This usually clears within a second of run — retry shortly."
+
+
 func get_commands() -> Dictionary:
 	return {
 		"get_input_map": get_input_map,
 		"execute_input_sequence": execute_input_sequence,
 		"type_text": type_text,
 	}
+
+
+# Block until the running game's bridge reports it can consume input, bounded by
+# READY_TIMEOUT. Returns true once ready, false if the game stops or never comes
+# up in time. In the common case (game already running) this returns immediately
+# without waiting a frame. Gating input on this is the fix for #241: the debug
+# session connects before the main scene loads, so input dispatched on
+# has_active_session() alone lands in a game with nothing to receive it.
+func _await_bridge_ready(debugger_plugin) -> bool:
+	var start_time := Time.get_ticks_msec()
+	while not debugger_plugin.is_bridge_ready():
+		if not EditorInterface.is_playing_scene():
+			return false  # game stopped or crashed while we waited
+		await Engine.get_main_loop().process_frame
+		if (Time.get_ticks_msec() - start_time) / 1000.0 > READY_TIMEOUT:
+			return false
+	return true
 
 
 func get_input_map(_params: Dictionary) -> Dictionary:
@@ -113,8 +138,10 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 		return _error("NOT_RUNNING", "No game is currently running")
 
 	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
-	if debugger_plugin == null or not debugger_plugin.has_active_session():
+	if debugger_plugin == null:
 		return _error("NO_SESSION", "No active debug session")
+	if not await _await_bridge_ready(debugger_plugin):
+		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
 
 	var max_end_time: float = 0.0
 	for input in inputs:
@@ -162,8 +189,10 @@ func type_text(params: Dictionary) -> Dictionary:
 		return _error("NOT_RUNNING", "No game is currently running")
 
 	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
-	if debugger_plugin == null or not debugger_plugin.has_active_session():
+	if debugger_plugin == null:
 		return _error("NO_SESSION", "No active debug session")
+	if not await _await_bridge_ready(debugger_plugin):
+		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
 
 	var timeout := max(INPUT_TIMEOUT, (text.length() * delay_ms / 1000.0) + 5.0)
 

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -10,8 +10,13 @@ signal input_map_received(actions: Array, error: String)
 signal input_sequence_completed(result: Dictionary)
 signal type_text_completed(result: Dictionary)
 signal game_response(message_type: String, data: Variant)
+signal bridge_ready()
 
 var _active_session_id: int = -1
+# True once the running game's bridge has announced it is ready to receive input
+# (its main scene is up). The debug session connects before the scene loads, so
+# has_active_session() alone is not enough to know input will land (#241).
+var _bridge_ready: bool = false
 var _pending_screenshot: bool = false
 var _pending_debug_output: bool = false
 var _pending_performance_metrics: bool = false
@@ -53,15 +58,30 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 		"godot_mcp:game_response":
 			_handle_game_response(data)
 			return true
+		"godot_mcp:bridge_ready":
+			_handle_bridge_ready(session_id)
+			return true
 	return false
+
+
+func _handle_bridge_ready(session_id: int) -> void:
+	# Only the active session's bridge counts; ignore a late message from a prior
+	# run (a new _setup_session has already reset the flag for the current one).
+	if session_id != _active_session_id:
+		return
+	_bridge_ready = true
+	bridge_ready.emit()
 
 
 func _setup_session(session_id: int) -> void:
 	_active_session_id = session_id
+	# New game session: its bridge has not announced readiness yet.
+	_bridge_ready = false
 
 
 func _session_stopped() -> void:
 	_active_session_id = -1
+	_bridge_ready = false
 	if _pending_screenshot:
 		_pending_screenshot = false
 		screenshot_received.emit(false, "", 0, 0, "Game session ended")
@@ -95,6 +115,13 @@ func has_active_session() -> bool:
 		_active_session_id = -1
 		return false
 	return true
+
+
+# True only once the running game's bridge has reported its main scene is up and
+# can consume input. Input commands gate on this (not just has_active_session) so
+# a sequence injected right after run is not dispatched into a half-booted game.
+func is_bridge_ready() -> bool:
+	return _bridge_ready and has_active_session()
 
 
 func request_screenshot(max_width: int = 1024, quality: float = 0.75) -> void:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -5,9 +5,19 @@ const DEFAULT_MAX_WIDTH := 1024
 const DEFAULT_JPEG_QUALITY := 0.75
 const Onscreen := preload("onscreen.gd")
 
+# Cap on frames waited for the main scene to appear before announcing ready
+# anyway. The scene is normally added within a frame or two of the bridge
+# autoload's _ready; the cap only matters for a scene-less run (a SceneTree-only
+# tool), so it never blocks readiness forever. ~10s at 60 fps.
+const READY_SCENE_WAIT_FRAMES := 600
+
 var _logger: _MCPGameLogger
 var _profiler: MCPFrameProfiler
 var _sampler: MCPRuntimeStateSampler
+
+# Set once the bridge has told the editor the game is ready to drive. Guards the
+# announcement against firing twice and lets the headless test observe it.
+var _ready_announced := false
 
 
 func _ready() -> void:
@@ -39,6 +49,10 @@ func _ready() -> void:
 		_engage_freeze()
 		MCPLog.info("Game bridge: launched frozen")
 
+	# Tell the editor when the game is actually drivable, so input injected right
+	# after `run` is not silently dropped into a half-booted game (see #241).
+	_announce_bridge_ready_when_drivable()
+
 
 func _exit_tree() -> void:
 	# Guaranteed cleanup: never leave an action latched when the bridge node
@@ -48,6 +62,35 @@ func _exit_tree() -> void:
 		EngineDebugger.unregister_message_capture("godot_mcp")
 		if _profiler:
 			EngineDebugger.unregister_profiler("mcp_frame_profiler")
+
+
+# The bridge autoload's _ready runs BEFORE the main scene is added to the tree,
+# so the debug session is live (and the editor sees has_active_session) while
+# current_scene is still null. Input injected in that window is dispatched into a
+# game that has nothing to consume it — reported as executed, but a silent no-op
+# (#241). Wait for the scene to exist plus one frame (so its own _ready/input
+# wiring has run), then announce readiness; the editor gates input on this signal.
+func _announce_bridge_ready_when_drivable() -> void:
+	var tree := get_tree()
+	if tree == null:
+		return
+	var frames := 0
+	while tree.current_scene == null and frames < READY_SCENE_WAIT_FRAMES:
+		await tree.process_frame
+		frames += 1
+	# One more frame so a freshly-added scene has had its first _ready/process pass.
+	# process_frame fires even while paused, so launch-frozen runs still report ready.
+	await tree.process_frame
+	var scene_path := tree.current_scene.scene_file_path if tree.current_scene else ""
+	_emit_bridge_ready(scene_path)
+
+
+func _emit_bridge_ready(scene_path: String) -> void:
+	if _ready_announced:
+		return
+	_ready_announced = true
+	EngineDebugger.send_message("godot_mcp:bridge_ready", [scene_path])
+	MCPLog.info("Game bridge: ready to drive (%s)" % scene_path)
 
 
 func _process(delta: float) -> void:

--- a/godot/addons/godot_mcp/test/bridge_ready_handshake_test.gd
+++ b/godot/addons/godot_mcp/test/bridge_ready_handshake_test.gd
@@ -1,0 +1,91 @@
+extends SceneTree
+
+## Regression guard for the bridge-ready handshake (#241).
+## Drives the REAL MCPGameBridge node.
+##
+## THE BUG: the bridge autoload's _ready() runs BEFORE the main scene is added to
+## the tree. The debug session is already live, so the editor's has_active_session()
+## returns true and it forwards an input sequence — but with current_scene still
+## null there is nothing to consume the input. The sequence reports actions_executed
+## > 0 (apparent success) yet has zero effect: a silent drop. A round-trip's delay
+## lets the scene load, which is why "probe before injecting" worked around it.
+##
+## THE FIX: the bridge announces `godot_mcp:bridge_ready` only AFTER current_scene
+## exists plus one frame; the editor gates input on that signal. This test asserts
+## the FIXED invariant directly on the bridge: it must NOT announce ready while the
+## tree has no current_scene, and MUST announce once a scene is present.
+##
+## EngineDebugger.send_message is an inert no-op without a live debug session, so
+## the real send is harmless here; _ready_announced is the observable proxy (it is
+## set in lockstep with the send). The bridge's own _ready() early-returns without a
+## session, so the readiness coroutine is invoked directly, mirroring the
+## input-sequence stuck-held test.
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/bridge_ready_handshake_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n===================== BRIDGE-READY HANDSHAKE TEST =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var bridge := MCPGameBridge.new()
+	root.add_child(bridge)
+	for i in 3:
+		await process_frame
+
+	_check("bridge has NOT announced ready on construction", bridge._ready_announced, false)
+
+	# Start the readiness watcher with NO current_scene set: it must keep waiting.
+	bridge._announce_bridge_ready_when_drivable()
+	for i in 5:
+		await process_frame
+	_check("bridge withholds ready while current_scene is null (the bug guard)",
+		bridge._ready_announced, false)
+
+	# A scene appears (the engine adds the main scene after autoloads). The watcher
+	# should observe it, give it one settle frame, then announce ready.
+	var scene := Node.new()
+	scene.name = "FakeMainScene"
+	root.add_child(scene)
+	current_scene = scene
+	for i in 5:
+		await process_frame
+	_check("bridge announces ready once a current_scene exists", bridge._ready_announced, true)
+
+	# Idempotent: a second emit must not re-fire (guards against double signals).
+	var before := bridge._ready_announced
+	bridge._emit_bridge_ready("res://other.tscn")
+	_check("emit is idempotent once announced", bridge._ready_announced == before and before == true, true)
+
+	current_scene = null
+	root.remove_child(scene)
+	scene.free()
+	root.remove_child(bridge)
+	bridge.free()
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/bridge_ready_handshake_test.gd.uid
+++ b/godot/addons/godot_mcp/test/bridge_ready_handshake_test.gd.uid
@@ -1,0 +1,1 @@
+uid://c215wah8gs3qe


### PR DESCRIPTION
Closes #241.

## Problem

There is a window after `godot_editor run` where injected input is silently dropped. The debug session connects during the game's engine init — before the main scene is added to the tree — so the editor's `has_active_session()` is already true and it forwards an `execute_input_sequence` into a game that has nothing to consume it. The sequence reports `actions_executed > 0` (apparent success) but has zero effect. The only defense was tribal knowledge ("probe with a runtime-state digest before the first injection"), which every agent session had to rediscover and which #248's docs and #252's harness both encode as a workaround.

## Fix

A bridge-ready handshake, entirely within the editor-game channel:

- The game bridge announces `godot_mcp:bridge_ready` once `current_scene` exists (plus one frame, so the scene's own `_ready`/input wiring has run). Launch-frozen safe, since `process_frame` fires while paused.
- The editor debugger plugin tracks readiness per session via `is_bridge_ready()` (reset on session setup/stop, guarded against a stale/late message from a prior run).
- `execute_input_sequence` and `type_text` wait for readiness (bounded by `READY_TIMEOUT`, 10s) before dispatching. The natural `run -> drive` workflow now buffers and succeeds; a game that never comes up fails loud with `BRIDGE_NOT_READY` instead of dropping input. Both resolutions the issue floated (buffer / fail-loud), at once.

The common case (game already running) returns immediately without waiting a frame, so there is no added latency outside the boot window. Injecting with no game running still hits `NOT_RUNNING` instantly.

## Verification

- **Headless regression test** (`test/bridge_ready_handshake_test.gd`): the bridge withholds readiness while `current_scene` is null and announces once a scene exists; emit is idempotent. 4/4.
- **Full-addon parse/compile check**: 35/35 scripts clean.
- **Real game (NEON RAMPAGE)**: `run -> immediately inject` (no probe) starts the game from the menu and registers shots, reliably across runs; the bridge logs `ready to drive (res://scenes/main_menu.tscn)`.
- **A/B causation (zero-latency tight loop over the raw websocket)**: same `run -> input` with no gap between them —
  - gate **off**: the sequence hangs 30s and delivers nothing (the silent-drop window);
  - gate **on**: the sequence waits, then delivers all input (`accepts: 2, shots: 120`).

  Model latency normally pushes the input past the race window (so it "just works"); the tight loop is what actually exercises it.

Cross-platform: pure GDScript (`EngineDebugger`, `SceneTree.process_frame`, `Time`) with no OS-specific calls.
