### PR TITLE
feat: capture frames mid-input-sequence for transient visuals

### DIFF
--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -14,6 +14,9 @@ var _input_map_pending: bool = false
 
 var _sequence_result: Dictionary = {}
 var _sequence_pending: bool = false
+# Frames captured mid-sequence (#239), collected from sequence_capture_received
+# signals and attached to the result once the sequence completes.
+var _sequence_captures: Array = []
 
 
 var _type_text_result: Dictionary = {}
@@ -132,6 +135,8 @@ func _on_input_map_received(actions: Array, error: String) -> void:
 func execute_input_sequence(params: Dictionary) -> Dictionary:
 	var inputs: Array = params.get("inputs", [])
 	var report: Array = params.get("report", [])
+	var screenshots: Array = params.get("screenshot_at_ms", [])
+	var screenshot_max_width: int = int(params.get("screenshot_max_width", 640))
 	if inputs.is_empty():
 		return _error("INVALID_PARAMS", "inputs array is required and must not be empty")
 
@@ -144,19 +149,27 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 	if not await _await_bridge_ready(debugger_plugin):
 		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
 
+	# The window can extend past the last input if a frame capture is requested
+	# at a later offset, so factor capture offsets into the timeout too.
 	var max_end_time: float = 0.0
 	for input in inputs:
 		var start_ms: float = input.get("start_ms", 0.0)
 		var duration_ms: float = input.get("duration_ms", 0.0)
 		max_end_time = max(max_end_time, start_ms + duration_ms)
+	for shot_ms in screenshots:
+		max_end_time = max(max_end_time, float(shot_ms))
 
 	var timeout := max(INPUT_TIMEOUT, (max_end_time / 1000.0) + 5.0)
 
 	_sequence_pending = true
 	_sequence_result = {}
+	_sequence_captures = []
 
+	# Captures stream in as separate signals before the final result; collect
+	# them for the duration of the wait (not one-shot), then detach.
+	debugger_plugin.sequence_capture_received.connect(_on_sequence_capture)
 	debugger_plugin.input_sequence_completed.connect(_on_sequence_completed, CONNECT_ONE_SHOT)
-	debugger_plugin.request_input_sequence(inputs, report)
+	debugger_plugin.request_input_sequence(inputs, report, screenshots, screenshot_max_width)
 
 	var start_time := Time.get_ticks_msec()
 	while _sequence_pending:
@@ -165,10 +178,18 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 			_sequence_pending = false
 			if debugger_plugin.input_sequence_completed.is_connected(_on_sequence_completed):
 				debugger_plugin.input_sequence_completed.disconnect(_on_sequence_completed)
+			if debugger_plugin.sequence_capture_received.is_connected(_on_sequence_capture):
+				debugger_plugin.sequence_capture_received.disconnect(_on_sequence_capture)
 			return _error("TIMEOUT", "Timed out waiting for input sequence to complete")
+
+	if debugger_plugin.sequence_capture_received.is_connected(_on_sequence_capture):
+		debugger_plugin.sequence_capture_received.disconnect(_on_sequence_capture)
 
 	if _sequence_result.has("error"):
 		return _error("SEQUENCE_ERROR", _sequence_result.get("error", "Unknown error"))
+
+	if not _sequence_captures.is_empty():
+		_sequence_result["captures"] = _sequence_captures
 
 	return _success(_sequence_result)
 
@@ -176,6 +197,18 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 func _on_sequence_completed(result: Dictionary) -> void:
 	_sequence_pending = false
 	_sequence_result = result
