### PR TITLE
feat: emit screenshots as lossless PNG instead of JPEG

### DIFF
--- a/godot/addons/godot_mcp/commands/screenshot_commands.gd
+++ b/godot/addons/godot_mcp/commands/screenshot_commands.gd
@@ -3,7 +3,6 @@ extends MCPBaseCommand
 class_name MCPScreenshotCommands
 
 const DEFAULT_MAX_WIDTH := 900
-const DEFAULT_JPEG_QUALITY := 75
 const SCREENSHOT_TIMEOUT := 5.0
 
 var _screenshot_result: Dictionary = {}
@@ -22,7 +21,6 @@ func capture_game_screenshot(params: Dictionary) -> Dictionary:
 		return _error("NOT_RUNNING", "No game is currently running. Use run_project first.")
 
 	var max_width: int = params.get("max_width", DEFAULT_MAX_WIDTH)
-	var quality: float = params.get("quality", DEFAULT_JPEG_QUALITY) / 100.0
 
 	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
 	if debugger_plugin == null:
@@ -35,7 +33,7 @@ func capture_game_screenshot(params: Dictionary) -> Dictionary:
 	_screenshot_result = {}
 
 	debugger_plugin.screenshot_received.connect(_on_screenshot_received, CONNECT_ONE_SHOT)
-	debugger_plugin.request_screenshot(max_width, quality)
+	debugger_plugin.request_screenshot(max_width)
 
 	var start_time := Time.get_ticks_msec()
 	while _screenshot_pending:
