### PR TITLE
feat: surface an effect signal on input sequence results

### DIFF
--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -131,6 +131,7 @@ func _on_input_map_received(actions: Array, error: String) -> void:
 
 func execute_input_sequence(params: Dictionary) -> Dictionary:
 	var inputs: Array = params.get("inputs", [])
+	var report: Array = params.get("report", [])
 	if inputs.is_empty():
 		return _error("INVALID_PARAMS", "inputs array is required and must not be empty")
 
@@ -155,7 +156,7 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 	_sequence_result = {}
 
 	debugger_plugin.input_sequence_completed.connect(_on_sequence_completed, CONNECT_ONE_SHOT)
-	debugger_plugin.request_input_sequence(inputs)
+	debugger_plugin.request_input_sequence(inputs, report)
 
 	var start_time := Time.get_ticks_msec()
 	while _sequence_pending:

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -229,14 +229,14 @@ func _handle_input_map_result(data: Array) -> void:
 	input_map_received.emit(actions, error)
 
 
-func request_input_sequence(inputs: Array) -> void:
+func request_input_sequence(inputs: Array, report: Array = []) -> void:
 	if _active_session_id < 0:
 		input_sequence_completed.emit({"error": "No active game session"})
 		return
 	_pending_input_sequence = true
 	var session := get_session(_active_session_id)
 	if session:
-		session.send_message("godot_mcp:execute_input_sequence", [inputs])
+		session.send_message("godot_mcp:execute_input_sequence", [inputs, report])
 	else:
 		_pending_input_sequence = false
 		input_sequence_completed.emit({"error": "Could not get debugger session"})

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1117,6 +1117,12 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	_sequence_gameplay_ms = 0.0
 	_sequence_draining = false
 	_sequence_settle_remaining = 0
+	# Clear probe state up front so an early return below (unknown action) cannot
+	# leave a stale report to be drained against an interrupted window. It is
+	# re-armed from report_compiled once the timeline is validated.
+	_sequence_report = []
+	_sequence_report_inputs = []
+	_sequence_report_before = {}
 
 	for input in inputs:
 		var action_name: String = input.get("action_name", "")

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -95,7 +95,7 @@ func _emit_bridge_ready(scene_path: String) -> void:
 
 func _process(delta: float) -> void:
 	_game_time_process(delta)
-	_sequence_process()
+	_sequence_process(delta)
 
 
 # Processing is needed by three independent features; only switch it off when
@@ -105,9 +105,30 @@ func _update_processing() -> void:
 	set_process(_sequence_running or _frozen or _step_active)
 
 
-func _sequence_process() -> void:
-	if not _sequence_running or _sequence_events.is_empty():
+func _sequence_process(delta: float) -> void:
+	if not _sequence_running:
 		return
+
+	var tree := get_tree()
+
+	# Drain phase: the timeline is exhausted, but a requested effect probe still
+	# needs its `after` reading. The bridge runs BEFORE the scene and injected
+	# events flush at the top of the NEXT frame, so a snapshot taken the instant
+	# the queue empties would precede gameplay processing the final input — a real
+	# effect would read as a no-op. Let a couple of gameplay frames elapse first.
+	if _sequence_draining:
+		if tree and not tree.paused:
+			_sequence_gameplay_ms += delta * 1000.0
+		_sequence_settle_remaining -= 1
+		if _sequence_settle_remaining <= 0:
+			_emit_sequence_result()
+		return
+
+	# Game time the sequence actually advanced (unpaused, scaled) vs. wall time
+	# is a no-setup no-op signal: a sequence that ran entirely under a pause or
+	# freeze shows gameplay_ms ~= 0 against a full wall_ms.
+	if tree and not tree.paused:
+		_sequence_gameplay_ms += delta * 1000.0
 
 	var elapsed := Time.get_ticks_msec() - _sequence_start_time
 
@@ -125,12 +146,61 @@ func _sequence_process() -> void:
 			_actions_completed += 1
 
 	if _sequence_events.is_empty():