+
+
+func _on_sequence_capture(requested_ms: int, actual_ms: int, ok: bool, image_base64: String, width: int, height: int, error: String) -> void:
+	_sequence_captures.append({
+		"requested_ms": requested_ms,
+		"actual_ms": actual_ms,
+		"ok": ok,
+		"image_base64": image_base64,
+		"width": width,
+		"height": height,
+		"error": error,
+	})
 
 
 func type_text(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -8,6 +8,7 @@ signal performance_metrics_received(metrics: Dictionary)
 signal find_nodes_received(matches: Array, count: int, error: String)
 signal input_map_received(actions: Array, error: String)
 signal input_sequence_completed(result: Dictionary)
+signal sequence_capture_received(requested_ms: int, actual_ms: int, ok: bool, image_base64: String, width: int, height: int, error: String)
 signal type_text_completed(result: Dictionary)
 signal game_response(message_type: String, data: Variant)
 signal bridge_ready()
@@ -51,6 +52,9 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			return true
 		"godot_mcp:input_sequence_result":
 			_handle_input_sequence_result(data)
+			return true
+		"godot_mcp:sequence_capture":
+			_handle_sequence_capture(data)
 			return true
 		"godot_mcp:type_text_result":
 			_handle_type_text_result(data)
@@ -229,14 +233,14 @@ func _handle_input_map_result(data: Array) -> void:
 	input_map_received.emit(actions, error)
 
 
-func request_input_sequence(inputs: Array, report: Array = []) -> void:
+func request_input_sequence(inputs: Array, report: Array = [], screenshots: Array = [], screenshot_max_width: int = 640) -> void:
 	if _active_session_id < 0:
 		input_sequence_completed.emit({"error": "No active game session"})
 		return
 	_pending_input_sequence = true
 	var session := get_session(_active_session_id)
 	if session:
-		session.send_message("godot_mcp:execute_input_sequence", [inputs, report])
+		session.send_message("godot_mcp:execute_input_sequence", [inputs, report, screenshots, screenshot_max_width])
 	else:
 		_pending_input_sequence = false
 		input_sequence_completed.emit({"error": "Could not get debugger session"})
@@ -246,6 +250,20 @@ func _handle_input_sequence_result(data: Array) -> void:
 	_pending_input_sequence = false
 	var result: Dictionary = data[0] if data.size() > 0 else {}
 	input_sequence_completed.emit(result)
+
+
+# A mid-sequence frame capture (#239) arriving on its own message. Re-emitted for
+# the editor command to collect; the final input_sequence_result follows once the
+# bridge has sent every requested frame.
+func _handle_sequence_capture(data: Array) -> void:
+	var requested_ms: int = int(data[0]) if data.size() > 0 else 0
+	var actual_ms: int = int(data[1]) if data.size() > 1 else 0
+	var ok: bool = bool(data[2]) if data.size() > 2 else false
+	var base64: String = String(data[3]) if data.size() > 3 else ""
+	var width: int = int(data[4]) if data.size() > 4 else 0
+	var height: int = int(data[5]) if data.size() > 5 else 0
+	var error: String = String(data[6]) if data.size() > 6 else ""
+	sequence_capture_received.emit(requested_ms, actual_ms, ok, base64, width, height, error)
 
 
 func request_type_text(text: String, delay_ms: int, submit: bool) -> void:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -119,8 +119,12 @@ func _sequence_process(delta: float) -> void:
 	if _sequence_draining:
 		if tree and not tree.paused:
 			_sequence_gameplay_ms += delta * 1000.0
-		_sequence_settle_remaining -= 1
-		if _sequence_settle_remaining <= 0:
+		if _sequence_settle_remaining > 0:
+			_sequence_settle_remaining -= 1
+		# Finalize only once the settle frames have elapsed (so an effect probe's
+		# `after` reflects the final input) AND every deferred frame capture has
+		# been sent back.
+		if _sequence_settle_remaining <= 0 and _sequence_captures_pending == 0:
 			_emit_sequence_result()
 		return
 
@@ -145,13 +149,28 @@ func _sequence_process(delta: float) -> void:
 			_held_actions.erase(seq_event.action)
 			_actions_completed += 1
 
-	if _sequence_events.is_empty():
-		if _sequence_report.is_empty():
-			_emit_sequence_result()
-		else:
-			# Defer the result so the effect probe's `after` reflects the final input.
+	# Trigger any frame captures whose offset has arrived (#239). Capture is
+	# deferred to frame_post_draw, so it completes a frame or two later; the
+	# pending count keeps the result from being sent until every frame is in.
+	while _sequence_capture_offsets.size() > 0 and int(_sequence_capture_offsets[0]) <= elapsed:
+		var off: int = int(_sequence_capture_offsets.pop_front())
+		_sequence_captures_pending += 1
+		_capture_sequence_frame.call_deferred(off)
+
+	# Done when both the input timeline and the capture schedule are exhausted;
+	# captures scheduled past the last input keep the window open until their
+	# offsets arrive.
+	if _sequence_events.is_empty() and _sequence_capture_offsets.is_empty():
+		if not _sequence_report.is_empty():
+			# Defer so the effect probe's `after` reflects the final input.
 			_sequence_draining = true
 			_sequence_settle_remaining = SEQUENCE_SETTLE_FRAMES
+		elif _sequence_captures_pending == 0:
+			_emit_sequence_result()
+		else:
+			# No probe, but captures are still resolving — wait for them.
+			_sequence_draining = true
+			_sequence_settle_remaining = 0
 
 
 # Assemble and send the input-sequence result, then reset probe state. Carries an
@@ -203,6 +222,42 @@ func _compute_report_deltas(before: Dictionary, after: Dictionary) -> Dictionary
 	return {"report": deltas, "any_changed": any_changed}
 
 
+# Capture one frame mid-sequence (#239) and stream it back on its own message.
+# Deferred from _sequence_process to frame_post_draw so it reads the rendered
+# frame nearest the requested offset; the actual elapsed offset is reported
+# alongside so the agent knows exactly when each frame landed. Each capture rides
+# its own message, and the count gates the result.
+#
+# Encoded as lossless PNG, deliberately not JPEG: vision-token cost is a function
+# of resolution (≈ width*height/750), not of file size or codec, so JPEG would
+# only add compression artifacts for zero token saving. The token lever is
+# _sequence_capture_max_width (resolution); PNG just costs more transport bytes.
+func _capture_sequence_frame(requested_offset_ms: int) -> void:
+	await RenderingServer.frame_post_draw
+	var actual_ms := Time.get_ticks_msec() - _sequence_start_time
+	var viewport := get_viewport()
+	if viewport == null:
+		_send_sequence_capture(requested_offset_ms, actual_ms, false, "", 0, 0, "NO_VIEWPORT: could not get game viewport")
+		return
+	var image := viewport.get_texture().get_image()
+	if image == null:
+		_send_sequence_capture(requested_offset_ms, actual_ms, false, "", 0, 0, "CAPTURE_FAILED: could not read viewport image")
+		return
+	if _sequence_capture_max_width > 0 and image.get_width() > _sequence_capture_max_width:
+		var scale_factor := float(_sequence_capture_max_width) / float(image.get_width())
+		image.resize(_sequence_capture_max_width, int(image.get_height() * scale_factor), Image.INTERPOLATE_LANCZOS)
+	var png_buffer := image.save_png_to_buffer()
+	var base64 := Marshalls.raw_to_base64(png_buffer)
+	_send_sequence_capture(requested_offset_ms, actual_ms, true, base64, image.get_width(), image.get_height(), "")
+
+
+func _send_sequence_capture(requested_ms: int, actual_ms: int, ok: bool, base64: String, width: int, height: int, error: String) -> void:
+	# Decrement first: the result is gated on this reaching zero, and a capture
+	# that errors must still release its slot or the sequence would never finish.
+	_sequence_captures_pending = maxi(0, _sequence_captures_pending - 1)
+	EngineDebugger.send_message("godot_mcp:sequence_capture", [requested_ms, actual_ms, ok, base64, width, height, error])
+
+
 var _sequence_events: Array = []
 var _sequence_start_time: int = 0
 var _sequence_running: bool = false
@@ -222,6 +277,14 @@ const SEQUENCE_SETTLE_FRAMES := 2
 var _sequence_report: Array = []
 var _sequence_report_inputs: Array = []
 var _sequence_report_before: Dictionary = {}
+# Mid-sequence frame capture (#239): offsets (ms from start, sorted) still to be
+# captured during the real-time run, the capture params, and the count of
+# deferred captures not yet sent — the result is held until this reaches zero.
+var _sequence_capture_offsets: Array = []
+var _sequence_captures_pending: int = 0
+var _sequence_capture_max_width: int = 640
+const SEQUENCE_MAX_CAPTURES := 8
+const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 60000
 # Actions whose press has been injected but whose paired release has not yet
 # fired. Used to guarantee a release even if the queue is cleared mid-flight
 # (new sequence) or the node leaves the tree — otherwise the dropped release
@@ -1084,12 +1147,23 @@ func _event_to_string(event: InputEvent) -> String:
 func _handle_execute_input_sequence(data: Array) -> void:
 	var inputs: Array = data[0] if data.size() > 0 else []
 	var report: Array = data[1] if data.size() > 1 and data[1] is Array else []
+	var screenshot_offsets: Array = data[2] if data.size() > 2 and data[2] is Array else []
+	var cap_max_width: int = int(data[3]) if data.size() > 3 else 640
 
 	if inputs.is_empty():
 		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
 			"error": "No inputs provided",
 		}])
 		return
