### PR TITLE
feat: derive per-request command timeouts from a single-source cascade

### DIFF
--- a/godot/addons/godot_mcp/commands/game_time_commands.gd
+++ b/godot/addons/godot_mcp/commands/game_time_commands.gd
@@ -4,10 +4,11 @@ class_name MCPGameTimeCommands
 
 # Game-time control relay: freeze / step / step_until / thaw / status execute in
 # the game bridge (see mcp_game_bridge.gd); this side only forwards over the
-# debugger channel and waits. Timeout cascade: a step/step_until request is
-# capped at 20s of game time and the bridge's wall budget returns by 25s, so the
-# 28s relay timeout below fires only if the bridge is gone — and stays under the
-# server's 30s command timeout so errors surface typed instead of generic.
+# debugger channel and waits. Timeout cascade (#276): the server derives the
+# whole stagger from the call's in-game budget and pushes relay_timeout_ms down
+# in params; we wait exactly that long, so the bridge (which returns by its
+# pushed wall budget) answers first and errors surface typed. BASE_TIMEOUT and
+# STEP_TIMEOUT are fallbacks only — for an older server that pushes no budget.
 const BASE_TIMEOUT := 10.0
 const STEP_TIMEOUT := 28.0
 
@@ -29,11 +30,11 @@ func game_time_freeze(params: Dictionary) -> Dictionary:
 
 
 func game_time_step(params: Dictionary) -> Dictionary:
-	return await _relay("game_time_step", [params], STEP_TIMEOUT)
+	return await _relay("game_time_step", [params], _relay_timeout(params, STEP_TIMEOUT))
 
 
 func game_time_step_until(params: Dictionary) -> Dictionary:
-	return await _relay("game_time_step_until", [params], STEP_TIMEOUT)
+	return await _relay("game_time_step_until", [params], _relay_timeout(params, STEP_TIMEOUT))
 
 
 func game_time_thaw(params: Dictionary) -> Dictionary:
@@ -42,6 +43,13 @@ func game_time_thaw(params: Dictionary) -> Dictionary:
 
 func game_time_status(params: Dictionary) -> Dictionary:
 	return await _relay("game_time_status", [params], BASE_TIMEOUT)
+
+
+func _relay_timeout(params: Dictionary, fallback: float) -> float:
+	# Use the server-pushed relay budget when present (#276); the local constant
+	# is only a fallback for an older server that does not derive the cascade.
+	var ms: float = float(params.get("relay_timeout_ms", fallback * 1000.0))
+	return ms / 1000.0
 
 
 func _relay(msg_type: String, args: Array, timeout: float) -> Dictionary:

--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -34,19 +34,30 @@ func get_commands() -> Dictionary:
 	}
 
 
+# Total wall budget for a long-running input command. The server derives the
+# whole cascade and pushes relay_timeout_ms down in params (#276); the local
+# fallback is used only for an older server that pushes no budget.
+func _pushed_budget(params: Dictionary, fallback: float) -> float:
+	if params.has("relay_timeout_ms"):
+		return float(params["relay_timeout_ms"]) / 1000.0
+	return fallback
+
+
 # Block until the running game's bridge reports it can consume input, bounded by
-# READY_TIMEOUT. Returns true once ready, false if the game stops or never comes
-# up in time. In the common case (game already running) this returns immediately
-# without waiting a frame. Gating input on this is the fix for #241: the debug
-# session connects before the main scene loads, so input dispatched on
-# has_active_session() alone lands in a game with nothing to receive it.
-func _await_bridge_ready(debugger_plugin) -> bool:
-	var start_time := Time.get_ticks_msec()
+# READY_TIMEOUT and the shared call deadline (op_start + total_budget) so the
+# ready-wait can never eat the budget the command itself needs (#276). Returns
+# true once ready, false if the game stops or never comes up in time. In the
+# common case (game already running) this returns immediately without waiting a
+# frame. Gating input on this is the fix for #241: the debug session connects
+# before the main scene loads, so input dispatched on has_active_session() alone
+# lands in a game with nothing to receive it.
+func _await_bridge_ready(debugger_plugin, op_start: int, total_budget: float) -> bool:
 	while not debugger_plugin.is_bridge_ready():
 		if not EditorInterface.is_playing_scene():
 			return false  # game stopped or crashed while we waited
 		await Engine.get_main_loop().process_frame
-		if (Time.get_ticks_msec() - start_time) / 1000.0 > READY_TIMEOUT:
+		var elapsed := (Time.get_ticks_msec() - op_start) / 1000.0
+		if elapsed > READY_TIMEOUT or elapsed > total_budget:
 			return false
 	return true
 
@@ -146,11 +157,12 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
 	if debugger_plugin == null:
 		return _error("NO_SESSION", "No active debug session")
-	if not await _await_bridge_ready(debugger_plugin):
-		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
-
-	# The window can extend past the last input if a frame capture is requested
-	# at a later offset, so factor capture offsets into the timeout too.
+	# One deadline for the whole call, stamped BEFORE the ready-wait so the
+	# bridge-ready gap is folded into the budget instead of stacking on top of
+	# it (#276). Prefer the server-pushed budget; the fallback (older server) is
+	# the longest input/capture offset plus headroom, floored at INPUT_TIMEOUT,
+	# plus the ready-wait that now counts against the same deadline.
+	var op_start := Time.get_ticks_msec()
 	var max_end_time: float = 0.0
 	for input in inputs:
 		var start_ms: float = input.get("start_ms", 0.0)
@@ -158,8 +170,11 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 		max_end_time = max(max_end_time, start_ms + duration_ms)
 	for shot_ms in screenshots:
 		max_end_time = max(max_end_time, float(shot_ms))
+	var fallback: float = max(INPUT_TIMEOUT, (max_end_time / 1000.0) + 5.0) + READY_TIMEOUT
+	var timeout := _pushed_budget(params, fallback)
 
-	var timeout := max(INPUT_TIMEOUT, (max_end_time / 1000.0) + 5.0)
+	if not await _await_bridge_ready(debugger_plugin, op_start, timeout):
+		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
 
 	_sequence_pending = true
 	_sequence_result = {}
@@ -171,10 +186,9 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 	debugger_plugin.input_sequence_completed.connect(_on_sequence_completed, CONNECT_ONE_SHOT)
 	debugger_plugin.request_input_sequence(inputs, report, screenshots, screenshot_max_width)
 
-	var start_time := Time.get_ticks_msec()
 	while _sequence_pending:
 		await Engine.get_main_loop().process_frame
-		if (Time.get_ticks_msec() - start_time) / 1000.0 > timeout:
+		if (Time.get_ticks_msec() - op_start) / 1000.0 > timeout:
 			_sequence_pending = false
 			if debugger_plugin.input_sequence_completed.is_connected(_on_sequence_completed):
 				debugger_plugin.input_sequence_completed.disconnect(_on_sequence_completed)
@@ -225,10 +239,14 @@ func type_text(params: Dictionary) -> Dictionary:
 	var debugger_plugin = _plugin.get_debugger_plugin() if _plugin else null
 	if debugger_plugin == null:
 		return _error("NO_SESSION", "No active debug session")
-	if not await _await_bridge_ready(debugger_plugin):
-		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
+	# Shared deadline (ready-wait + typing), stamped before the ready-wait so the
+	# gap is folded into the budget (#276); server-pushed budget or local fallback.
+	var op_start := Time.get_ticks_msec()
+	var fallback: float = max(INPUT_TIMEOUT, (text.length() * delay_ms / 1000.0) + 5.0) + READY_TIMEOUT
+	var timeout := _pushed_budget(params, fallback)
 