-		_sequence_running = false
-		_update_processing()
-		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
-			"completed": true,
-			"actions_executed": _actions_completed,
-		}])
+		if _sequence_report.is_empty():
+			_emit_sequence_result()
+		else:
+			# Defer the result so the effect probe's `after` reflects the final input.
+			_sequence_draining = true
+			_sequence_settle_remaining = SEQUENCE_SETTLE_FRAMES
+
+
+# Assemble and send the input-sequence result, then reset probe state. Carries an
+# effect signal (#240): always-on context (scene / pause / freeze / game-vs-wall
+# time) plus, when the caller attached a `report`, the per-expression before->after
+# delta and an `any_changed` summary — enough to tell "inputs changed the world"
+# from "inputs fell into the void" in one round-trip.
+func _emit_sequence_result() -> void:
+	_sequence_running = false
+	_sequence_draining = false
+	_update_processing()
+
+	var tree := get_tree()
+	var result: Dictionary = {
+		"completed": true,
+		"actions_executed": _actions_completed,
+		"scene": tree.current_scene.scene_file_path if tree and tree.current_scene else "",
+		"tree_paused": tree.paused if tree else false,
+		"frozen": _frozen,
+		"gameplay_ms": roundi(_sequence_gameplay_ms),
+		"wall_ms": Time.get_ticks_msec() - _sequence_start_time,
+	}
+
+	if not _sequence_report.is_empty():
+		var after := _evaluate_report(_sequence_report, _sequence_report_inputs)
+		result.merge(_compute_report_deltas(_sequence_report_before, after))
+
+	_sequence_report = []
+	_sequence_report_inputs = []
+	_sequence_report_before = {}
+
+	EngineDebugger.send_message("godot_mcp:input_sequence_result", [result])
+
+
+# Pure before/after diff over the probe expressions: {report: {src: {before, after,
+# changed}}, any_changed}. A missing `after` (expression started erroring) reads as
+# null and so counts as changed — the world did move. Kept side-effect-free so the
+# headless test can assert it directly.
+func _compute_report_deltas(before: Dictionary, after: Dictionary) -> Dictionary:
+	var deltas: Dictionary = {}
+	var any_changed := false
+	for src in before:
+		var b: Variant = before[src]
+		var a: Variant = after.get(src, null)
+		var changed: bool = b != a
+		if changed:
+			any_changed = true
+		deltas[src] = {"before": b, "after": a, "changed": changed}
+	return {"report": deltas, "any_changed": any_changed}
 
 
 var _sequence_events: Array = []
@@ -138,6 +208,20 @@ var _sequence_start_time: int = 0
 var _sequence_running: bool = false
 var _actions_completed: int = 0
 var _actions_total: int = 0
+# Game time (unpaused, scaled) accumulated across the sequence window — compared
+# against wall time in the result to flag a sequence that ran under a pause/freeze.
+var _sequence_gameplay_ms: float = 0.0
+# Drain phase: after the timeline empties, hold for a few frames so an effect
+# probe's `after` reflects the final input before the result is sent.
+var _sequence_draining: bool = false
+var _sequence_settle_remaining: int = 0
+const SEQUENCE_SETTLE_FRAMES := 2
+# Optional effect probe (#240): compiled GDScript expressions [{src, expr}]
+# evaluated in the step_until predicate context, once before the first input and
+# again after the last, to prove the sequence changed something.
+var _sequence_report: Array = []
+var _sequence_report_inputs: Array = []
+var _sequence_report_before: Dictionary = {}
 # Actions whose press has been injected but whose paired release has not yet
 # fired. Used to guarantee a release even if the queue is cleared mid-flight
 # (new sequence) or the node leaves the tree — otherwise the dropped release
@@ -999,12 +1083,29 @@ func _event_to_string(event: InputEvent) -> String:
 
 func _handle_execute_input_sequence(data: Array) -> void:
 	var inputs: Array = data[0] if data.size() > 0 else []