+
+	# Normalize the optional frame-capture schedule (#239): clamp each offset,
+	# cap the count, and sort so _sequence_process can pop them in order.
+	var capture_offsets: Array = []
+	for o in screenshot_offsets:
+		if capture_offsets.size() >= SEQUENCE_MAX_CAPTURES:
+			break
+		capture_offsets.append(clampi(int(o), 0, SEQUENCE_MAX_CAPTURE_OFFSET_MS))
+	capture_offsets.sort()
 
 	# Compile the optional effect probe up front, before touching any input state,
 	# so a bad expression rejects the call cleanly (same contract as step_until's
@@ -1117,12 +1191,15 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	_sequence_gameplay_ms = 0.0
 	_sequence_draining = false
 	_sequence_settle_remaining = 0
-	# Clear probe state up front so an early return below (unknown action) cannot
-	# leave a stale report to be drained against an interrupted window. It is
-	# re-armed from report_compiled once the timeline is validated.
+	# Clear probe and capture state up front so an early return below (unknown
+	# action) cannot leave a stale report or capture schedule to be acted on
+	# against an interrupted window. Both are re-armed once the timeline validates.
 	_sequence_report = []
 	_sequence_report_inputs = []
 	_sequence_report_before = {}
+	_sequence_capture_offsets = []
+	_sequence_captures_pending = 0
+	_sequence_capture_max_width = cap_max_width
 
 	for input in inputs:
 		var action_name: String = input.get("action_name", "")