-	var timeout := max(INPUT_TIMEOUT, (text.length() * delay_ms / 1000.0) + 5.0)
+	if not await _await_bridge_ready(debugger_plugin, op_start, timeout):
+		return _error("BRIDGE_NOT_READY", _BRIDGE_NOT_READY_MSG)
 
 	_type_text_pending = true
 	_type_text_result = {}
@@ -236,10 +254,9 @@ func type_text(params: Dictionary) -> Dictionary:
 	debugger_plugin.type_text_completed.connect(_on_type_text_completed, CONNECT_ONE_SHOT)
 	debugger_plugin.request_type_text(text, delay_ms, submit)
 
-	var start_time := Time.get_ticks_msec()
 	while _type_text_pending:
 		await Engine.get_main_loop().process_frame
-		if (Time.get_ticks_msec() - start_time) / 1000.0 > timeout:
+		if (Time.get_ticks_msec() - op_start) / 1000.0 > timeout:
 			_type_text_pending = false
 			if debugger_plugin.type_text_completed.is_connected(_on_type_text_completed):
 				debugger_plugin.type_text_completed.disconnect(_on_type_text_completed)

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -283,11 +283,13 @@ var _sequence_capture_offsets: Array = []
 var _sequence_captures_pending: int = 0
 var _sequence_capture_max_width: int = 640
 const SEQUENCE_MAX_CAPTURES := 8
-# Capped well under the 30s server command timeout: the sequence runs until its
-# last capture offset, so a larger value would let the whole call time out
-# server-side. 20s is already far longer than any transient-visual capture needs.
-# This bound is a placeholder for the global-timeout fix tracked in godot-mcp#276.
-const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 20000
+# Non-binding sanity backstop only (#276). The server derives the per-call
+# timeout from the sequence span and rejects offsets beyond what the ceiling
+# permits before they ever reach here, so this just guards a malformed direct
+# message. Kept far above any server-permitted budget so it never silently
+# clamps a legitimate offset (which would reintroduce the cross-layer drift
+# that #276 removed).
+const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 300000
 # Actions whose press has been injected but whose paired release has not yet
 # fired. Used to guarantee a release even if the queue is cleared mid-flight
 # (new sequence) or the node leaves the tree — otherwise the dropped release
@@ -1332,10 +1334,15 @@ func _type_text_async(text: String, delay_ms: int, submit: bool) -> void:
 # ---------------------------------------------------------------------------
 
 const LAUNCH_FROZEN_ENV := "GODOT_MCP_LAUNCH_FROZEN"
-# Timeout cascade: step request <= 20s game time, wall budget 25s, editor
-# relay 28s, server command timeout 30s. Each layer answers before the one
-# above it gives up.
-const STEP_MAX_MS := 20000
+# Timeout cascade (#276): the server derives the whole stagger from the call's
+# in-game budget and pushes wall_budget_ms down here. The bridge returns by that
+# wall budget, the editor relay waits a margin longer, the server socket a
+# margin longer still — each answers before the one above gives up.
+#   STEP_MAX_MS         non-binding sanity backstop (the server already clamps the request)
+#   STEP_DEFAULT_MS     budget used when a call omits max_ms (older server that sends no default)
+#   STEP_WALL_BUDGET_MS wall-budget fallback when the server pushes no wall_budget_ms
+const STEP_MAX_MS := 300000
+const STEP_DEFAULT_MS := 20000
 const STEP_MAX_FRAMES := 1200
 const STEP_WALL_BUDGET_MS := 25000
 const STEP_MAX_TRANSITIONS := 50
@@ -1358,6 +1365,7 @@ var _step_gameplay_ms := 0.0  # the unpaused portion: what gameplay actually exp
 var _step_frames := 0
 var _step_physics_ticks := 0
 var _step_wall_start := 0
+var _step_wall_budget_ms := STEP_WALL_BUDGET_MS  # set per-call from the server-pushed wall_budget_ms (#276)
 var _step_events: Array = []  # in-step input timeline, scheduled on the game-time clock
 var _step_events_fired := 0
 var _step_transitions: Array = []
@@ -1515,6 +1523,7 @@ func _handle_game_time_step(data: Array) -> void:
 	_step_finish_pending = false
 	_step_wall_exceeded = false
 	_step_wall_start = Time.get_ticks_msec()
+	_step_wall_budget_ms = int(params.get("wall_budget_ms", STEP_WALL_BUDGET_MS))
 	_step_predicate = null
 	_step_response_type = "game_time_step"
 	_step_active = true
@@ -1631,9 +1640,9 @@ func _handle_game_time_step_until(data: Array) -> void:
 		_send_game_time_response("game_time_step_until", {"error": "step_until requires a non-empty `until` expression"})
 		return
 
-	var max_ms: int = int(params.get("max_ms", STEP_MAX_MS))
+	var max_ms: int = int(params.get("max_ms", STEP_DEFAULT_MS))
 	if max_ms <= 0:
-		max_ms = STEP_MAX_MS
+		max_ms = STEP_DEFAULT_MS
 	max_ms = mini(max_ms, STEP_MAX_MS)
 
 	# Compile and validate the predicate against the live tree before committing
@@ -1696,6 +1705,7 @@ func _handle_game_time_step_until(data: Array) -> void:
 	_step_finish_pending = false
 	_step_wall_exceeded = false
 	_step_wall_start = Time.get_ticks_msec()
+	_step_wall_budget_ms = int(params.get("wall_budget_ms", STEP_WALL_BUDGET_MS))
 	_step_predicate = expr
 	_step_predicate_inputs = ctx_inputs
 	_step_predicate_met = false
@@ -1767,7 +1777,7 @@ func _step_process(delta: float) -> void:
 			_step_predicate_met = true
 			done = true
 
-	if Time.get_ticks_msec() - _step_wall_start > STEP_WALL_BUDGET_MS:
+	if Time.get_ticks_msec() - _step_wall_start > _step_wall_budget_ms:
 		# Slow-mo, Engine.time_scale = 0, or a pause-held window can starve
 		# the game-time clock; the wall budget guarantees the call returns
 		# (partial, honestly reported) before the editor relay gives up.

--- a/godot/addons/godot_mcp/test/input_sequence_capture_test.gd
+++ b/godot/addons/godot_mcp/test/input_sequence_capture_test.gd
@@ -49,7 +49,9 @@ func _run() -> void:
 	var offs: Array = bridge._sequence_capture_offsets.duplicate()
 	_check("offsets sorted ascending (first)", offs[0], 50)
 	_check("offsets sorted ascending (second)", offs[1], 200)