+	var report: Array = data[1] if data.size() > 1 and data[1] is Array else []
 
 	if inputs.is_empty():
 		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
 			"error": "No inputs provided",
 		}])
 		return
+
+	# Compile the optional effect probe up front, before touching any input state,
+	# so a bad expression rejects the call cleanly (same contract as step_until's
+	# report). Reuses the predicate context: autoloads by name, plus `tree`/`root`.
+	var report_compiled: Array = []
+	var report_inputs: Array = []
+	if not report.is_empty():
+		var ctx := _build_predicate_context()
+		var rr := _compile_report(report, ctx["names"], ctx["inputs"])
+		if rr.has("error"):
+			EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
+				"error": rr["error"],
+			}])
+			return
+		report_compiled = rr["report"]
+		report_inputs = ctx["inputs"]
 
 	# Release anything still held from a prior, interrupted sequence BEFORE
 	# clearing the queue — otherwise that sequence's unfired releases are dropped
@@ -1013,6 +1114,9 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	_sequence_events.clear()
 	_actions_completed = 0
 	_actions_total = inputs.size()
+	_sequence_gameplay_ms = 0.0
+	_sequence_draining = false
+	_sequence_settle_remaining = 0
 
 	for input in inputs:
 		var action_name: String = input.get("action_name", "")
@@ -1042,6 +1146,11 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	_sequence_events.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 		return a.time < b.time
 	)
+
+	# Baseline the effect probe at the last possible moment before any input fires.
+	_sequence_report = report_compiled
+	_sequence_report_inputs = report_inputs
+	_sequence_report_before = _evaluate_report(report_compiled, report_inputs) if not report_compiled.is_empty() else {}
 
 	_sequence_start_time = Time.get_ticks_msec()
 	_sequence_running = true

--- a/godot/addons/godot_mcp/test/input_sequence_effect_probe_test.gd
+++ b/godot/addons/godot_mcp/test/input_sequence_effect_probe_test.gd
@@ -1,0 +1,110 @@
+extends SceneTree
+
+## Behavior guard for the input-sequence effect signal (#240).
+## Drives the REAL MCPGameBridge node.
+##
+## THE GAP: execute_input_sequence reported only "N actions executed" — pure event
+## dispatch, no indication whether the inputs changed the world. A 12s sequence run
+## while the player was dead returned "success" identically to one that worked.
+##
+## THE SIGNAL: the bridge now attaches an optional effect probe — GDScript
+## expressions evaluated before the first input and again after the last — plus
+## always-on context (scene / pause / freeze / game-vs-wall time). This test covers
+## the two pieces the feature rests on:
+##  1. _compute_report_deltas() — the pure before/after diff behind the verdict.
+##  2. The drain/settle path — a report-ful sequence defers its result a couple
+##     frames so the probe's `after` reflects the final input, then emits + resets.
+##
+## EngineDebugger.send_message is inert without a debug session (as in the
+## stuck-held test), so the end-to-end check inspects the bridge's own state rather
+## than the sent dict. Runs HEADLESS or windowed.
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/input_sequence_effect_probe_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const ACTION := "mcp_probe_effect_a"
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+	if not InputMap.has_action(ACTION):
+		InputMap.add_action(ACTION)
+
+	print("\n===================== INPUT-SEQUENCE EFFECT-PROBE TEST =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var bridge := MCPGameBridge.new()
+	root.add_child(bridge)
+	for i in 3:
+		await process_frame
+
+	# --- 1. _compute_report_deltas (pure) -----------------------------------
+	var d1 := bridge._compute_report_deltas({"a": 1, "b": "x"}, {"a": 1, "b": "x"})
+	_check("identical before/after -> any_changed false", d1["any_changed"], false)
+	_check("unchanged field flagged not-changed", d1["report"]["a"]["changed"], false)
+
+	var d2 := bridge._compute_report_deltas({"a": 1}, {"a": 2})
+	_check("differing value -> changed", d2["report"]["a"]["changed"], true)
+	_check("any differing field -> any_changed true", d2["any_changed"], true)
+	_check("before value preserved", d2["report"]["a"]["before"], 1)
+	_check("after value preserved", d2["report"]["a"]["after"], 2)
+
+	# An expression that started erroring drops out of `after`; a missing reading
+	# reads as null and counts as changed (the world did move).
+	var d3 := bridge._compute_report_deltas({"a": 5}, {})
+	_check("missing after reads as null", d3["report"]["a"]["after"], null)
+	_check("missing after counts as changed", d3["report"]["a"]["changed"], true)
+
+	# --- 2. drain/settle + clean emit on a report-ful sequence --------------
+	# `1 + 1` evaluates in the predicate context (tree/root always present), so the
+	# probe path is exercised with no game-specific autoload.
+	bridge._handle_execute_input_sequence([
+		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 10}],
+		["1 + 1"],
+	])
+	_check("report-ful sequence started", bridge._sequence_running, true)
+	_check("baseline captured before any input", bridge._sequence_report_before.has("1 + 1"), true)
+
+	await create_timer(0.05).timeout
+	for i in 6:
+		await process_frame
+	_check("sequence finished (running cleared)", bridge._sequence_running, false)
+	_check("drain flag cleared", bridge._sequence_draining, false)
+	_check("probe state reset after emit", bridge._sequence_report.is_empty(), true)
+	_check("the tap registered and released (not latched)", Input.is_action_pressed(ACTION), false)
+
+	# --- 3. a bad report expression rejects without starting a sequence -----
+	bridge._handle_execute_input_sequence([
+		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 10}],
+		["bogus_identifier_xyz + 1"],
+	])
+	_check("invalid report expression does NOT start a sequence", bridge._sequence_running, false)
+
+	root.remove_child(bridge)
+	bridge.free()
+	if InputMap.has_action(ACTION):
+		InputMap.erase_action(ACTION)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/input_sequence_effect_probe_test.gd.uid
+++ b/godot/addons/godot_mcp/test/input_sequence_effect_probe_test.gd.uid
@@ -1,0 +1,1 @@
+uid://drkscjkx6rtjx

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -36,6 +36,20 @@ describe('input tool', () => {
         delay_ms: -1,
       }).success).toBe(false);
     });