@@ -1157,6 +1234,9 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	_sequence_report = report_compiled
 	_sequence_report_inputs = report_inputs
 	_sequence_report_before = _evaluate_report(report_compiled, report_inputs) if not report_compiled.is_empty() else {}
+
+	# Arm the capture schedule (validated and sorted above).
+	_sequence_capture_offsets = capture_offsets
 
 	_sequence_start_time = Time.get_ticks_msec()
 	_sequence_running = true

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -284,7 +284,10 @@ var _sequence_capture_offsets: Array = []
 var _sequence_captures_pending: int = 0
 var _sequence_capture_max_width: int = 640
 const SEQUENCE_MAX_CAPTURES := 8
-const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 60000
+# Capped well under the 30s server command timeout: the sequence runs until its
+# last capture offset, so a larger value would let the whole call time out
+# server-side. 20s is already far longer than any transient-visual capture needs.
+const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 20000
 # Actions whose press has been injected but whose paired release has not yet
 # fired. Used to guarantee a release even if the queue is cleared mid-flight
 # (new sequence) or the node leaves the tree — otherwise the dropped release

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -287,6 +287,7 @@ const SEQUENCE_MAX_CAPTURES := 8
 # Capped well under the 30s server command timeout: the sequence runs until its
 # last capture offset, so a larger value would let the whole call time out
 # server-side. 20s is already far longer than any transient-visual capture needs.