-	_check("offset clamped to SEQUENCE_MAX_CAPTURE_OFFSET_MS", offs[2], 20000)
+	# SEQUENCE_MAX_CAPTURE_OFFSET_MS is now a non-binding sanity backstop (#276):
+	# the server clamps the real budget, so this only catches a malformed message.
+	_check("offset clamped to SEQUENCE_MAX_CAPTURE_OFFSET_MS backstop", offs[2], 300000)
 
 	# --- 2. cap at SEQUENCE_MAX_CAPTURES ------------------------------------
 	bridge._handle_execute_input_sequence([

--- a/server/src/__tests__/connection/timeouts.test.ts
+++ b/server/src/__tests__/connection/timeouts.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveTimeouts,
+  maxInGameBudgetMs,
+  QUICK_TIMEOUT_MS,
+  ABSOLUTE_CEILING_MS,
+  READY_WAIT_MS,
+  BRIDGE_WALL_SLOP_MS,
+  STEP_BUDGET_CAP_MS,
+  SEQUENCE_BUDGET_CAP_MS,
+} from '../../connection/timeouts.js';
+
+describe('timeout cascade (#276)', () => {
+  describe('deriveTimeouts stagger invariant', () => {
+    // The whole point: bridge answers before relay answers before the server
+    // gives up, and the server never exceeds the absolute ceiling — for ANY
+    // budget, clamped or not, with or without the ready-wait.
+    const cases = [
+      { label: 'zero budget, no ready', budget: 0, readyWait: false },
+      { label: 'mid budget, no ready', budget: 5_000, readyWait: false },
+      { label: 'at step cap', budget: STEP_BUDGET_CAP_MS, readyWait: false },
+      { label: 'over cap, no ready', budget: 10_000_000, readyWait: false },
+      { label: 'zero budget, ready', budget: 0, readyWait: true },
+      { label: 'at sequence cap', budget: SEQUENCE_BUDGET_CAP_MS, readyWait: true },
+      { label: 'over cap, ready', budget: 999_999, readyWait: true },
+    ];
+
+    for (const c of cases) {
+      it(`${c.label}: bridgeWall < relay < server <= ceiling`, () => {
+        const t = deriveTimeouts(c.budget, { readyWait: c.readyWait });
+        expect(t.bridgeWallMs).toBeLessThan(t.relayMs);
+        expect(t.relayMs).toBeLessThan(t.serverMs);
+        expect(t.serverMs).toBeLessThanOrEqual(ABSOLUTE_CEILING_MS);
+        expect(t.clampedBudgetMs).toBeGreaterThanOrEqual(0);
+        expect(t.clampedBudgetMs).toBeLessThanOrEqual(maxInGameBudgetMs({ readyWait: c.readyWait }));
+      });
+    }
+  });
+
+  it('produces a proportionally small (sub-ceiling) timeout for a small budget', () => {
+    const t = deriveTimeouts(3_000, { readyWait: false });
+    // bridgeWall = 3000 + slop; relay = +2000; server = +2000.
+    expect(t.bridgeWallMs).toBe(3_000 + BRIDGE_WALL_SLOP_MS);
+    expect(t.serverMs).toBeLessThan(ABSOLUTE_CEILING_MS);
+  });
+
+  it('reserves an extra READY_WAIT_MS of headroom when the ready-wait applies', () => {
+    expect(maxInGameBudgetMs({ readyWait: false }) - maxInGameBudgetMs({ readyWait: true })).toBe(READY_WAIT_MS);
+  });
+
+  it('clamps an over-budget request to the ceiling, never beyond', () => {
+    expect(deriveTimeouts(Number.MAX_SAFE_INTEGER, { readyWait: true }).serverMs).toBe(ABSOLUTE_CEILING_MS);
+    expect(deriveTimeouts(Number.MAX_SAFE_INTEGER, { readyWait: false }).serverMs).toBe(ABSOLUTE_CEILING_MS);
+  });
+
+  it('handles a non-finite budget defensively (treats it as zero)', () => {
+    const t = deriveTimeouts(NaN, { readyWait: false });
+    expect(t.clampedBudgetMs).toBe(0);
+    expect(t.serverMs).toBeGreaterThan(0);
+  });
+
+  describe('published caps stay under the ceiling so they can never time out server-side', () => {
+    it('step cap <= max in-game budget (no ready-wait)', () => {
+      expect(STEP_BUDGET_CAP_MS).toBeLessThanOrEqual(maxInGameBudgetMs({ readyWait: false }));
+    });
+    it('sequence cap <= max in-game budget (with ready-wait)', () => {
+      expect(SEQUENCE_BUDGET_CAP_MS).toBeLessThanOrEqual(maxInGameBudgetMs({ readyWait: true }));
+    });
+  });
+
+  it('keeps the quick default unchanged at 30s', () => {
+    expect(QUICK_TIMEOUT_MS).toBe(30_000);
+  });
+});

--- a/server/src/__tests__/connection/timeouts.test.ts
+++ b/server/src/__tests__/connection/timeouts.test.ts
@@ -7,7 +7,7 @@ import {
   READY_WAIT_MS,
   BRIDGE_WALL_SLOP_MS,
   STEP_BUDGET_CAP_MS,
-  SEQUENCE_BUDGET_CAP_MS,
+  INPUT_BUDGET_CAP_MS,
 } from '../../connection/timeouts.js';
 
 describe('timeout cascade (#276)', () => {
@@ -21,7 +21,7 @@ describe('timeout cascade (#276)', () => {
       { label: 'at step cap', budget: STEP_BUDGET_CAP_MS, readyWait: false },
       { label: 'over cap, no ready', budget: 10_000_000, readyWait: false },
       { label: 'zero budget, ready', budget: 0, readyWait: true },
-      { label: 'at sequence cap', budget: SEQUENCE_BUDGET_CAP_MS, readyWait: true },
+      { label: 'at input cap', budget: INPUT_BUDGET_CAP_MS, readyWait: true },
       { label: 'over cap, ready', budget: 999_999, readyWait: true },
     ];
 
@@ -63,8 +63,8 @@ describe('timeout cascade (#276)', () => {
     it('step cap <= max in-game budget (no ready-wait)', () => {
       expect(STEP_BUDGET_CAP_MS).toBeLessThanOrEqual(maxInGameBudgetMs({ readyWait: false }));
     });
-    it('sequence cap <= max in-game budget (with ready-wait)', () => {
-      expect(SEQUENCE_BUDGET_CAP_MS).toBeLessThanOrEqual(maxInGameBudgetMs({ readyWait: true }));
+    it('input cap <= max in-game budget (with ready-wait)', () => {
+      expect(INPUT_BUDGET_CAP_MS).toBeLessThanOrEqual(maxInGameBudgetMs({ readyWait: true }));
     });
   });
 

--- a/server/src/__tests__/connection/websocket.test.ts
+++ b/server/src/__tests__/connection/websocket.test.ts
@@ -3,6 +3,7 @@ import { once } from 'node:events';
 import type { AddressInfo } from 'node:net';
 import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
 import { GodotConnection } from '../../connection/websocket.js';
+import { getServerVersion } from '../../version.js';
 
 // Keep diagnostics hermetic (no WSL detection / no child processes) and quiet.
 vi.mock('../../utils/connection-strategy.js', () => ({
@@ -123,5 +124,69 @@ describe('GodotConnection contention handling (#237)', () => {
     const message = connection.getDiagnosticMessage();
     expect(message).not.toMatch(/no longer active/i);
     expect(message).toMatch(/reconnect/i);
+  });
+});
+
+describe('GodotConnection per-request timeout (#276)', () => {
+  let connection: GodotConnection | null = null;
+  let wss: WebSocketServer | null = null;
+
+  afterEach(async () => {
+    connection?.disconnect();
+    connection = null;
+    if (wss) {
+      await new Promise<void>((resolve) => wss!.close(() => resolve()));
+      wss = null;
+    }
+  });
+
+  // Reply to the handshake (so connect() resolves immediately and without a
+  // version-mismatch), then let the supplied handler deal with real commands.
+  async function bridgeAfterHandshake(
+    onCommand: (socket: WsSocket, msg: { id: string; command: string }) => void
+  ): Promise<{ wss: WebSocketServer; port: number }> {
+    return startFakeBridge((socket) => {
+      socket.on('message', (raw) => {
+        let msg: { id: string; command: string } | undefined;
+        try {
+          msg = JSON.parse(raw.toString());
+        } catch {
+          return;
+        }
+        if (!msg) return;
+        if (msg.command === 'mcp_handshake') {
+          socket.send(JSON.stringify({ id: msg.id, status: 'success', result: { addon_version: getServerVersion() } }));
+          return;
+        }
+        onCommand(socket, msg);
+      });
+    });
+  }
+
+  it('rejects after opts.timeoutMs when the bridge never answers the command', async () => {
+    // Drop every non-handshake command on the floor.
+    const bridge = await bridgeAfterHandshake(() => {});
+    wss = bridge.wss;
+    connection = new GodotConnection({ host: '127.0.0.1', port: bridge.port, autoReconnect: false });
+    await connection.connect();
+
+    const start = Date.now();
+    await expect(connection.sendCommand('get_runtime_state', {}, { timeoutMs: 150 })).rejects.toThrow();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(120);
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it('does not fire early when given a generous opts.timeoutMs', async () => {
+    // Answer the command after a short delay; a 1s budget must not trip on it.
+    const bridge = await bridgeAfterHandshake((socket, msg) => {
+      setTimeout(() => socket.send(JSON.stringify({ id: msg.id, status: 'success', result: { ok: true } })), 100);
+    });
+    wss = bridge.wss;
+    connection = new GodotConnection({ host: '127.0.0.1', port: bridge.port, autoReconnect: false });
+    await connection.connect();
+
+    const result = await connection.sendCommand<{ ok: boolean }>('get_runtime_state', {}, { timeoutMs: 1000 });
+    expect(result.ok).toBe(true);
   });
 });

--- a/server/src/__tests__/helpers/mock-godot.ts
+++ b/server/src/__tests__/helpers/mock-godot.ts
@@ -4,6 +4,7 @@ import type { GodotConnection } from '../../connection/websocket.js';
 export interface CommandCall {
   command: string;
   params: Record<string, unknown>;
+  opts?: { timeoutMs?: number };
 }
 
 export interface MockGodotConnection {
@@ -19,8 +20,8 @@ export function createMockGodot(): MockGodotConnection {
   let nextResponse: unknown = {};
   let nextError: Error | null = null;
 
-  const sendCommand = vi.fn(async (command: string, params: Record<string, unknown> = {}) => {
-    calls.push({ command, params });
+  const sendCommand = vi.fn(async (command: string, params: Record<string, unknown> = {}, opts?: { timeoutMs?: number }) => {
+    calls.push({ command, params, opts });
     if (nextError) {
       const err = nextError;
       nextError = null;

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createMockGodot, createToolContext, MockGodotConnection, structuredOf } from '../helpers/mock-godot.js';
 import { gameTime } from '../../tools/game-time.js';
+import { deriveTimeouts } from '../../connection/timeouts.js';
 
 describe('game_time tool', () => {
   let mock: MockGodotConnection;
@@ -137,10 +138,10 @@ describe('game_time tool', () => {
 
       await gameTime.execute({ action: 'step', duration_ms: 500 }, ctx);
       const call = mock.calls[0];
-      // budget 500 (no ready-wait) -> bridgeWall 5500, relay 7500, server 9500.
-      expect(call.params.wall_budget_ms).toBe(5500);
-      expect(call.params.relay_timeout_ms).toBe(7500);
-      expect(call.opts?.timeoutMs).toBe(9500);
+      const t = deriveTimeouts(500); // game_time has no ready-wait
+      expect(call.params.wall_budget_ms).toBe(t.bridgeWallMs);
+      expect(call.params.relay_timeout_ms).toBe(t.relayMs);
+      expect(call.opts?.timeoutMs).toBe(t.serverMs);
     });
   });
 
@@ -214,11 +215,25 @@ describe('game_time tool', () => {
 
       await gameTime.execute({ action: 'step_until', until: 'true', max_ms: 8000 }, ctx);
       const call = mock.calls[0];
-      // budget 8000 (no ready-wait) -> bridgeWall 13000, relay 15000, server 17000.
+      const t = deriveTimeouts(8000); // budget = explicit max_ms, no ready-wait
       expect(call.params.max_ms).toBe(8000);
-      expect(call.params.wall_budget_ms).toBe(13000);
-      expect(call.params.relay_timeout_ms).toBe(15000);
-      expect(call.opts?.timeoutMs).toBe(17000);
+      expect(call.params.wall_budget_ms).toBe(t.bridgeWallMs);
+      expect(call.params.relay_timeout_ms).toBe(t.relayMs);
+      expect(call.opts?.timeoutMs).toBe(t.serverMs);
+    });
+
+    it('defaults max_ms to a modest 20s, decoupled from the 50s cap, when omitted (#276)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 20000, gameplay_ms: 20000,
+        frames: 1200, physics_ticks: 1200, game_paused: false, predicate_met: false,
+      });
+      const ctx = createToolContext(mock);
+
+      await gameTime.execute({ action: 'step_until', until: 'false' }, ctx);
+      const call = mock.calls[0];
+      // Omitted max_ms must not inherit the 50s cap: a wrong predicate gives up in ~20s.
+      expect(call.params.max_ms).toBe(20000);
+      expect(call.opts?.timeoutMs).toBe(deriveTimeouts(20000).serverMs);
     });
   });
 

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -17,9 +17,9 @@ describe('game_time tool', () => {
       expect(gameTime.schema.safeParse({ action: 'step', frames: 1 }).success).toBe(true);
     });
 
-    it('step enforces the bridge-side caps', () => {
-      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 20000 }).success).toBe(true);
-      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 20001 }).success).toBe(false);
+    it('step enforces the published caps', () => {
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 50000 }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 50001 }).success).toBe(false);
       expect(gameTime.schema.safeParse({ action: 'step', frames: 1200 }).success).toBe(true);
       expect(gameTime.schema.safeParse({ action: 'step', frames: 1201 }).success).toBe(false);
       expect(gameTime.schema.safeParse({ action: 'step', duration_ms: 0 }).success).toBe(false);
@@ -40,8 +40,8 @@ describe('game_time tool', () => {
     });
 
     it('step_until caps max_ms and accepts report expressions and an input timeline', () => {
-      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 20000 }).success).toBe(true);
-      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 20001 }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 50000 }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 50001 }).success).toBe(false);
       expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 0 }).success).toBe(false);
       expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', report: ['G.wave', 'G.score'] }).success).toBe(true);
       expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', report: [''] }).success).toBe(false);