@@ -64,7 +62,6 @@ func _on_screenshot_received(success: bool, image_base64: String, width: int, he
 func capture_editor_screenshot(params: Dictionary) -> Dictionary:
 	var viewport_type: String = params.get("viewport", "")
 	var max_width: int = params.get("max_width", DEFAULT_MAX_WIDTH)
-	var quality: float = params.get("quality", DEFAULT_JPEG_QUALITY) / 100.0
 
 	var viewport: SubViewport = null
 
@@ -80,10 +77,12 @@ func capture_editor_screenshot(params: Dictionary) -> Dictionary:
 		return _error("NO_VIEWPORT", "Could not find editor viewport")
 
 	var image := viewport.get_texture().get_image()
-	return _process_and_encode_image(image, max_width, quality)
+	return _process_and_encode_image(image, max_width)
 
 
-func _process_and_encode_image(image: Image, max_width: int, quality: float = 0.75) -> Dictionary:
+# Lossless PNG, not JPEG: vision-token cost is set by resolution, not codec, so
+# JPEG only added compression artifacts. max_width bounds the resolution cost.
+func _process_and_encode_image(image: Image, max_width: int) -> Dictionary:
 	if image == null:
 		return _error("CAPTURE_FAILED", "Failed to capture image from viewport")
 
@@ -92,8 +91,8 @@ func _process_and_encode_image(image: Image, max_width: int, quality: float = 0.
 		var new_height := int(image.get_height() * scale_factor)
 		image.resize(max_width, new_height, Image.INTERPOLATE_LANCZOS)
 
-	var jpg_buffer := image.save_jpg_to_buffer(quality)
-	var base64 := Marshalls.raw_to_base64(jpg_buffer)
+	var png_buffer := image.save_png_to_buffer()
+	var base64 := Marshalls.raw_to_base64(png_buffer)
 
 	return _success({
 		"image_base64": base64,

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -124,14 +124,14 @@ func is_bridge_ready() -> bool:
 	return _bridge_ready and has_active_session()
 
 
-func request_screenshot(max_width: int = 1024, quality: float = 0.75) -> void:
+func request_screenshot(max_width: int = 1024) -> void:
 	if _active_session_id < 0:
 		screenshot_received.emit(false, "", 0, 0, "No active game session")
 		return
 	_pending_screenshot = true
 	var session := get_session(_active_session_id)
 	if session:
-		session.send_message("godot_mcp:take_screenshot", [max_width, quality])
+		session.send_message("godot_mcp:take_screenshot", [max_width])
 	else:
 		_pending_screenshot = false
 		screenshot_received.emit(false, "", 0, 0, "Could not get debugger session")

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -2,7 +2,6 @@ extends Node
 class_name MCPGameBridge
 
 const DEFAULT_MAX_WIDTH := 1024
-const DEFAULT_JPEG_QUALITY := 0.75
 const Onscreen := preload("onscreen.gd")
 
 # Cap on frames waited for the main scene to appear before announcing ready
@@ -311,12 +310,14 @@ func _on_debugger_message(message: String, data: Array) -> bool:
 
 func _take_screenshot_deferred(data: Array) -> void:
 	var max_width: int = data[0] if data.size() > 0 else DEFAULT_MAX_WIDTH
-	var quality: float = data[1] if data.size() > 1 else DEFAULT_JPEG_QUALITY
 	await RenderingServer.frame_post_draw
-	_capture_and_send_screenshot(max_width, quality)
+	_capture_and_send_screenshot(max_width)
 
 
-func _capture_and_send_screenshot(max_width: int, quality: float = DEFAULT_JPEG_QUALITY) -> void:
+# Lossless PNG, not JPEG: image vision-token cost scales with resolution, not
+# codec, so JPEG only traded fidelity (compression artifacts) for nothing. Width
+# is downscaled to max_width to bound that resolution-driven cost.
+func _capture_and_send_screenshot(max_width: int) -> void:
 	var viewport := get_viewport()
 	if viewport == null:
 		_send_screenshot_error("NO_VIEWPORT", "Could not get game viewport")
@@ -329,8 +330,8 @@ func _capture_and_send_screenshot(max_width: int, quality: float = DEFAULT_JPEG_
 		var scale_factor := float(max_width) / float(image.get_width())
 		var new_height := int(image.get_height() * scale_factor)
 		image.resize(max_width, new_height, Image.INTERPOLATE_LANCZOS)
-	var jpg_buffer := image.save_jpg_to_buffer(quality)
-	var base64 := Marshalls.raw_to_base64(jpg_buffer)
+	var png_buffer := image.save_png_to_buffer()
+	var base64 := Marshalls.raw_to_base64(png_buffer)
 	EngineDebugger.send_message("godot_mcp:screenshot_result", [
 		true,
 		base64,

--- a/server/src/__tests__/tools/editor.test.ts
+++ b/server/src/__tests__/tools/editor.test.ts
@@ -221,7 +221,7 @@ describe('editor tool', () => {
       const ctx = createToolContext(mock);
 
       const result = await editor.execute({ action: 'screenshot_game' }, ctx);
-      expect(result).toEqual({ type: 'image', data: base64, mimeType: 'image/jpeg' });
+      expect(result).toEqual({ type: 'image', data: base64, mimeType: 'image/png' });
     });
 
     it('passes viewport and max_width params for editor screenshot', async () => {

--- a/server/src/tools/editor.ts
+++ b/server/src/tools/editor.ts
@@ -30,7 +30,7 @@ function toImageContent(base64: string): ImageContent {
   return {
     type: 'image',
     data: base64,
-    mimeType: 'image/jpeg',
+    mimeType: 'image/png',
   };
 }
 
@@ -83,15 +83,13 @@ const EditorSchema = z
     }),
     z.object({ action: z.literal('get_stack_trace').describe('Get the most recent error stack trace') }),
     z.object({
-      action: z.literal('screenshot_game').describe('Capture a JPEG screenshot of the running game'),
-      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 900)'),
-      quality: z.number().int().min(1).max(100).optional().describe('JPEG quality 1-100 (default: 75)'),
+      action: z.literal('screenshot_game').describe('Capture a lossless PNG screenshot of the running game'),
+      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 900). Resolution is the vision-token cost lever (~width*height/750); lower it to spend less context.'),
     }),
     z.object({
-      action: z.literal('screenshot_editor').describe('Capture a JPEG screenshot of an editor viewport'),
+      action: z.literal('screenshot_editor').describe('Capture a lossless PNG screenshot of an editor viewport'),
       viewport: z.enum(['2d', '3d']).optional().describe('Which editor viewport to capture'),
-      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 900)'),
-      quality: z.number().int().min(1).max(100).optional().describe('JPEG quality 1-100 (default: 75)'),
+      max_width: z.number().int().optional().describe('Maximum width in pixels (default: 900). Resolution is the vision-token cost lever (~width*height/750); lower it to spend less context.'),
     }),
     z.object({
       action: z.literal('set_viewport_2d').describe('Center and zoom the 2D editor viewport'),
@@ -237,7 +235,7 @@ export const editor = defineTool({
       case 'screenshot_game': {
         const result = await godot.sendCommand<ScreenshotResponse>(
           'capture_game_screenshot',
-          { max_width: args.max_width, quality: args.quality }
+          { max_width: args.max_width }
         );
         return toImageContent(result.image_base64);
       }
@@ -245,7 +243,7 @@ export const editor = defineTool({
       case 'screenshot_editor': {
         const result = await godot.sendCommand<ScreenshotResponse>(
           'capture_editor_screenshot',
-          { viewport: args.viewport, max_width: args.max_width, quality: args.quality }
+          { viewport: args.viewport, max_width: args.max_width }
         );
         return toImageContent(result.image_base64);
       }


### PR DESCRIPTION
## Why

Image **vision-token cost scales with resolution** (~`width*height/750`), not with file size or codec. A JPEG at quality 75 and a lossless PNG of the same dimensions cost the **identical** number of tokens — JPEG only traded fidelity (compression artifacts) for smaller wire bytes, which don't affect the context budget (base64 is transport, counted as an image by resolution, not as text).

So JPEG bought nothing on cost and only added artifacts. PNG is strictly better here.

## What changes

- `godot_editor` `screenshot_game` and `screenshot_editor` now encode **lossless PNG** (`save_png_to_buffer`, `image/png`), across both the running-game bridge path (`_capture_and_send_screenshot`) and the editor-viewport path (`screenshot_commands.gd`).
- The now-meaningless **`quality` parameter is removed** from the `godot_editor` schema and the relay. `max_width` (resolution) remains the documented vision-token cost lever.

## Validation

- **257/257 server tests** — the screenshot result assertion now expects `image/png`; no test relied on `quality`.
- Bridge parses (headless guard 15/15); the running-game `screenshot_game` and editor `screenshot_editor` paths were exercised **live on run-n-gun** and returned clean PNGs with no `quality` argument.

Companion to #239 (mid-sequence capture), which already emits PNG frames — this aligns the existing single-screenshot tools to the same lossless format.