+# This bound is a placeholder for the global-timeout fix tracked in godot-mcp#276.
 const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 20000
 # Actions whose press has been injected but whose paired release has not yet
 # fired. Used to guarantee a release even if the queue is cleared mid-flight

--- a/godot/addons/godot_mcp/test/input_sequence_capture_test.gd
+++ b/godot/addons/godot_mcp/test/input_sequence_capture_test.gd
@@ -1,0 +1,101 @@
+extends SceneTree
+
+## Behavior guard for mid-sequence frame capture (#239).
+## Drives the REAL MCPGameBridge node.
+##
+## Verifies the capture SCHEDULING and finish-gating, which is the timing-sensitive
+## part: offsets are clamped, capped, and sorted; the sequence keeps running until
+## every scheduled capture has been triggered and its deferred send has resolved;
+## the result is not emitted while captures are still pending.
+##
+## Actual image bytes are NOT asserted — under `--headless` the dummy renderer may
+## return no image, so each capture resolves via the error path. That still
+## exercises the pending-count gating (a failed capture MUST release its slot, or
+## the sequence would hang forever), which is exactly what this guards.
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/input_sequence_capture_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const ACTION := "mcp_probe_capture_a"
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+	if not InputMap.has_action(ACTION):
+		InputMap.add_action(ACTION)
+
+	print("\n===================== INPUT-SEQUENCE CAPTURE TEST =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var bridge := MCPGameBridge.new()
+	root.add_child(bridge)
+	for i in 3:
+		await process_frame
+
+	# --- 1. normalization: clamp + sort ------------------------------------
+	# Inspected immediately, before any frame advances, so nothing has fired yet.
+	bridge._handle_execute_input_sequence([
+		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 5}],
+		[], [200, 50, 99999999], 640, 0.6,
+	])
+	var offs: Array = bridge._sequence_capture_offsets.duplicate()
+	_check("offsets sorted ascending (first)", offs[0], 50)
+	_check("offsets sorted ascending (second)", offs[1], 200)
+	_check("offset clamped to SEQUENCE_MAX_CAPTURE_OFFSET_MS", offs[2], 60000)
+
+	# --- 2. cap at SEQUENCE_MAX_CAPTURES ------------------------------------
+	bridge._handle_execute_input_sequence([
+		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 5}],
+		[], [30, 10, 10, 5, 40, 20, 50, 60, 70, 80], 640, 0.6,
+	])
+	_check("capture offsets capped at 8", bridge._sequence_capture_offsets.size(), 8)
+
+	# --- 3. finish gating: the result is held while captures are pending ----
+	# Two short capture offsets. Capture resolves on RenderingServer.frame_post_draw,
+	# which does not fire under `--headless` (no draw), so the captures stay pending
+	# here — which is precisely what proves the gate: the sequence must NOT finish
+	# while a frame is still owed. (Resolution + finish is covered by live testing
+	# on a rendering game.)
+	bridge._handle_execute_input_sequence([
+		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 5}],
+		[], [10, 25], 640, 0.6,
+	])
+	_check("capture sequence started", bridge._sequence_running, true)
+
+	await create_timer(0.1).timeout
+	for i in 10:
+		await process_frame
+
+	_check("both capture offsets were triggered", bridge._sequence_capture_offsets.is_empty(), true)
+	_check("captures incremented the pending count", bridge._sequence_captures_pending, 2)
+	_check("sequence correctly HELD open while a frame is still pending", bridge._sequence_running, true)
+	_check("the tap registered and released (not latched)", Input.is_action_pressed(ACTION), false)
+
+	root.remove_child(bridge)
+	bridge.free()
+	if InputMap.has_action(ACTION):
+		InputMap.erase_action(ACTION)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/input_sequence_capture_test.gd
+++ b/godot/addons/godot_mcp/test/input_sequence_capture_test.gd
@@ -49,7 +49,7 @@ func _run() -> void:
 	var offs: Array = bridge._sequence_capture_offsets.duplicate()
 	_check("offsets sorted ascending (first)", offs[0], 50)
 	_check("offsets sorted ascending (second)", offs[1], 200)