@@ -127,6 +127,21 @@ describe('game_time tool', () => {
       expect(data.game_paused).toBe(true);
       expect(data.gameplay_ms).toBe(120);
     });
+
+    it('derives the per-request timeout and pushes the relay/wall budgets to the bridge (#276)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,
+        frames: 30, physics_ticks: 30, game_paused: false,
+      });
+      const ctx = createToolContext(mock);
+
+      await gameTime.execute({ action: 'step', duration_ms: 500 }, ctx);
+      const call = mock.calls[0];
+      // budget 500 (no ready-wait) -> bridgeWall 5500, relay 7500, server 9500.
+      expect(call.params.wall_budget_ms).toBe(5500);
+      expect(call.params.relay_timeout_ms).toBe(7500);
+      expect(call.opts?.timeoutMs).toBe(9500);
+    });
   });
 
   describe('step_until', () => {
@@ -188,6 +203,22 @@ describe('game_time tool', () => {
       await expect(
         gameTime.execute({ action: 'step_until', until: 'Bogus.foo > 1' }, ctx),
       ).rejects.toThrow('predicate failed to evaluate');
+    });
+
+    it('sizes the timeout from max_ms and pushes the derived budgets (#276)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 0, gameplay_ms: 0,
+        frames: 0, physics_ticks: 0, game_paused: false, predicate_met: true,
+      });
+      const ctx = createToolContext(mock);
+
+      await gameTime.execute({ action: 'step_until', until: 'true', max_ms: 8000 }, ctx);
+      const call = mock.calls[0];
+      // budget 8000 (no ready-wait) -> bridgeWall 13000, relay 15000, server 17000.
+      expect(call.params.max_ms).toBe(8000);
+      expect(call.params.wall_budget_ms).toBe(13000);
+      expect(call.params.relay_timeout_ms).toBe(15000);
+      expect(call.opts?.timeoutMs).toBe(17000);
     });
   });
 

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createMockGodot, createToolContext, MockGodotConnection } from '../helpers/mock-godot.js';
 import { input } from '../../tools/input.js';