+
+    it('accepts an optional report array of expression strings', () => {
+      expect(input.schema.safeParse({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire' }],
+        report: ['G.shots', 'G.wave'],
+      }).success).toBe(true);
+      // report must be strings, not arbitrary values
+      expect(input.schema.safeParse({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire' }],
+        report: [1, 2],
+      }).success).toBe(false);
+    });
   });
 
   describe('get_map', () => {
@@ -104,6 +118,82 @@ describe('input tool', () => {
         action: 'sequence',
         inputs: [{ action_name: 'invalid', start_ms: 0, duration_ms: 0 }],
       }, ctx)).rejects.toThrow('Unknown action: invalid');
+    });
+
+    it('passes report expressions through and surfaces before -> after deltas', async () => {
+      mock.mockResponse({
+        completed: true,
+        actions_executed: 1,
+        scene: 'res://arena.tscn',
+        tree_paused: false,
+        frozen: false,
+        gameplay_ms: 210,
+        wall_ms: 212,
+        report: {
+          'G.shots': { before: 42, after: 47, changed: true },
+          'G.wave': { before: 2, after: 2, changed: false },
+        },
+        any_changed: true,
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 100 }],
+        report: ['G.shots', 'G.wave'],
+      }, ctx);
+
+      expect(mock.calls[0].params.report).toEqual(['G.shots', 'G.wave']);
+      expect(result).toContain('G.shots: 42 -> 47  (changed)');
+      expect(result).toContain('G.wave: 2 -> 2  (no change)');
+      expect(result).toContain('scene res://arena.tscn');
+      expect(result).not.toContain('may have had no effect');
+    });
+
+    it('flags a probable no-op when nothing the probe watched changed', async () => {
+      // The headline #240 case: a long sequence that ran while the player was dead.
+      mock.mockResponse({
+        completed: true,
+        actions_executed: 12,
+        scene: 'res://arena.tscn',
+        tree_paused: false,
+        frozen: false,
+        gameplay_ms: 12700,
+        wall_ms: 12710,
+        report: { 'G.shots': { before: 99, after: 99, changed: false } },
+        any_changed: false,
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 12000 }],
+        report: ['G.shots'],
+      }, ctx);
+
+      expect(result).toContain('G.shots: 99 -> 99  (no change)');
+      expect(result).toContain('may have had no effect');
+    });
+
+    it('warns when the tree was paused for the sequence (no gameplay advanced)', async () => {
+      mock.mockResponse({
+        completed: true,
+        actions_executed: 2,
+        scene: 'res://arena.tscn',
+        tree_paused: true,
+        frozen: false,
+        gameplay_ms: 0,
+        wall_ms: 2000,
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'move_left', start_ms: 0, duration_ms: 1000 }],
+      }, ctx);
+
+      expect(result).toContain('PAUSED');
+      expect(result).toContain('gameplay 0ms / wall 2000ms');
     });
   });
 

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -18,6 +18,20 @@ const InputSchema = z.discriminatedUnion('action', [
       .array(InputActionSchema)
       .min(1)
       .describe('Array of inputs to execute'),
+    report: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Optional effect probe: GDScript expressions evaluated once before the first input and ' +
+        'again after the last, to prove the inputs actually changed something (vs. falling into ' +
+        'the void — player dead, UI focus elsewhere, wrong action). Reference autoloads by name ' +
+        '(e.g. "G.shots", "G.wave") plus `tree`/`root` (e.g. ' +
+        '"tree.get_nodes_in_group(\'enemies\').size()"), same context as godot_game_time step_until. ' +
+        'Each expression returns {before, after, changed}; the result also carries any_changed. ' +
+        'Expressions do NOT short-circuit and a parse/eval error rejects the call. The after-reading ' +
+        'is sampled a couple frames past the final input, so only near-immediate effects register — ' +
+        'for slower effects use godot_game_time or runtime_state watch.'
+      ),
   }),
   z.object({
     action: z.literal('type_text').describe('Type text into the focused UI element'),
@@ -51,7 +65,7 @@ export const input = defineTool({
   name: 'godot_input',
   annotations: { title: 'Input Injection', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
-    'Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing, or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.',
+    'Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.',
   schema: InputSchema,
   async execute(args: InputArgs, { godot }) {
     switch (args.action) {
@@ -78,8 +92,15 @@ export const input = defineTool({
         const result = await godot.sendCommand<{
           completed: boolean;
           actions_executed: number;
+          scene?: string;
+          tree_paused?: boolean;
+          frozen?: boolean;
+          gameplay_ms?: number;
+          wall_ms?: number;
+          report?: Record<string, { before: unknown; after: unknown; changed: boolean }>;
+          any_changed?: boolean;
           error?: string;
-        }>('execute_input_sequence', { inputs });
+        }>('execute_input_sequence', { inputs, report: args.report });
 
         if (result.error) {
           throw new Error(result.error);
@@ -88,7 +109,43 @@ export const input = defineTool({
         const totalDuration = Math.max(...inputs.map((i) => (i.start_ms ?? 0) + (i.duration_ms ?? 0)));
         const actionNames = [...new Set(inputs.map((i) => i.action_name))].join(', ');
 
-        return `Input sequence completed: ${result.actions_executed} action(s) executed [${actionNames}] over ${totalDuration}ms`;
+        const lines = [
+          `Input sequence completed: ${result.actions_executed} action(s) executed [${actionNames}] over ${totalDuration}ms.`,
+        ];
+
+        // Always-on context: a sequence that ran under a pause/freeze advanced no
+        // gameplay, so its inputs almost certainly did nothing — surface that
+        // without the caller having to ask.
+        const ctx: string[] = [];
+        if (result.scene !== undefined) ctx.push(`scene ${result.scene || '(none)'}`);
+        if (result.gameplay_ms !== undefined && result.wall_ms !== undefined) {
+          ctx.push(`gameplay ${result.gameplay_ms}ms / wall ${result.wall_ms}ms`);
+        }
+        if (ctx.length > 0) lines.push(`Context: ${ctx.join(', ')}.`);
+        if (result.tree_paused) {
+          lines.push(
+            `WARNING: the scene tree was PAUSED at completion${result.frozen ? ' (godot_game_time freeze active)' : ''} — ` +
+            `gameplay did not advance, so these inputs likely had no effect. Thaw/unpause first, or drive a paused ` +
+            `tree with godot_game_time step inputs.`
+          );
+        }
+
+        // Effect probe (#240): the headline "did it do anything" signal.
+        if (result.report) {
+          lines.push('Effect probe (before -> after):');
+          for (const [expr, d] of Object.entries(result.report)) {
+            const tag = d.changed ? 'changed' : 'no change';
+            lines.push(`  ${expr}: ${JSON.stringify(d.before)} -> ${JSON.stringify(d.after)}  (${tag})`);
+          }
+          if (result.any_changed === false) {
+            lines.push(
+              'No probed expression changed — the inputs may have had no effect (player dead/disabled, ' +
+              'UI focus elsewhere, wrong action, or the effect is slower than the probe window).'
+            );
+          }
+        }
+
+        return lines.join('\n');
       }
 
       case 'type_text': {


### PR DESCRIPTION
## Problem (#240)

`godot_input` `sequence` reported only `N actions executed` — pure event dispatch. It could not distinguish *inputs changed the world* from *inputs fell into the void*. In the field session, a 12.7s kiting sequence returned success while the player had been **dead the whole time** (`shots` unchanged); diagnosing that "success" took three more tool calls across two runs, and the pattern recurred.

## What this adds

The sequence result now carries an **effect signal**, in two complementary tiers:

**1. Always-on context (zero caller setup).** Every result includes `scene`, `tree_paused`, `frozen`, and `gameplay_ms` vs `wall_ms`. A sequence that ran under a pause or freeze shows `gameplay_ms ≈ 0` against a full `wall_ms` and trips a PAUSED warning — the structural no-op modes, flagged for free.

**2. Opt-in effect probe.** Callers may attach a `report` of GDScript expressions, evaluated once before the first input and again after the last. It reuses the **same predicate context as `game_time` `step_until`** (autoloads by name, plus `tree`/`root`), so `report: ["G.shots", "G.wave"]` just works. Each expression returns `{before, after, changed}` plus a top-level `any_changed`. The after-reading is deferred a couple of frames past the final input (the bridge runs before the scene and injected events flush on the next frame), so a real effect is not misread as a no-op.

A dead-player / fell-into-the-void sequence now reads `G.shots: 99 -> 99 (no change)` in **one** call.

## Design notes

- Bad `report` expressions reject the call up front (parse + dry-run execute), same contract as `step_until`'s `report`.
- The always-on fast path is byte-for-byte unchanged in timing when no `report` is supplied — the settle deferral only engages when a probe needs its `after`.
- `request_input_sequence(inputs, report = [])` defaults keep every existing caller working.

## Validation

- **257/257 server unit tests pass**, including new cases: `report` schema, before→after surfacing, the no-op verdict (the headline dead-player case), and the paused-tree warning.
- **New headless regression guard** (`input_sequence_effect_probe_test.gd`) — 15/15 on the real engine: `_compute_report_deltas` (changed/unchanged/missing-after), the drain/settle path, clean emit+reset, and bad-expression rejection.
- **Live end-to-end on a real game (run-n-gun):**

  | | Effect case | No-op case (frozen) |
  |---|---|---|
  | `G.shots` | `0 -> 5 (changed)` | `5 -> 5 (no change)` |
  | game vs wall | `667ms / 649ms` (healthy) | `0ms / 648ms` (diverged) |
  | `any_changed` | true (no warning) | false -> "may have had no effect" |
  | tree state | — | PAUSED warning surfaced |

Closes #240