-	_check("offset clamped to SEQUENCE_MAX_CAPTURE_OFFSET_MS", offs[2], 60000)
+	_check("offset clamped to SEQUENCE_MAX_CAPTURE_OFFSET_MS", offs[2], 20000)
 
 	# --- 2. cap at SEQUENCE_MAX_CAPTURES ------------------------------------
 	bridge._handle_execute_input_sequence([

--- a/godot/addons/godot_mcp/test/input_sequence_capture_test.gd.uid
+++ b/godot/addons/godot_mcp/test/input_sequence_capture_test.gd.uid
@@ -1,0 +1,1 @@
+uid://ccphaodh2q0bm

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -50,6 +50,27 @@ describe('input tool', () => {
         report: [1, 2],
       }).success).toBe(false);
     });
+
+    it('accepts screenshot_at_ms offsets (max 8, non-negative ints)', () => {
+      expect(input.schema.safeParse({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire' }],
+        screenshot_at_ms: [0, 100, 300],
+        screenshot_max_width: 480,
+      }).success).toBe(true);
+      // more than 8 offsets is rejected
+      expect(input.schema.safeParse({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire' }],
+        screenshot_at_ms: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      }).success).toBe(false);
+      // negative offsets are rejected
+      expect(input.schema.safeParse({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire' }],
+        screenshot_at_ms: [-1],
+      }).success).toBe(false);
+    });
   });
 
   describe('get_map', () => {
@@ -194,6 +215,65 @@ describe('input tool', () => {
 
       expect(result).toContain('PAUSED');
       expect(result).toContain('gameplay 0ms / wall 2000ms');
+    });
+
+    it('returns a multi-content result (summary + image blocks) when frames are captured', async () => {
+      mock.mockResponse({
+        completed: true,
+        actions_executed: 1,
+        scene: 'res://arena.tscn',
+        gameplay_ms: 320,
+        wall_ms: 322,
+        captures: [
+          { requested_ms: 50, actual_ms: 52, ok: true, image_base64: 'AAAA', width: 640, height: 360, error: '' },
+          { requested_ms: 200, actual_ms: 205, ok: true, image_base64: 'BBBB', width: 640, height: 360, error: '' },
+        ],
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 300 }],
+        screenshot_at_ms: [50, 200],
+      }, ctx);
+
+      expect(mock.calls[0].params.screenshot_at_ms).toEqual([50, 200]);
+      expect(Array.isArray(result)).toBe(true);
+      const blocks = result as Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+      // [summary, label, image, label, image]
+      expect(blocks).toHaveLength(5);
+      expect(blocks[0].type).toBe('text');
+      expect(blocks[0].text).toContain('Captured 2/2 frame(s)');
+      expect(blocks[2]).toEqual({ type: 'image', data: 'AAAA', mimeType: 'image/png' });
+      expect(blocks[4]).toEqual({ type: 'image', data: 'BBBB', mimeType: 'image/png' });
+      expect(blocks[1].text).toContain('@52ms (requested 50ms)');
+    });
+
+    it('renders a failed capture as a note, not an image block', async () => {
+      mock.mockResponse({
+        completed: true,
+        actions_executed: 1,
+        scene: 'res://arena.tscn',
+        captures: [
+          { requested_ms: 50, actual_ms: 51, ok: true, image_base64: 'AAAA', width: 640, height: 360, error: '' },
+          { requested_ms: 200, actual_ms: 0, ok: false, image_base64: '', width: 0, height: 0, error: 'CAPTURE_FAILED: could not read viewport image' },
+        ],
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 300 }],
+        screenshot_at_ms: [50, 200],
+      }, ctx);
+
+      expect(Array.isArray(result)).toBe(true);
+      const blocks = result as Array<{ type: string; text?: string }>;
+      // [summary, label, image, failure-note] — only one image
+      expect(blocks.filter((b) => b.type === 'image')).toHaveLength(1);
+      const noteBlock = blocks.find((b) => b.type === 'text' && b.text?.includes('capture failed'));
+      expect(noteBlock?.text).toContain('CAPTURE_FAILED');
+      expect((blocks[0].text)).toContain('Captured 1/2 frame(s)');
     });
   });
 