+import { deriveTimeouts, INPUT_BUDGET_CAP_MS } from '../../connection/timeouts.js';
 
 describe('input tool', () => {
   let mock: MockGodotConnection;
@@ -276,7 +277,7 @@ describe('input tool', () => {
       expect((blocks[0].text)).toContain('Captured 1/2 frame(s)');
     });
 
-    it('derives a ready-wait-inclusive timeout and pushes relay/wall budgets (#276)', async () => {
+    it('derives a ready-wait-inclusive timeout and pushes the relay budget (#276)', async () => {
       mock.mockResponse({ completed: true, actions_executed: 1 });
       const ctx = createToolContext(mock);
 
@@ -286,10 +287,11 @@ describe('input tool', () => {
       }, ctx);
 
       const call = mock.calls[0];
-      // span 300 + ready-wait -> bridgeWall 5300, relay 17300, server 19300.
-      expect(call.params.wall_budget_ms).toBe(5300);
-      expect(call.params.relay_timeout_ms).toBe(17300);
-      expect(call.opts?.timeoutMs).toBe(19300);
+      const t = deriveTimeouts(300, { readyWait: true }); // span 300 + folded ready-wait
+      expect(call.params.relay_timeout_ms).toBe(t.relayMs);
+      expect(call.opts?.timeoutMs).toBe(t.serverMs);
+      // wall_budget_ms is a step-only concept; the sequence path never reads it.
+      expect(call.params.wall_budget_ms).toBeUndefined();
     });
 
     it('factors a later capture offset into the timeout budget (#239 + #276)', async () => {
@@ -302,8 +304,8 @@ describe('input tool', () => {
         screenshot_at_ms: [8000],
       }, ctx);
 
-      // The 8000ms capture offset dominates the 100ms input span -> server 27000.
-      expect(mock.calls[0].opts?.timeoutMs).toBe(27000);
+      // The 8000ms capture offset dominates the 100ms input span.
+      expect(mock.calls[0].opts?.timeoutMs).toBe(deriveTimeouts(8000, { readyWait: true }).serverMs);
     });
 
     it('rejects a sequence whose span exceeds the single-call window, before touching the bridge', async () => {
@@ -311,7 +313,7 @@ describe('input tool', () => {
 
       await expect(input.execute({
         action: 'sequence',
-        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 45000 }],
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: INPUT_BUDGET_CAP_MS + 1 }],
       }, ctx)).rejects.toThrow(/single call can cover at most/);
       expect(mock.calls).toHaveLength(0);
     });
@@ -368,9 +370,9 @@ describe('input tool', () => {
 
       await input.execute({ action: 'type_text', text: 'Hello', delay_ms: 50, submit: false }, ctx);
 
-      // 5 chars * 50ms = 250 span + ready-wait -> relay 17250, server 19250.
-      expect(mock.calls[0].params.relay_timeout_ms).toBe(17250);
-      expect(mock.calls[0].opts?.timeoutMs).toBe(19250);
+      const t = deriveTimeouts(5 * 50, { readyWait: true }); // 5 chars * 50ms + folded ready-wait
+      expect(mock.calls[0].params.relay_timeout_ms).toBe(t.relayMs);
+      expect(mock.calls[0].opts?.timeoutMs).toBe(t.serverMs);
     });
   });
 });

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -275,6 +275,46 @@ describe('input tool', () => {
       expect(noteBlock?.text).toContain('CAPTURE_FAILED');
       expect((blocks[0].text)).toContain('Captured 1/2 frame(s)');
     });
+
+    it('derives a ready-wait-inclusive timeout and pushes relay/wall budgets (#276)', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1 });
+      const ctx = createToolContext(mock);
+
+      await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 300 }],
+      }, ctx);
+
+      const call = mock.calls[0];
+      // span 300 + ready-wait -> bridgeWall 5300, relay 17300, server 19300.
+      expect(call.params.wall_budget_ms).toBe(5300);
+      expect(call.params.relay_timeout_ms).toBe(17300);
+      expect(call.opts?.timeoutMs).toBe(19300);
+    });
+
+    it('factors a later capture offset into the timeout budget (#239 + #276)', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1 });
+      const ctx = createToolContext(mock);
+
+      await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 100 }],
+        screenshot_at_ms: [8000],
+      }, ctx);
+
+      // The 8000ms capture offset dominates the 100ms input span -> server 27000.
+      expect(mock.calls[0].opts?.timeoutMs).toBe(27000);
+    });
+
+    it('rejects a sequence whose span exceeds the single-call window, before touching the bridge', async () => {
+      const ctx = createToolContext(mock);
+
+      await expect(input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 45000 }],
+      }, ctx)).rejects.toThrow(/single call can cover at most/);
+      expect(mock.calls).toHaveLength(0);
+    });
   });
 
   describe('type_text', () => {
@@ -320,6 +360,17 @@ describe('input tool', () => {
         delay_ms: 50,
         submit: false,
       }, ctx)).rejects.toThrow('No focused element');
+    });
+
+    it('sizes the timeout from the typing duration and pushes the relay budget (#276)', async () => {
+      mock.mockResponse({ completed: true, chars_typed: 5, submitted: false });
+      const ctx = createToolContext(mock);
+
+      await input.execute({ action: 'type_text', text: 'Hello', delay_ms: 50, submit: false }, ctx);
+
+      // 5 chars * 50ms = 250 span + ready-wait -> relay 17250, server 19250.
+      expect(mock.calls[0].params.relay_timeout_ms).toBe(17250);
+      expect(mock.calls[0].opts?.timeoutMs).toBe(19250);
     });
   });
 });

--- a/server/src/connection/timeouts.ts
+++ b/server/src/connection/timeouts.ts
@@ -88,8 +88,10 @@ export function deriveTimeouts(inGameBudgetMs: number, opts: DeriveOptions = {})
   return { bridgeWallMs, relayMs, serverMs, clampedBudgetMs };
 }
 
-// Published per-tool caps (kept as clean round numbers for the schemas/UX). Each
-// must stay <= maxInGameBudgetMs for its readyWait class — asserted by a unit
-// test so they cannot silently exceed the ceiling if the margins above change.
-export const STEP_BUDGET_CAP_MS = 50_000;       // game_time step / step_until (no ready-wait)
-export const SEQUENCE_BUDGET_CAP_MS = 40_000;   // input sequence span / capture offsets (ready-wait)
+// Published per-tool-family caps — the clean round numbers the tools actually
+// enforce (game_time schema .max(), godot_input span/offset reject) and surface
+// to callers. Each sits at or below maxInGameBudgetMs for its readyWait class
+// (asserted by a unit test), leaving headroom under the ceiling so a request at
+// the published cap can never time out server-side.
+export const STEP_BUDGET_CAP_MS = 50_000;    // game_time step / step_until (no ready-wait)
+export const INPUT_BUDGET_CAP_MS = 40_000;   // godot_input sequence span / capture offsets / type_text duration (ready-wait)

--- a/server/src/connection/timeouts.ts
+++ b/server/src/connection/timeouts.ts
@@ -1,0 +1,95 @@
+// Single source of truth for the command-timeout cascade (#276).
+//
+// Most MCP commands answer in milliseconds and run under one fixed socket
+// timeout (QUICK_TIMEOUT_MS). A few legitimately run a while in-game
+// (game_time step/step_until, input sequences with long timelines or capture
+// offsets). For those, the server sizes its socket timeout from the tool's
+// declared in-game budget and pushes the derived sub-budgets DOWN into the
+// command params, so the editor relay and the game bridge stop hand-rolling
+// their own magic numbers and inherit a correct stagger automatically.
+//
+// The layers, innermost first — each must answer BEFORE the one above it gives
+// up, so a timeout surfaces as a typed error from the layer that hit it rather
+// than a generic socket kill that orphans work below:
+//
+//   in-game budget      game-ms a step advances / the span an input sequence covers
+//   bridge wall budget  = budget + slop (frame overrun, capture render)   [game bridge]
+//   editor relay wait   = ready-wait + bridge wall budget + relay margin  [editor addon]
+//   server socket       = editor relay wait + server margin               [this server]
+//
+// All values are wall-clock milliseconds. Define the margins ONCE here; every
+// layer derives from this, so the stagger cannot drift and a new long-running
+// tool inherits a correct cascade for free.
+
+/** Default socket timeout for any command that declares no in-game budget. Unchanged behavior. */
+export const QUICK_TIMEOUT_MS = 30_000;
+
+/**
+ * Hard backstop on the server socket regardless of declared budget — a
+ * per-request timeout must never degrade into "wait forever" when the game
+ * hangs. Chosen with Godot's 45s stale-connection timeout in mind: the 30s
+ * application heartbeat refreshes that timer well inside this ceiling, so a
+ * max-length command stays alive (see websocket_server.gd).
+ */
+export const ABSOLUTE_CEILING_MS = 60_000;
+
+/** Bridge-ready wait that precedes an input sequence; folded into the budget so caps are worst-case-safe. */
+export const READY_WAIT_MS = 10_000;
+
+/** Wall-clock headroom the bridge allows over the in-game cap (a frame overrun, a capture render). */
+export const BRIDGE_WALL_SLOP_MS = 5_000;
+
+/** The editor relay waits this much longer than the bridge's wall budget. */
+export const RELAY_MARGIN_MS = 2_000;
+
+/** The server socket waits this much longer than the editor relay. */
+export const SERVER_MARGIN_MS = 2_000;
+
+const FIXED_OVERHEAD_MS = BRIDGE_WALL_SLOP_MS + RELAY_MARGIN_MS + SERVER_MARGIN_MS;
+
+export interface DeriveOptions {
+  /** Account for the bridge-ready wait (input sequences gate on it; game_time does not). */
+  readyWait?: boolean;
+}
+
+export interface DerivedTimeouts {
+  /** Wall budget the bridge enforces before aborting (partial, honestly reported). */
+  bridgeWallMs: number;
+  /** Total wall the editor relay waits (covers the ready-wait plus the bridge wall budget). */
+  relayMs: number;
+  /** Socket timeout the server applies to this command. <= ABSOLUTE_CEILING_MS by construction. */
+  serverMs: number;
+  /** The declared budget after clamping to what the ceiling permits. */
+  clampedBudgetMs: number;
+}
+
+/**
+ * The largest in-game budget a single call can declare and still answer before
+ * the absolute ceiling, after subtracting the fixed cascade overhead (and the
+ * ready-wait when applicable). Published tool caps must stay <= this.
+ */
+export function maxInGameBudgetMs(opts: DeriveOptions = {}): number {
+  const ready = opts.readyWait ? READY_WAIT_MS : 0;
+  return ABSOLUTE_CEILING_MS - FIXED_OVERHEAD_MS - ready;
+}
+
+/**
+ * Derive the whole cascade from a tool's declared in-game budget. The budget is
+ * clamped to what the ceiling permits BEFORE the ladder is built, so the
+ * stagger (bridgeWall < relay < server <= ceiling) holds for any input.
+ */
+export function deriveTimeouts(inGameBudgetMs: number, opts: DeriveOptions = {}): DerivedTimeouts {
+  const ready = opts.readyWait ? READY_WAIT_MS : 0;
+  const budget = Number.isFinite(inGameBudgetMs) ? Math.ceil(inGameBudgetMs) : 0;
+  const clampedBudgetMs = Math.min(Math.max(budget, 0), maxInGameBudgetMs(opts));
+  const bridgeWallMs = clampedBudgetMs + BRIDGE_WALL_SLOP_MS;
+  const relayMs = ready + bridgeWallMs + RELAY_MARGIN_MS;
+  const serverMs = relayMs + SERVER_MARGIN_MS;
+  return { bridgeWallMs, relayMs, serverMs, clampedBudgetMs };
+}
+
+// Published per-tool caps (kept as clean round numbers for the schemas/UX). Each
+// must stay <= maxInGameBudgetMs for its readyWait class — asserted by a unit
+// test so they cannot silently exceed the ceiling if the margins above change.
+export const STEP_BUDGET_CAP_MS = 50_000;       // game_time step / step_until (no ready-wait)
+export const SEQUENCE_BUDGET_CAP_MS = 40_000;   // input sequence span / capture offsets (ready-wait)

--- a/server/src/connection/websocket.ts
+++ b/server/src/connection/websocket.ts
@@ -9,10 +9,10 @@ import {
 import { getServerVersion } from '../version.js';
 import { logger } from '../utils/logger.js';
 import { getTargetHost, getConnectionStrategy } from '../utils/connection-strategy.js';
+import { QUICK_TIMEOUT_MS } from './timeouts.js';
 
 const DEFAULT_PORT = 6550;
 const DEFAULT_HOST = 'localhost';
-const COMMAND_TIMEOUT_MS = 30000;
 const HANDSHAKE_TIMEOUT_MS = 5000;
 const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
 const PING_INTERVAL_MS = 30000;
@@ -311,19 +311,27 @@ export class GodotConnection extends EventEmitter {
     }
   }
 