--- a/server/src/core/types.ts
+++ b/server/src/core/types.ts
@@ -17,7 +17,12 @@ export interface StructuredToolResult {
   structuredContent: Record<string, unknown>;
 }
 
-export type ToolExecuteResult = string | ToolResult | StructuredToolResult;
+// An ordered list of content blocks returned as the MCP result's `content`
+// array, for a single call that yields several observations at once — e.g. a
+// text summary followed by several captured frames (godot_input sequence).
+export type MultiContentResult = ToolResult[];
+
+export type ToolExecuteResult = string | ToolResult | MultiContentResult | StructuredToolResult;
 
 // MCP tool annotations: advisory hints clients use to label tools and decide
 // auto-approval. See the MCP spec's ToolAnnotations.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -51,6 +51,13 @@ export async function main() {
           content: [{ type: 'text', text: result }],
         };
       }
+      // An array is a multi-content result (text + image blocks in order) —
+      // checked before isStructuredResult since arrays are objects too.
+      if (Array.isArray(result)) {
+        return {
+          content: result,
+        };
+      }
       if (isStructuredResult(result)) {
         return {
           content: [{ type: 'text', text: result.text }],

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
-import type { AnyToolDefinition } from '../core/types.js';
+import type { AnyToolDefinition, ToolResult } from '../core/types.js';
 
 export const InputActionSchema = z.object({
   action_name: z.string().describe('The input action name from the project Input Map'),
@@ -31,6 +31,32 @@ const InputSchema = z.discriminatedUnion('action', [
         'Expressions do NOT short-circuit and a parse/eval error rejects the call. The after-reading ' +
         'is sampled a couple frames past the final input, so only near-immediate effects register — ' +
         'for slower effects use godot_game_time or runtime_state watch.'
+      ),
+    screenshot_at_ms: z
+      .array(z.number().int().min(0))
+      .max(8)
+      .optional()
+      .describe(
+        'Optional: millisecond offsets (from sequence start) at which to capture a lossless PNG ' +
+        'frame DURING the real-time run. The bridge owns the sequence clock, so it grabs each frame ' +
+        'at the right moment and returns them with the result — letting you catch transient visuals ' +
+        '(muzzle flashes, explosions, kill banners) that fade long before a separate screenshot ' +
+        'call could land. Up to 8 frames, each returned as an image labeled with its actual offset. ' +
+        'COST: each frame costs vision tokens by RESOLUTION (~width*height/750), independent of ' +
+        'format, and persists in context on every following turn — so prefer a few frames at a ' +
+        'modest screenshot_max_width over many large ones. For frozen/precise inspection prefer ' +
+        'godot_game_time step + screenshot_game instead.'
+      ),
+    screenshot_max_width: z
+      .number()
+      .int()
+      .min(16)
+      .max(1920)
+      .optional()
+      .describe(
+        'Max width in px for captured frames (default 640). Resolution is the real vision-token ' +
+        'lever (cost ~width*height/750 per frame); lower it to spend less context, raise it only ' +
+        'when fine detail matters.'
       ),
   }),
   z.object({
@@ -99,8 +125,22 @@ export const input = defineTool({
           wall_ms?: number;
           report?: Record<string, { before: unknown; after: unknown; changed: boolean }>;
           any_changed?: boolean;
+          captures?: Array<{
+            requested_ms: number;
+            actual_ms: number;
+            ok: boolean;
+            image_base64: string;
+            width: number;
+            height: number;
+            error: string;
+          }>;
           error?: string;
-        }>('execute_input_sequence', { inputs, report: args.report });
+        }>('execute_input_sequence', {
+          inputs,
+          report: args.report,
+          screenshot_at_ms: args.screenshot_at_ms,
+          screenshot_max_width: args.screenshot_max_width,
+        });
 
         if (result.error) {
           throw new Error(result.error);
@@ -145,7 +185,30 @@ export const input = defineTool({
           }
         }
 
-        return lines.join('\n');
+        // Mid-sequence frame captures (#239): if none were requested, keep the
+        // plain-text result; otherwise return a summary plus one labeled image
+        // block per captured frame (a failed capture becomes a note, not an image).
+        if (!result.captures || result.captures.length === 0) {
+          return lines.join('\n');
+        }
+
+        const ok = result.captures.filter((c) => c.ok);
+        lines.push(
+          `Captured ${ok.length}/${result.captures.length} frame(s) at offsets ` +
+          `[${result.captures.map((c) => c.actual_ms).join(', ')}]ms ` +
+          `(requested [${result.captures.map((c) => c.requested_ms).join(', ')}]ms).`
+        );
+
+        const content: ToolResult[] = [{ type: 'text', text: lines.join('\n') }];
+        for (const c of result.captures) {
+          if (c.ok && c.image_base64) {
+            content.push({ type: 'text', text: `Frame @${c.actual_ms}ms (requested ${c.requested_ms}ms), ${c.width}x${c.height}:` });
+            content.push({ type: 'image', data: c.image_base64, mimeType: 'image/png' });
+          } else {
+            content.push({ type: 'text', text: `Frame @${c.requested_ms}ms: capture failed (${c.error || 'unknown error'}).` });
+          }
+        }
+        return content;
       }
 
       case 'type_text': {


### PR DESCRIPTION
## Problem (#239)

`godot_input` `sequence` blocked until completion and returned only an action count; screenshots were separate, *later* calls. In an action game the interesting frames — muzzle flashes, explosions, kill banners — fade in well under a second, long before an agent's next call lands (10-40s later). Catching one was luck-based, and the field-session workaround was building an autofire bot into the game itself just so combat was always on screen.

This is the real-time complement to `godot_game_time` freeze/step: when you *don't* want to freeze (testing real-time behavior, physics, animation at true speed), you can still correlate action with observation in a single call.

## What this adds

`sequence` gains **`screenshot_at_ms`**: a list of millisecond offsets (from sequence start) at which the bridge — which owns the sequence clock — captures a frame *during* the real-time run and streams each back on its own message. The tool returns a text summary plus one labeled image per offset (each tagged with its *actual* captured offset), so action and observation are correlated in one round-trip. Up to 8 frames; `screenshot_max_width` (default 640) bounds cost.

It composes with #240's `report` — a single call can drive input, prove an effect, and capture the frames that show it.

## Design notes

- **Lossless PNG, not JPEG.** Image vision-token cost scales with *resolution* (~`width*height/750`), not codec — so JPEG only traded fidelity (compression artifacts) for zero token saving. The cost lever is `screenshot_max_width` (resolution), documented as such; persistence across turns is the real budget concern, so the default resolution is modest and frames are capped at 8.
- **Each frame on its own message**, so no single oversized debugger payload; the count of in-flight captures gates the result, so the sequence does not report complete until every requested frame is in (a failed capture still releases its slot).
- **Captures resolve on `frame_post_draw`**, which needs a rendering context (same constraint as `screenshot_game`); for frozen/precise inspection, prefer `godot_game_time` step + `screenshot_game`.
- Adds a small framework primitive: a multi-content tool result (`ToolResult[]`) so one call can return text plus several image blocks. Additive — existing single-result tools are unchanged.

## Validation

- **260/260 server tests** — added `screenshot_at_ms` schema, multi-content assembly, and failed-capture-as-note cases.
- **New headless guard** (`input_sequence_capture_test.gd`, 9/9): offset normalization (clamp/cap/sort) and the finish-gating — the sequence is correctly held open while a frame is still pending (captures resolve on a draw the headless renderer doesn't provide, which is exactly what proves the gate). No regression in the #240 (15/15) or stuck-held (5/5) guards.
- **Live on a running game (run-n-gun):** fired a 500ms burst with `screenshot_at_ms: [0, 80, 200, 400]` → result was a summary plus **four PNG frames** captured at actual [14, 110, 224, 420]ms, showing the firing glow evolve across the burst; composed with `report` (`G.shots: 0 -> 4`).

Closes #239