-  async sendCommand<T = unknown>(command: string, params: Record<string, unknown> = {}): Promise<T> {
+  // Long-running commands (game_time step, input sequence) pass an explicit
+  // opts.timeoutMs derived from their in-game budget (see timeouts.ts); every
+  // other command falls back to the quick default.
+  async sendCommand<T = unknown>(
+    command: string,
+    params: Record<string, unknown> = {},
+    opts: { timeoutMs?: number } = {}
+  ): Promise<T> {
     if (!this.isConnected) {
       const diagnosticMessage = this.getDiagnosticMessage();
       throw new GodotConnectionError(`Not connected to Godot\n${diagnosticMessage}`);
     }
 
     const request = createRequest(command, params);
+    const timeoutMs = opts.timeoutMs ?? QUICK_TIMEOUT_MS;
 
     return new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         this.pendingRequests.delete(request.id);
-        reject(new GodotTimeoutError(command, COMMAND_TIMEOUT_MS));
-      }, COMMAND_TIMEOUT_MS);
+        reject(new GodotTimeoutError(command, timeoutMs));
+      }, timeoutMs);
 
       this.pendingRequests.set(request.id, {
         resolve: resolve as (result: unknown) => void,

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -1,14 +1,29 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
 import { structured } from '../core/structured.js';
+import { deriveTimeouts, STEP_BUDGET_CAP_MS } from '../connection/timeouts.js';
 import { InputActionSchema } from './input.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
-// Bridge-side step caps (see mcp_game_bridge.gd). The editor relay times out
-// at 28s and the server command timeout is 30s, so a step request must stay
-// well inside both.
-const STEP_MAX_MS = 20000;
+// Published cap on game time advanced in one call. The server sizes its socket
+// timeout from this budget and pushes the derived relay/wall budgets down to
+// the bridge (see timeouts.ts / mcp_game_bridge.gd), so the cap is a real
+// capability bound now, not a transport artifact.
+const STEP_MAX_MS = STEP_BUDGET_CAP_MS;
 const STEP_MAX_FRAMES = 1200;
+
+// Game-time budget (ms) this call advances at most, used to size the timeout
+// cascade. frames are converted at 60 fps (their wall cost at normal speed).
+function stepBudgetMs(args: GameTimeArgs): number {
+  if (args.action === 'step') {
+    if (args.duration_ms !== undefined) return args.duration_ms;
+    return Math.ceil(((args.frames ?? 0) * 1000) / 60);
+  }
+  if (args.action === 'step_until') {
+    return args.max_ms ?? STEP_MAX_MS;
+  }
+  return STEP_MAX_MS; // not reached: only step/step_until size a budget
+}
 
 const GameTimeSchema = z
   .discriminatedUnion('action', [
@@ -121,21 +136,27 @@ export const gameTime = defineTool({
       }
 
       case 'step': {
+        const t = deriveTimeouts(stepBudgetMs(args));
         const result = await godot.sendCommand<StepResult>('game_time_step', {
           duration_ms: args.duration_ms,
           frames: args.frames,
           inputs: args.inputs,
-        });
+          relay_timeout_ms: t.relayMs,
+          wall_budget_ms: t.bridgeWallMs,
+        }, { timeoutMs: t.serverMs });
         return structured(result);
       }
 
       case 'step_until': {
+        const t = deriveTimeouts(stepBudgetMs(args));
         const result = await godot.sendCommand<StepResult>('game_time_step_until', {
           until: args.until,
-          max_ms: args.max_ms,
+          max_ms: args.max_ms ?? STEP_MAX_MS,
           report: args.report,
           inputs: args.inputs,
-        });
+          relay_timeout_ms: t.relayMs,
+          wall_budget_ms: t.bridgeWallMs,
+        }, { timeoutMs: t.serverMs });
         return structured(result);
       }
 

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -11,6 +11,10 @@ import type { AnyToolDefinition } from '../core/types.js';
 // capability bound now, not a transport artifact.
 const STEP_MAX_MS = STEP_BUDGET_CAP_MS;
 const STEP_MAX_FRAMES = 1200;
+// step_until's max_ms is a safety net, not an expectation, so its default is
+// kept modest and decoupled from the cap: a forgotten or wrong predicate gives
+// up in ~20s, while an explicit max_ms unlocks the full window up to STEP_MAX_MS.
+const STEP_DEFAULT_MS = 20000;
 
 // Game-time budget (ms) this call advances at most, used to size the timeout
 // cascade. frames are converted at 60 fps (their wall cost at normal speed).
@@ -20,9 +24,9 @@ function stepBudgetMs(args: GameTimeArgs): number {
     return Math.ceil(((args.frames ?? 0) * 1000) / 60);
   }
   if (args.action === 'step_until') {
-    return args.max_ms ?? STEP_MAX_MS;
+    return args.max_ms ?? STEP_DEFAULT_MS;
   }
-  return STEP_MAX_MS; // not reached: only step/step_until size a budget
+  return STEP_DEFAULT_MS; // not reached: only step/step_until size a budget
 }
 
 const GameTimeSchema = z
@@ -69,7 +73,7 @@ const GameTimeSchema = z
         .min(1)
         .max(STEP_MAX_MS)
         .optional()
-        .describe(`Safety cap on game time to advance while waiting (max ${STEP_MAX_MS}, default ${STEP_MAX_MS}). If the predicate never holds within this budget (or the wall-clock budget), the call returns with predicate_met: false instead of hanging.`),
+        .describe(`Safety cap on game time to advance while waiting (max ${STEP_MAX_MS}, default ${STEP_DEFAULT_MS}). If the predicate never holds within this budget (or the wall-clock budget), the call returns with predicate_met: false instead of hanging.`),
       report: z
         .array(z.string().min(1))
         .optional()
@@ -151,7 +155,7 @@ export const gameTime = defineTool({
         const t = deriveTimeouts(stepBudgetMs(args));
         const result = await godot.sendCommand<StepResult>('game_time_step_until', {
           until: args.until,
-          max_ms: args.max_ms ?? STEP_MAX_MS,
+          max_ms: args.max_ms ?? STEP_DEFAULT_MS,
           report: args.report,
           inputs: args.inputs,
           relay_timeout_ms: t.relayMs,

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
+import { deriveTimeouts, maxInGameBudgetMs } from '../connection/timeouts.js';
 import type { AnyToolDefinition, ToolResult } from '../core/types.js';
 
 export const InputActionSchema = z.object({
@@ -115,6 +116,22 @@ export const input = defineTool({
 
       case 'sequence': {
         const inputs = args.inputs!;
+
+        // Size the timeout cascade from how long the sequence actually runs:
+        // the last input's end, or a later capture offset. The bridge-ready
+        // wait precedes this call, so it is folded into the budget (readyWait).
+        const lastInputEnd = inputs.reduce((m, i) => Math.max(m, (i.start_ms ?? 0) + (i.duration_ms ?? 0)), 0);
+        const lastShot = (args.screenshot_at_ms ?? []).reduce((m, o) => Math.max(m, o), 0);
+        const budget = Math.max(lastInputEnd, lastShot);
+        const cap = maxInGameBudgetMs({ readyWait: true });
+        if (budget > cap) {
+          throw new Error(
+            `Input sequence spans ${budget}ms but a single call can cover at most ${cap}ms ` +
+            `(the transport ceiling). Split it into multiple sequences, or use godot_game_time to drive a longer window.`
+          );
+        }
+        const t = deriveTimeouts(budget, { readyWait: true });
+
         const result = await godot.sendCommand<{
           completed: boolean;
           actions_executed: number;
@@ -140,7 +157,9 @@ export const input = defineTool({
           report: args.report,
           screenshot_at_ms: args.screenshot_at_ms,
           screenshot_max_width: args.screenshot_max_width,
-        });
+          relay_timeout_ms: t.relayMs,
+          wall_budget_ms: t.bridgeWallMs,
+        }, { timeoutMs: t.serverMs });
 
         if (result.error) {
           throw new Error(result.error);
@@ -212,12 +231,25 @@ export const input = defineTool({
       }
 
       case 'type_text': {
+        // Keystrokes are spaced by delay_ms; size the timeout from the total
+        // span (and the bridge-ready wait that precedes typing) so a long type
+        // can't hit the quick default and get killed mid-stream.
+        const budget = args.text.length * (args.delay_ms ?? 50);
+        const cap = maxInGameBudgetMs({ readyWait: true });
+        if (budget > cap) {
+          throw new Error(
+            `Typing ${args.text.length} chars at ${args.delay_ms ?? 50}ms each spans ${budget}ms, over the ` +
+            `${cap}ms single-call ceiling. Type in smaller chunks or lower delay_ms.`
+          );
+        }
+        const t = deriveTimeouts(budget, { readyWait: true });
+
         const result = await godot.sendCommand<{
           completed: boolean;
           chars_typed: number;
           submitted: boolean;
           error?: string;
-        }>('type_text', { text: args.text, delay_ms: args.delay_ms, submit: args.submit });
+        }>('type_text', { text: args.text, delay_ms: args.delay_ms, submit: args.submit, relay_timeout_ms: t.relayMs }, { timeoutMs: t.serverMs });
 
         if (result.error) {
           throw new Error(result.error);

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
-import { deriveTimeouts, maxInGameBudgetMs } from '../connection/timeouts.js';
+import { deriveTimeouts, INPUT_BUDGET_CAP_MS } from '../connection/timeouts.js';
 import type { AnyToolDefinition, ToolResult } from '../core/types.js';
 
 export const InputActionSchema = z.object({
@@ -42,7 +42,8 @@ const InputSchema = z.discriminatedUnion('action', [
         'frame DURING the real-time run. The bridge owns the sequence clock, so it grabs each frame ' +
         'at the right moment and returns them with the result — letting you catch transient visuals ' +
         '(muzzle flashes, explosions, kill banners) that fade long before a separate screenshot ' +
-        'call could land. Up to 8 frames, each returned as an image labeled with its actual offset. ' +
+        'call could land. Up to 8 frames, each returned as an image labeled with its actual offset; ' +
+        `an offset (like the whole sequence) must fall within the ${INPUT_BUDGET_CAP_MS}ms single-call window. ` +
         'COST: each frame costs vision tokens by RESOLUTION (~width*height/750), independent of ' +
         'format, and persists in context on every following turn — so prefer a few frames at a ' +
         'modest screenshot_max_width over many large ones. For frozen/precise inspection prefer ' +
@@ -123,7 +124,7 @@ export const input = defineTool({
         const lastInputEnd = inputs.reduce((m, i) => Math.max(m, (i.start_ms ?? 0) + (i.duration_ms ?? 0)), 0);
         const lastShot = (args.screenshot_at_ms ?? []).reduce((m, o) => Math.max(m, o), 0);
         const budget = Math.max(lastInputEnd, lastShot);
-        const cap = maxInGameBudgetMs({ readyWait: true });
+        const cap = INPUT_BUDGET_CAP_MS;
         if (budget > cap) {
           throw new Error(
             `Input sequence spans ${budget}ms but a single call can cover at most ${cap}ms ` +
@@ -157,8 +158,10 @@ export const input = defineTool({
           report: args.report,
           screenshot_at_ms: args.screenshot_at_ms,
           screenshot_max_width: args.screenshot_max_width,
+          // The bridge's sequence path has no wall guard (the editor relay is its
+          // effective deadline), so only the relay budget is pushed; sizing the
+          // server socket from it is enough. wall_budget_ms is a step-only concept.
           relay_timeout_ms: t.relayMs,
-          wall_budget_ms: t.bridgeWallMs,
         }, { timeoutMs: t.serverMs });
 
         if (result.error) {
@@ -235,7 +238,7 @@ export const input = defineTool({
         // span (and the bridge-ready wait that precedes typing) so a long type
         // can't hit the quick default and get killed mid-stream.
         const budget = args.text.length * (args.delay_ms ?? 50);
-        const cap = maxInGameBudgetMs({ readyWait: true });
+        const cap = INPUT_BUDGET_CAP_MS;
         if (budget > cap) {
           throw new Error(
             `Typing ${args.text.length} chars at ${args.delay_ms ?? 50}ms each spans ${budget}ms, over the ` +


### PR DESCRIPTION
Closes #276.

## Problem

Every MCP command shared one server-side socket timeout (`COMMAND_TIMEOUT_MS = 30000`), applied uniformly to a sub-millisecond digest and a multi-second `game_time step` alike. Any tool whose in-game work ran a while had to hard-cap its duration well under 30s and hand-stack a cascade of magic numbers across three layers (game bridge -> editor relay -> server) with no shared source of truth. Changing one silently broke the stagger; the `godot_input` sequence layer's `INPUT_TIMEOUT = 30.0` equalled the server's 30s so it raced instead of answering first (orphaning bridge work on a server timeout); and the 10s bridge-ready wait stacked on top of the caps unaccounted.

The cap was purely a transport artifact, not a gameplay or safety limit.

## Approach

Make the server the single source of truth. A new `server/src/connection/timeouts.ts` defines the margin ladder **once**; long-running tools call `deriveTimeouts(budget)` to size their own socket timeout and push the derived `relay_timeout_ms` / `wall_budget_ms` **down** in the command params, so the editor relay and game bridge stop hand-rolling their own values and inherit a correct, non-drifting stagger.

```
bridge wall budget  = budget + slop        (game bridge)
editor relay wait   = ready + wall + 2s    (editor addon)
server socket       = relay + 2s           (this server)   <= 60s ceiling
```

- **Per-request timeout**: `sendCommand` gains an optional `timeoutMs` (default unchanged at 30s, so quick commands are untouched). Per-call timeouts scale with each call's declared budget — the snappy majority is unaffected.
- **Single source of truth**: margins live only in `timeouts.ts`; the GDScript layers consume the pushed budgets and keep their old constants only as fallbacks for an older server.
- **Ready-wait folded in**: `input_commands` now runs the ready-wait and the sequence under one shared deadline, so caps are worst-case-safe.
- **Absolute 60s ceiling**: a hard backstop; never "wait forever". Sits within Godot's 45s stale-connection window via the 30s heartbeat refresh.
- **Caps rise**: `game_time` step/step_until 20s -> **50s**; input sequence span / capture offsets 20s -> **40s**. Bridge-side caps demoted to non-binding 300s sanity backstops so they cannot reintroduce drift. Over-cap sequences / `type_text` are rejected up front with a clear message.

## Validation

- Server: `tsc` clean; **282 unit tests pass** including a new `timeouts.test.ts` (stagger invariant across clamped/unclamped budgets, ready-wait headroom, published-cap-under-ceiling), `sendCommand` per-request timeout, and tool tests asserting the derived `timeoutMs` + injected budgets and the over-cap rejection.
- Addon: all 37 GDScript files parse clean; the three input-sequence bridge tests pass.
- Live (against a running game): a single `step duration_ms: 45000` returned `gameplay_ms 45015` cleanly (impossible under the old cap); an input sequence captured a frame at **38029ms** with the effect probe confirming the inputs landed; stderr empty (no orphaned-bridge / timeout / physics-flush errors); the over-cap path rejected a 45000ms span immediately.

## Notes

- Standalone release; lets the `game_time` and input-capture caps rise (or go dynamic) instead of sitting at the conservative 20s chosen for the old 30s ceiling.
- Version skew is safe both directions (new schema ships with the server; old addon clamps and returns early, new addon falls back to its local constants).