### PR TITLE
feat: add opt-in signal event timeline to the runtime_state watch lifecycle

### DIFF
--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -252,11 +252,56 @@ length. See [Tools Reference -> Runtime State](tools/runtime-state.md) for the f
 
 ---
 
+## Event timeline
+
+Sampling answers "how did values move"; the timeline answers "what discrete things happened,
+and in what order". `watch_start` optionally takes `signals` — an explicit allowlist of
+signals to record during the window:
+
+```json
+{
+  "action": "watch_start",
+  "specs": [{ "path": "/root/Level/Player", "fields": ["anim", "vel.x"] }],
+  "signals": [
+    { "path": "/root/GameState", "signal": "wave_started" },
+    { "path": "/root/Level/Player", "signal": "died" }
+  ],
+  "duration_ms": 2000
+}
+```
+
+`watch_collect` / `watch_stop` then return a merged, time-sorted `timeline` alongside the
+per-field summaries:
+
+```json
+"timeline": [
+  { "t_ms": 120, "kind": "signal", "source": "/root/GameState", "name": "wave_started", "args": "[2]" },
+  { "t_ms": 400, "kind": "anim_transition", "source": "/root/Level/Player", "from": "idle", "to": "run" },
+  { "t_ms": 880, "kind": "signal", "source": "/root/Level/Player", "name": "died" }
+]
+```
+
+- `signal` entries are exact emission times; built-in signals (`body_entered`, ...) work the
+  same as script signals. Signal connections live for the whole window — until `duration_ms`
+  elapses or `watch_stop` — regardless of mid-window `watch_collect` calls.
+- `anim_transition` and `field_change` entries come from the sampled string fields, so their
+  timestamps are detection times at the sample rate. Watching the `anim` field on an
+  `AnimationPlayer`, `AnimatedSprite2D`, or `AnimationTree` (state-machine root; other roots
+  such as BlendTree yield nothing) gets you state transitions on the timeline for free — as
+  does any string key you expose via `_mcp_state()`.
+- Caps: 16 signal connections per watch, 200 events per window (`timeline_truncated: true`
+  when exceeded — beware high-frequency signals like `body_shape_entered`), signal args
+  stringified to ~100 chars. Bad paths/names, duplicates, and signals with more than 5
+  parameters are skipped and reported by name in `unresolved_signals`.
+
+---
+
 ## Quick checklist
 
 - Tag the entities that matter into the `mcp_watch` group.
 - Add `_mcp_state()` to those nodes; return live values AND the context to interpret them.
 - Keep each `_mcp_state()` cheap, side-effect-free, JSON-able, and under ~1 KB.
 - Let agents call `digest` for a snapshot and `watch_start` / `watch_collect` for motion.
+- Watch `signals` (and the `anim` field) when ORDER of events matters, not just trajectories.
 - For global state in autoload singletons, read them with `select="none"` and `paths`
   (every response lists them in `available_autoloads`).

--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -281,18 +281,27 @@ per-field summaries:
 ]
 ```
 
-- `signal` entries are exact emission times; built-in signals (`body_entered`, ...) work the
-  same as script signals. Signal connections live for the whole window — until `duration_ms`
-  elapses or `watch_stop` — regardless of mid-window `watch_collect` calls.
+- `signal` entries carry emission-time stamps (millisecond resolution); built-in signals
+  (`body_entered`, ...) work the same as script signals. Signal connections live for the whole
+  window — until `duration_ms` elapses or `watch_stop` — regardless of mid-window
+  `watch_collect` calls. Same-millisecond signal entries keep emission order; the order of
+  same-millisecond entries of *different* kinds is a fixed presentation order (signal,
+  anim_transition, field_change), not chronology.
 - `anim_transition` and `field_change` entries come from the sampled string fields, so their
-  timestamps are detection times at the sample rate. Watching the `anim` field on an
-  `AnimationPlayer`, `AnimatedSprite2D`, or `AnimationTree` (state-machine root; other roots
-  such as BlendTree yield nothing) gets you state transitions on the timeline for free — as
-  does any string key you expose via `_mcp_state()`.
+  timestamps are detection times at the sample rate — the change happened up to one sample
+  interval earlier. Do not infer cross-kind ordering from nearby timestamps. Watching the
+  `anim` field on an `AnimationPlayer`, `AnimatedSprite2D`, or `AnimationTree` (state-machine
+  root; other roots such as BlendTree yield nothing) gets you state transitions on the
+  timeline for free — as does any string key you expose via `_mcp_state()`.
 - Caps: 16 signal connections per watch, 200 events per window (`timeline_truncated: true`
   when exceeded — beware high-frequency signals like `body_shape_entered`), signal args
   stringified to ~100 chars. Bad paths/names, duplicates, and signals with more than 5
   parameters are skipped and reported by name in `unresolved_signals`.
+- Limitations: signals must be emitted on the main thread (worker-thread or
+  threaded-physics emissions are unsupported). Sampled-field history is capped at 200
+  samples per field, so at `hz` above 40 a 5-second window saturates before it ends and
+  late `anim_transition`/`field_change` entries silently stop — `timeline_truncated` covers
+  only the signal-event budget.
 
 ---
 

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -25,7 +25,7 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 | `max_nodes` | integer | No | Maximum nodes in result (default: 40) |
 | `include` | string[] | No | Subset of fields to include (default: all available) |
 | `specs` | object[] | No | Which nodes and fields to watch. Optional when signals is provided. |
-| `signals` | object[] | No | Signals to record as discrete timeline events during the window. Each emission is buffered as {t_ms, source, signal, args} (max 200 events/window, then truncated with a flag; args stringified to ~100 chars). watch_collect merges these with string-field transitions into a time-sorted `timeline`. Signals with more than 5 parameters are skipped and reported in unresolved_signals, as are bad paths/names. Connections stay live until duration_ms elapses or watch_stop. |
+| `signals` | object[] | No | Signals to record as discrete timeline events during the window. Each emission is buffered as {t_ms, source, signal, args} (max 200 events/window, then truncated with a flag; args stringified to ~100 chars). watch_collect merges these with string-field transitions into a time-sorted `timeline`. Signals with more than 5 parameters are skipped and reported in unresolved_signals, as are bad paths/names. Connections stay live until duration_ms elapses or watch_stop. Signals must be emitted on the main thread (worker-thread emissions are unsupported). At least one of specs/signals is required. |
 | `hz` | integer | No | Sample rate in Hz (default: 20) |
 | `duration_ms` | integer | No | Auto-stop after this many milliseconds (default: 1000) |
 

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -24,7 +24,8 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 | `type` | string | No | Class filter (e.g. "CharacterBody2D") |
 | `max_nodes` | integer | No | Maximum nodes in result (default: 40) |
 | `include` | string[] | No | Subset of fields to include (default: all available) |
-| `specs` | object[] | No | Which nodes and fields to watch |
+| `specs` | object[] | No | Which nodes and fields to watch. Optional when signals is provided. |
+| `signals` | object[] | No | Signals to record as discrete timeline events during the window. Each emission is buffered as {t_ms, source, signal, args} (max 200 events/window, then truncated with a flag; args stringified to ~100 chars). watch_collect merges these with string-field transitions into a time-sorted `timeline`. Signals with more than 5 parameters are skipped and reported in unresolved_signals, as are bad paths/names. Connections stay live until duration_ms elapses or watch_stop. |
 | `hz` | integer | No | Sample rate in Hz (default: 20) |
 | `duration_ms` | integer | No | Auto-stop after this many milliseconds (default: 1000) |
 

--- a/godot/addons/godot_mcp/commands/runtime_state_commands.gd
+++ b/godot/addons/godot_mcp/commands/runtime_state_commands.gd
@@ -28,7 +28,8 @@ func watch_start(params: Dictionary) -> Dictionary:
 	var specs: Array = params.get("specs", [])
 	var hz: int = params.get("hz", 20)
 	var duration_ms: int = params.get("duration_ms", 1000)
-	var result = await _send_and_wait("watch_start", [specs, hz, duration_ms])
+	var sigs: Array = params.get("signals", [])
+	var result = await _send_and_wait("watch_start", [specs, hz, duration_ms, sigs])
 	if result == null:
 		return _last_error
 	if result is Dictionary:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1063,23 +1063,26 @@ func _handle_watch_start(data: Array) -> void:
 	var specs: Array = data[0] if data.size() > 0 else []
 	var hz: int = data[1] if data.size() > 1 else 20
 	var duration_ms: int = data[2] if data.size() > 2 else 1000
-	var start_result := _sampler.start(specs, hz, duration_ms)
+	var signal_specs: Array = data[3] if data.size() > 3 else []
+	var start_result := _sampler.start(specs, hz, duration_ms, signal_specs)
 	EngineDebugger.send_message("godot_mcp:game_response", ["watch_start", {
 		"started": true,
 		"resolved_fields": start_result.get("resolved_fields", 0),
+		"connected_signals": start_result.get("connected_signals", 0),
+		"unresolved_signals": start_result.get("unresolved_signals", []),
 	}])
 
 
 func _handle_watch_collect() -> void:
 	if _sampler == null:
-		EngineDebugger.send_message("godot_mcp:game_response", ["watch_collect", {"window_ms": 0, "sample_count": 0, "fields": {}}])
+		EngineDebugger.send_message("godot_mcp:game_response", ["watch_collect", {"window_ms": 0, "sample_count": 0, "fields": {}, "events": [], "events_truncated": false}])
 		return
 	EngineDebugger.send_message("godot_mcp:game_response", ["watch_collect", _sampler.collect()])
 
 
 func _handle_watch_stop() -> void:
 	if _sampler == null:
-		EngineDebugger.send_message("godot_mcp:game_response", ["watch_stop", {"window_ms": 0, "sample_count": 0, "fields": {}}])
+		EngineDebugger.send_message("godot_mcp:game_response", ["watch_stop", {"window_ms": 0, "sample_count": 0, "fields": {}, "events": [], "events_truncated": false}])
 		return
 	EngineDebugger.send_message("godot_mcp:game_response", ["watch_stop", _sampler.stop()])
 

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -74,19 +74,21 @@ func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) ->
 		var sig_name: String = str(sig_spec.get("signal", ""))
 		if sig_path.is_empty() or sig_name.is_empty():
 			continue
-		var dedupe_key := sig_path + "\n" + sig_name
-		# Duplicate specs would double-connect (our lambdas are distinct Callables,
-		# so connect() would not reject the second one) and double-record.
+		var emitter := _resolve_node(sig_path)
+		if emitter == null:
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "node_not_found"})
+			continue
+		# Dedupe on the RESOLVED node, not the path string: two spellings of the
+		# same node ("/root/Scene/Child" vs "Child") would otherwise both
+		# connect (our lambdas are distinct Callables, so connect() would not
+		# reject the second one) and double-record every emission.
+		var dedupe_key := str(emitter.get_instance_id()) + "\n" + sig_name
 		if seen.has(dedupe_key):
 			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "duplicate"})
 			continue
 		seen[dedupe_key] = true
 		if connected >= MAX_SIGNALS:
 			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "signal_cap"})
-			continue
-		var emitter := _resolve_node(sig_path)
-		if emitter == null:
-			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "node_not_found"})
 			continue
 		var arg_count := _signal_arg_count(emitter, sig_name)
 		if arg_count < 0:
@@ -96,8 +98,13 @@ func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) ->
 			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "unsupported_arity"})
 			continue
 		var cb := _make_recorder(sig_path, sig_name, arg_count)
-		# Immediate (not deferred) connect: exact emission-time recording, and the
-		# recorder only appends to an Array -- safe inside physics callbacks.
+		# Immediate (not deferred) connect: emission-time recording, and the
+		# recorder only appends to an Array -- safe inside main-thread physics
+		# callbacks. NOT safe for signals emitted off the main thread (worker
+		# threads, run_on_separate_thread physics): the append races collect().
+		# Deferred connect would fix that but quantizes t_ms to frame
+		# boundaries, destroying the exact-timing property -- documented as a
+		# main-thread-emission limitation instead.
 		if emitter.connect(StringName(sig_name), cb) != OK:
 			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "connect_failed"})
 			continue
@@ -245,7 +252,10 @@ func collect() -> Dictionary:
 
 func stop() -> Dictionary:
 	_active = false
-	_stop_time = Time.get_ticks_msec()
+	# Don't clobber an auto-stop's timestamp: a late manual stop would inflate
+	# window_ms to the call time instead of the actual window end.
+	if _stop_time == 0:
+		_stop_time = Time.get_ticks_msec()
 	set_process(false)
 	_disconnect_all()
 	return collect()

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -3,6 +3,11 @@ class_name MCPRuntimeStateSampler
 
 const MAX_FIELDS := 32
 const MAX_SAMPLES_PER_FIELD := 200
+const MAX_SIGNALS := 16
+const MAX_EVENTS := 200
+const MAX_ARGS_CHARS := 100    # total stringified-args cap per event
+const MAX_ARG_CHARS := 40      # per-arg cap before joining
+const MAX_SIGNAL_ARITY := 5
 
 var _active: bool = false
 var _specs: Array = []       # [{node, fields: [{key, resolver}]}]
@@ -13,11 +18,17 @@ var _stop_time: int = 0      # set on auto-stop or manual stop; 0 = still runnin
 var _frame_index: int = 0
 var _sample_interval: int = 1  # sample every N frames
 var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
+var _events: Array = []        # [{t_ms, source, signal, args?}] -- signal emissions this window
+var _events_truncated: bool = false
+var _connections: Array = []   # [{node, sig_name, callable}] -- live connections to tear down
 
 
-func start(specs: Array, hz: int, duration_ms: int) -> Dictionary:
+func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) -> Dictionary:
+	_disconnect_all()  # a restart while connections are live must tear the old ones down
 	_specs = []
 	_samples = {}
+	_events = []
+	_events_truncated = false
 	_hz = clampi(hz, 1, 60)
 	_duration_ms = clampi(duration_ms, 100, 5000)
 	_start_time = Time.get_ticks_msec()
@@ -52,7 +63,121 @@ func start(specs: Array, hz: int, duration_ms: int) -> Dictionary:
 	_stop_time = 0
 	_active = true
 	set_process(true)
-	return {"resolved_fields": field_count}
+
+	var connected := 0
+	var unresolved: Array = []
+	var seen := {}
+	for sig_spec in signal_specs:
+		if not sig_spec is Dictionary:
+			continue
+		var sig_path: String = str(sig_spec.get("path", ""))
+		var sig_name: String = str(sig_spec.get("signal", ""))
+		if sig_path.is_empty() or sig_name.is_empty():
+			continue
+		var dedupe_key := sig_path + "\n" + sig_name
+		# Duplicate specs would double-connect (our lambdas are distinct Callables,
+		# so connect() would not reject the second one) and double-record.
+		if seen.has(dedupe_key):
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "duplicate"})
+			continue
+		seen[dedupe_key] = true
+		if connected >= MAX_SIGNALS:
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "signal_cap"})
+			continue
+		var emitter := _resolve_node(sig_path)
+		if emitter == null:
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "node_not_found"})
+			continue
+		var arg_count := _signal_arg_count(emitter, sig_name)
+		if arg_count < 0:
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "signal_not_found"})
+			continue
+		if arg_count > MAX_SIGNAL_ARITY:
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "unsupported_arity"})
+			continue
+		var cb := _make_recorder(sig_path, sig_name, arg_count)
+		# Immediate (not deferred) connect: exact emission-time recording, and the
+		# recorder only appends to an Array -- safe inside physics callbacks.
+		if emitter.connect(StringName(sig_name), cb) != OK:
+			unresolved.append({"path": sig_path, "signal": sig_name, "reason": "connect_failed"})
+			continue
+		_connections.append({"node": emitter, "sig_name": sig_name, "callable": cb})
+		connected += 1
+
+	return {
+		"resolved_fields": field_count,
+		"connected_signals": connected,
+		"unresolved_signals": unresolved,
+	}
+
+
+func _signal_arg_count(node: Node, sig_name: String) -> int:
+	# Covers script signals AND built-ins (body_entered etc.). -1 = not found.
+	for info in node.get_signal_list():
+		if str(info.get("name", "")) == sig_name:
+			return (info.get("args", []) as Array).size()
+	return -1
+
+
+func _make_recorder(path: String, sig_name: String, arg_count: int) -> Callable:
+	# connect() requires the Callable arity to match the signal's; lambdas capture
+	# path/sig_name by value so no get_path() happens at record time.
+	match arg_count:
+		0: return func() -> void: _record_event(path, sig_name, [])
+		1: return func(a1) -> void: _record_event(path, sig_name, [a1])
+		2: return func(a1, a2) -> void: _record_event(path, sig_name, [a1, a2])
+		3: return func(a1, a2, a3) -> void: _record_event(path, sig_name, [a1, a2, a3])
+		4: return func(a1, a2, a3, a4) -> void: _record_event(path, sig_name, [a1, a2, a3, a4])
+		_: return func(a1, a2, a3, a4, a5) -> void: _record_event(path, sig_name, [a1, a2, a3, a4, a5])
+
+
+func _record_event(source: String, sig_name: String, args: Array) -> void:
+	if not _active:
+		return
+	if _events.size() >= MAX_EVENTS:
+		_events_truncated = true
+		return
+	var ev := {
+		"t_ms": Time.get_ticks_msec() - _start_time,
+		"source": source,
+		"signal": sig_name,
+	}
+	if not args.is_empty():
+		# Stringify AT RECORD TIME -- an arg object may be freed before collect().
+		# str() on an Object invokes its _to_string(); a _to_string() that mutates
+		# the tree is the game's bug, not ours.
+		ev["args"] = _stringify_args(args)
+	_events.append(ev)
+
+
+func _stringify_args(args: Array) -> String:
+	var parts: PackedStringArray = []
+	for a in args:
+		var s := str(a)
+		if s.length() > MAX_ARG_CHARS:
+			s = s.substr(0, MAX_ARG_CHARS) + "..."
+		parts.append(s)
+	var joined := "[" + ", ".join(parts) + "]"
+	if joined.length() > MAX_ARGS_CHARS:
+		joined = joined.substr(0, MAX_ARGS_CHARS) + "..."
+	return joined
+
+
+func _disconnect_all() -> void:
+	for c in _connections:
+		# UNTYPED on purpose: assigning a freed instance to a typed Node var is
+		# itself a script error that would abort this loop before
+		# is_instance_valid ever ran, leaving stale entries behind. Freed
+		# emitters drop their connections with the object; disconnecting a dead
+		# entry would error too, hence both guards.
+		var node = c.node
+		if is_instance_valid(node) and node.is_connected(StringName(c.sig_name), c.callable):
+			node.disconnect(StringName(c.sig_name), c.callable)
+	_connections.clear()
+
+
+func _exit_tree() -> void:
+	_disconnect_all()
 
 
 func _process(_delta: float) -> void:
@@ -65,6 +190,10 @@ func _process(_delta: float) -> void:
 		_active = false
 		_stop_time = Time.get_ticks_msec()
 		set_process(false)
+		# Window over: stop recording signal emissions too. An emission landing
+		# between duration_ms elapsing and this frame is recorded with t_ms
+		# slightly past the window -- harmless and honest.
+		_disconnect_all()
 		return
 
 	_frame_index += 1
@@ -72,7 +201,9 @@ func _process(_delta: float) -> void:
 		return
 
 	for spec in _specs:
-		var node: Node = spec.node
+		# Untyped: a typed assignment of a freed instance is a script error that
+		# would abort the whole sampling pass (same hazard as _disconnect_all).
+		var node = spec.node
 		if not is_instance_valid(node):
 			# node was freed — mark all fields and skip
 			for field_info in spec.fields:
@@ -105,6 +236,10 @@ func collect() -> Dictionary:
 		"window_ms": elapsed,
 		"sample_count": total_samples,
 		"fields": _samples.duplicate(true),
+		# duplicate: a mid-window collect leaves recording live, so the caller's
+		# copy must not alias the still-growing array.
+		"events": _events.duplicate(true),
+		"events_truncated": _events_truncated,
 	}
 
 
@@ -112,6 +247,7 @@ func stop() -> Dictionary:
 	_active = false
 	_stop_time = Time.get_ticks_msec()
 	set_process(false)
+	_disconnect_all()
 	return collect()
 
 
@@ -124,10 +260,24 @@ func _resolve_node(path: String) -> Node:
 	if tree == null:
 		return null
 	var scene_root := tree.current_scene
+
+	# "/" means the scene root, NOT the root Window -- keep ahead of the absolute
+	# attempt or a bare-/ NodePath would return the Window.
+	if path == "/":
+		return scene_root
+
+	# Absolute paths resolve from /root regardless of current_scene -- this is
+	# what makes autoloads (/root/G) watchable, including during scene
+	# transitions when current_scene is null.
+	if path.begins_with("/") and tree.root != null:
+		var abs_hit := tree.root.get_node_or_null(NodePath(path))
+		if abs_hit != null:
+			return abs_hit
+
 	if scene_root == null:
 		return null
 
-	if path == "/root/" + scene_root.name or path == "/":
+	if path == "/root/" + scene_root.name:
 		return scene_root
 
 	if path.begins_with("/root/"):
@@ -190,6 +340,13 @@ func _read_field(node: Node, key: String) -> Variant:
 				return (node as AnimationPlayer).current_animation
 			if node is AnimatedSprite2D:
 				return (node as AnimatedSprite2D).animation
+			if node is AnimationTree:
+				# Only state-machine roots expose parameters/playback; BlendTree
+				# and other roots fall through to null (silent skip, matching the
+				# other inapplicable-field arms).
+				var playback = node.get("parameters/playback")
+				if playback is AnimationNodeStateMachinePlayback:
+					return String(playback.get_current_node())
 		"anim_frame":
 			if node is AnimatedSprite2D:
 				return (node as AnimatedSprite2D).frame

--- a/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
@@ -54,6 +54,7 @@ func _run() -> void:
 	await _test_freed_field_node(sampler)
 	_test_reporting(sampler, emitter)
 	await _test_field_absolute_path(sampler)
+	_test_alias_dedupe(sampler)
 	_test_resolution_preservation(sampler)
 	await _test_animation_tree(sampler)
 
@@ -170,6 +171,15 @@ func _test_auto_stop(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void
 	_check("auto-stop: emission after window not recorded",
 		(sampler.collect().get("events") as Array).size(), 1)
 
+	# window_ms honesty: a late manual stop must NOT inflate the window to the
+	# call time (stop() used to clobber the auto-stop timestamp).
+	var settled: int = sampler.collect().get("window_ms")
+	await _pump_ms(200)
+	_check("auto-stop: window_ms stable across late collects",
+		sampler.collect().get("window_ms"), settled)
+	_check("auto-stop: late stop() keeps the auto-stop window_ms",
+		sampler.stop().get("window_ms"), settled)
+
 
 func _test_restart_cleanup(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
 	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}])
@@ -278,6 +288,34 @@ func _test_field_absolute_path(sampler: MCPRuntimeStateSampler) -> void:
 	_check("fields: autoload-style property sampled", samples.size() > 0, true)
 	if samples.size() > 0:
 		_check("fields: sampled value correct", samples[0].get("value"), 7)
+
+
+func _test_alias_dedupe(sampler: MCPRuntimeStateSampler) -> void:
+	# Two spellings of the SAME node must not double-connect: dedupe is on the
+	# resolved instance, not the path string.
+	var scene := Node.new()
+	scene.name = "AliasScene"
+	var child := _Emitter.new()
+	child.name = "AliasChild"
+	scene.add_child(child)
+	root.add_child(scene)
+	current_scene = scene
+
+	var res := _start_signals(sampler, [
+		{"path": "/root/AliasScene/AliasChild", "signal": "fired"},
+		{"path": "AliasChild", "signal": "fired"},
+	])
+	_check("alias: only one connection for two spellings", res.get("connected_signals"), 1)
+	var unresolved: Array = res.get("unresolved_signals", [])
+	_check("alias: second spelling reported as duplicate",
+		unresolved.size() == 1 and unresolved[0].get("reason") == "duplicate", true)
+	child.fired.emit()
+	_check("alias: one emission records one event",
+		(sampler.stop().get("events") as Array).size(), 1)
+
+	current_scene = null
+	root.remove_child(scene)
+	scene.free()
 
 
 func _test_resolution_preservation(sampler: MCPRuntimeStateSampler) -> void:

--- a/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
@@ -1,0 +1,361 @@
+extends SceneTree
+
+## Headless checks for the watch-lifecycle event timeline (#198): signal
+## connect/record/disconnect on MCPRuntimeStateSampler, caps/truncation,
+## restart and freed-emitter teardown, the absolute-path _resolve_node fix
+## (autoloads), and the AnimationTree "anim" read.
+##
+## Runs without a game or editor: current_scene is NULL under --script, which
+## is exactly the failure mode the resolver fix closes — the /root/FakeAutoload
+## checks below fail on the pre-fix sampler.
+##
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/watch_timeline_headless_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+var _count := 0
+var _failures := 0
+
+
+class _Emitter extends Node:
+	signal fired
+	signal hit(amount)
+	signal moved(x, y)
+	signal six(a, b, c, d, e, f)
+	var score := 7
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n===================== WATCH TIMELINE TEST =====================\n")
+	_check("root window is at /root (absolute paths resolve)", str(root.get_path()), "/root")
+
+	var sampler := MCPRuntimeStateSampler.new()
+	root.add_child(sampler)
+	var emitter := _Emitter.new()
+	emitter.name = "FakeAutoload"
+	root.add_child(emitter)
+	await process_frame
+
+	_test_arities_and_args(sampler, emitter)
+	await _test_timestamps(sampler, emitter)
+	_test_event_cap(sampler, emitter)
+	_test_arg_caps(sampler, emitter)
+	await _test_window_semantics(sampler, emitter)
+	await _test_auto_stop(sampler, emitter)
+	_test_restart_cleanup(sampler, emitter)
+	_test_freed_emitter(sampler)
+	await _test_freed_field_node(sampler)
+	_test_reporting(sampler, emitter)
+	await _test_field_absolute_path(sampler)
+	_test_resolution_preservation(sampler)
+	await _test_animation_tree(sampler)
+
+	sampler.stop()
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS - %d checks" % _count)
+	else:
+		printerr("FAILED - %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _start_signals(sampler: MCPRuntimeStateSampler, sig_specs: Array, duration_ms: int = 5000) -> Dictionary:
+	return sampler.start([], 20, duration_ms, sig_specs)
+
+
+func _pump_ms(ms: int) -> void:
+	var t0 := Time.get_ticks_msec()
+	while Time.get_ticks_msec() - t0 < ms:
+		await process_frame
+
+
+func _test_arities_and_args(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	var res := _start_signals(sampler, [
+		{"path": "/root/FakeAutoload", "signal": "fired"},
+		{"path": "/root/FakeAutoload", "signal": "hit"},
+		{"path": "/root/FakeAutoload", "signal": "moved"},
+	])
+	_check("arity: 3 signals connected", res.get("connected_signals"), 3)
+	_check("arity: none unresolved", (res.get("unresolved_signals") as Array).size(), 0)
+
+	emitter.fired.emit()
+	emitter.hit.emit(3)
+	emitter.moved.emit(1.5, 2)
+	var events: Array = sampler.collect().get("events", [])
+	_check("arity: 3 events recorded", events.size(), 3)
+	if events.size() == 3:
+		_check("arity-0: source is the requested path", events[0].get("source"), "/root/FakeAutoload")
+		_check("arity-0: signal name", events[0].get("signal"), "fired")
+		_check("arity-0: args key omitted", events[0].has("args"), false)
+		_check("arity-1: args stringified", events[1].get("args"), "[3]")
+		_check("arity-2: args stringified", events[2].get("args"), "[1.5, 2]")
+	sampler.stop()
+
+
+func _test_timestamps(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}])
+	emitter.fired.emit()
+	await _pump_ms(15)
+	emitter.fired.emit()
+	var events: Array = sampler.stop().get("events", [])
+	_check("timestamps: 2 events", events.size(), 2)
+	if events.size() == 2:
+		_check("timestamps: first t_ms >= 0", int(events[0].get("t_ms")) >= 0, true)
+		_check("timestamps: strictly increasing across a 15ms gap",
+			int(events[1].get("t_ms")) > int(events[0].get("t_ms")), true)
+
+
+func _test_event_cap(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "hit"}])
+	for i in 250:
+		emitter.hit.emit(i)
+	var result: Dictionary = sampler.stop()
+	_check("cap: events stop at MAX_EVENTS", (result.get("events") as Array).size(),
+		MCPRuntimeStateSampler.MAX_EVENTS)
+	_check("cap: truncation flagged honestly", result.get("events_truncated"), true)
+
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}])
+	emitter.fired.emit()
+	var result2: Dictionary = sampler.stop()
+	_check("cap: truncated flag resets on restart", result2.get("events_truncated"), false)
+
+
+func _test_arg_caps(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "hit"}])
+	emitter.hit.emit("x".repeat(500))
+	var events: Array = sampler.stop().get("events", [])
+	_check("arg cap: 1 event", events.size(), 1)
+	if events.size() == 1:
+		var args: String = events[0].get("args", "")
+		_check("arg cap: total capped (<= MAX_ARGS_CHARS + ellipsis)",
+			args.length() <= MCPRuntimeStateSampler.MAX_ARGS_CHARS + 3, true)
+
+
+func _test_window_semantics(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	# collect() mid-window must NOT disconnect: recording continues to duration.
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}])
+	emitter.fired.emit()
+	var first: Array = sampler.collect().get("events", [])
+	_check("window: first collect sees 1 event", first.size(), 1)
+	await process_frame
+	emitter.fired.emit()
+	var second: Array = sampler.collect().get("events", [])
+	_check("window: collect leaves connections live (2nd event recorded)", second.size(), 2)
+
+	# stop() disconnects: emissions after it are not recorded.
+	var stopped: Array = sampler.stop().get("events", [])
+	_check("window: stop returns both events", stopped.size(), 2)
+	_check("window: stop tears down connections", sampler._connections.is_empty(), true)
+	emitter.fired.emit()
+	_check("window: emission after stop not recorded",
+		(sampler.collect().get("events") as Array).size(), 2)
+
+
+func _test_auto_stop(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}], 100)
+	emitter.fired.emit()
+	var t0 := Time.get_ticks_msec()
+	while sampler.is_active() and Time.get_ticks_msec() - t0 < 2000:
+		await process_frame
+	_check("auto-stop: sampler stopped by duration", sampler.is_active(), false)
+	_check("auto-stop: connections torn down", sampler._connections.is_empty(), true)
+	emitter.fired.emit()
+	_check("auto-stop: emission after window not recorded",
+		(sampler.collect().get("events") as Array).size(), 1)
+
+
+func _test_restart_cleanup(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}])
+	_start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "hit"}])
+	emitter.fired.emit()
+	emitter.hit.emit(1)
+	var events: Array = sampler.stop().get("events", [])
+	_check("restart: only the new watch records", events.size(), 1)
+	if events.size() == 1:
+		_check("restart: surviving event is from the new spec", events[0].get("signal"), "hit")
+	_check("restart: old signal has no leftover connection",
+		emitter.get_signal_connection_list("fired").size(), 0)
+
+
+func _test_freed_emitter(sampler: MCPRuntimeStateSampler) -> void:
+	var doomed := _Emitter.new()
+	doomed.name = "Doomed"
+	root.add_child(doomed)
+	var res := _start_signals(sampler, [{"path": "/root/Doomed", "signal": "fired"}])
+	_check("freed: connected before free", res.get("connected_signals"), 1)
+	root.remove_child(doomed)
+	doomed.free()
+	var result: Dictionary = sampler.stop()  # must not error on the dead entry
+	_check("freed: stop survives a freed emitter", result.get("events_truncated"), false)
+	var res2 := _start_signals(sampler, [{"path": "/root/FakeAutoload", "signal": "fired"}])
+	_check("freed: clean restart afterwards", res2.get("connected_signals"), 1)
+	sampler.stop()
+
+
+func _test_freed_field_node(sampler: MCPRuntimeStateSampler) -> void:
+	# A typed `var node: Node = spec.node` on a freed instance is a script error
+	# that aborts the sampling pass — the freed-marker path never ran. Pins the
+	# untyped-assignment fix in _process (and _disconnect_all's twin).
+	var doomed := _Emitter.new()
+	doomed.name = "DoomedField"
+	root.add_child(doomed)
+	var res: Dictionary = sampler.start([{"path": "/root/DoomedField", "fields": ["score"]}], 60, 2000)
+	_check("freed-field: field resolved before free", res.get("resolved_fields"), 1)
+	await _pump_ms(50)
+	root.remove_child(doomed)
+	doomed.free()
+	await _pump_ms(50)
+	var result: Dictionary = sampler.stop()
+	var samples: Array = (result.get("fields") as Dictionary).get("/root/DoomedField:score", [])
+	var freed_markers := 0
+	for s in samples:
+		if str(s.get("value")) == "freed":
+			freed_markers += 1
+	_check("freed-field: sampling survived the free", samples.size() > 0, true)
+	_check("freed-field: freed markers recorded after the free", freed_markers > 0, true)
+
+
+func _test_reporting(sampler: MCPRuntimeStateSampler, _emitter: _Emitter) -> void:
+	var res := _start_signals(sampler, [
+		{"path": "/root/Bogus", "signal": "fired"},
+		{"path": "/root/FakeAutoload", "signal": "no_such_signal"},
+		{"path": "/root/FakeAutoload", "signal": "six"},
+		{"path": "/root/FakeAutoload", "signal": "fired"},
+		{"path": "/root/FakeAutoload", "signal": "fired"},
+	])
+	_check("report: only the valid non-duplicate connected", res.get("connected_signals"), 1)
+	var unresolved: Array = res.get("unresolved_signals", [])
+	_check("report: 4 unresolved", unresolved.size(), 4)
+	var reasons := {}
+	for u in unresolved:
+		reasons[u.get("reason")] = u
+	_check("report: node_not_found named", reasons.has("node_not_found"), true)
+	_check("report: signal_not_found named", reasons.has("signal_not_found"), true)
+	_check("report: unsupported_arity (6 params) named", reasons.has("unsupported_arity"), true)
+	_check("report: duplicate spec named", reasons.has("duplicate"), true)
+	sampler.stop()
+
+	# Connection cap: 20 distinct emitters, 16 connect, 4 report signal_cap.
+	var extras: Array = []
+	var sig_specs: Array = []
+	for i in 20:
+		var e := _Emitter.new()
+		e.name = "CapEmitter%d" % i
+		root.add_child(e)
+		extras.append(e)
+		sig_specs.append({"path": "/root/CapEmitter%d" % i, "signal": "fired"})
+	var cap_res := _start_signals(sampler, sig_specs)
+	_check("report: connections capped at MAX_SIGNALS", cap_res.get("connected_signals"),
+		MCPRuntimeStateSampler.MAX_SIGNALS)
+	var cap_unresolved: Array = cap_res.get("unresolved_signals", [])
+	var cap_hits := 0
+	for u in cap_unresolved:
+		if u.get("reason") == "signal_cap":
+			cap_hits += 1
+	_check("report: overflow reported as signal_cap", cap_hits, 20 - MCPRuntimeStateSampler.MAX_SIGNALS)
+	sampler.stop()
+	for e in extras:
+		root.remove_child(e)
+		e.free()
+
+
+func _test_field_absolute_path(sampler: MCPRuntimeStateSampler) -> void:
+	# Field specs share _resolve_node, so /root/* (autoload-style) sampling must
+	# work with current_scene null — the pre-fix sampler returns 0 fields here.
+	var res: Dictionary = sampler.start(
+		[{"path": "/root/FakeAutoload", "fields": ["score"]}], 60, 500)
+	_check("fields: /root path resolves with no current_scene", res.get("resolved_fields"), 1)
+	await _pump_ms(150)
+	var result: Dictionary = sampler.stop()
+	var samples: Array = (result.get("fields") as Dictionary).get("/root/FakeAutoload:score", [])
+	_check("fields: autoload-style property sampled", samples.size() > 0, true)
+	if samples.size() > 0:
+		_check("fields: sampled value correct", samples[0].get("value"), 7)
+
+
+func _test_resolution_preservation(sampler: MCPRuntimeStateSampler) -> void:
+	var scene := Node.new()
+	scene.name = "FakeScene"
+	var child := Node.new()
+	child.name = "Child"
+	scene.add_child(child)
+	root.add_child(scene)
+	current_scene = scene
+
+	_check("resolve: relative path against current_scene", sampler._resolve_node("Child"), child)
+	_check("resolve: /root/<scene>/Child remap", sampler._resolve_node("/root/FakeScene/Child"), child)
+	_check("resolve: bare / is the scene root, not the Window", sampler._resolve_node("/"), scene)
+	_check("resolve: /root/<scene> is the scene root", sampler._resolve_node("/root/FakeScene"), scene)
+	_check("resolve: absolute autoload path still wins", sampler._resolve_node("/root/FakeAutoload") != null, true)
+
+	current_scene = null
+	root.remove_child(scene)
+	scene.free()
+	_check("resolve: null current_scene + / degrades to null", sampler._resolve_node("/"), null)
+
+
+func _test_animation_tree(sampler: MCPRuntimeStateSampler) -> void:
+	# Built fully in code: AnimationTree is an AnimationMixer in 4.x, so it takes
+	# the library directly — no AnimationPlayer needed.
+	var lib := AnimationLibrary.new()
+	for anim_name in ["a", "b"]:
+		var anim := Animation.new()
+		anim.length = 0.05
+		lib.add_animation(anim_name, anim)
+
+	var sm := AnimationNodeStateMachine.new()
+	for state in ["a", "b"]:
+		var node := AnimationNodeAnimation.new()
+		node.animation = state
+		sm.add_node(state, node)
+	sm.add_transition("a", "b", AnimationNodeStateMachineTransition.new())
+
+	var at := AnimationTree.new()
+	at.tree_root = sm
+	root.add_child(at)
+	at.add_animation_library("", lib)
+	at.active = true
+	var playback = at.get("parameters/playback")
+	_check("animtree: state machine exposes playback",
+		playback is AnimationNodeStateMachinePlayback, true)
+
+	playback.start("a")
+	var t0 := Time.get_ticks_msec()
+	while str(sampler._read_field(at, "anim")) != "a" and Time.get_ticks_msec() - t0 < 1000:
+		await process_frame
+	_check("animtree: _read_field reads current state", sampler._read_field(at, "anim"), "a")
+	_check("animtree: value is a String (wire-stable)",
+		sampler._read_field(at, "anim") is String, true)
+
+	playback.travel("b")
+	t0 = Time.get_ticks_msec()
+	while str(sampler._read_field(at, "anim")) != "b" and Time.get_ticks_msec() - t0 < 1000:
+		await process_frame
+	_check("animtree: transition observed via the sampler read", sampler._read_field(at, "anim"), "b")
+
+	var blend := AnimationTree.new()
+	blend.tree_root = AnimationNodeBlendTree.new()
+	root.add_child(blend)
+	_check("animtree: BlendTree root yields null (documented silent skip)",
+		sampler._read_field(blend, "anim"), null)
+
+	root.remove_child(at)
+	at.free()
+	root.remove_child(blend)
+	blend.free()
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://i8pw46pj8wck

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -123,6 +123,15 @@ describe('runtimeState tool', () => {
         runtimeState.schema.safeParse({ action: 'watch_start', signals: [{ path: '/root/G' }] }).success
       ).toBe(false);
     });
+
+    it('rejects blank signal paths and names (blank entries would skew the drop detection)', () => {
+      expect(
+        runtimeState.schema.safeParse({ action: 'watch_start', signals: [{ path: '', signal: 'died' }] }).success
+      ).toBe(false);
+      expect(
+        runtimeState.schema.safeParse({ action: 'watch_start', signals: [{ path: '/root/G', signal: '' }] }).success
+      ).toBe(false);
+    });
   });
 
   // ── digest ───────────────────────────────────────────────────────────────
@@ -224,8 +233,8 @@ describe('runtimeState tool', () => {
   // ── watch_start ──────────────────────────────────────────────────────────
 
   describe('watch_start', () => {
-    it('calls watch_start with specs, hz, duration_ms and returns confirmation', async () => {
-      mock.mockResponse({ started: true });
+    it('calls watch_start with specs, hz, duration_ms and returns a structured confirmation', async () => {
+      mock.mockResponse({ started: true, resolved_fields: 2 });
       const ctx = createToolContext(mock);
 
       const result = await runtimeState.execute(
@@ -238,8 +247,11 @@ describe('runtimeState tool', () => {
         ctx
       );
 
-      expect(typeof result).toBe('string');
-      expect(result).toContain('500');
+      const data = structuredOf(result);
+      expect(data.started).toBe(true);
+      expect(data.note).toContain('500');
+      expect(data.resolved_fields).toBe(2);
+      expect(data.warnings).toEqual([]);
       expect(mock.calls[0].command).toBe('watch_start');
       expect(mock.calls[0].params.hz).toBe(30);
       expect(mock.calls[0].params.duration_ms).toBe(500);
@@ -277,7 +289,7 @@ describe('runtimeState tool', () => {
       expect(mock.calls[1].params.specs).toEqual([]);
     });
 
-    it('reports connected signal count in the confirmation text', async () => {
+    it('reports the connected signal count structurally', async () => {
       mock.mockResponse({ started: true, resolved_fields: 0, connected_signals: 2, unresolved_signals: [] });
       const ctx = createToolContext(mock);
 
@@ -291,10 +303,13 @@ describe('runtimeState tool', () => {
         },
         ctx
       );
-      expect(result).toContain('Connected 2 signal(s)');
+      const data = structuredOf(result);
+      expect(data.connected_signals).toBe(2);
+      expect(data.unresolved_signals).toEqual([]);
+      expect(data.warnings).toEqual([]);
     });
 
-    it('names unresolved signals with their reasons', async () => {
+    it('passes unresolved signals through structurally and names them in warnings', async () => {
       mock.mockResponse({
         started: true,
         resolved_fields: 0,
@@ -307,7 +322,9 @@ describe('runtimeState tool', () => {
         { action: 'watch_start', signals: [{ path: '/root/Bogus', signal: 'died' }] },
         ctx
       );
-      expect(result).toContain('/root/Bogus:died (node_not_found)');
+      const data = structuredOf(result);
+      expect(data.unresolved_signals).toEqual([{ path: '/root/Bogus', signal: 'died', reason: 'node_not_found' }]);
+      expect(data.warnings.some((w: string) => w.includes('/root/Bogus:died (node_not_found)'))).toBe(true);
     });
 
     it('does not warn about 0 fields on a signals-only watch', async () => {
@@ -318,7 +335,7 @@ describe('runtimeState tool', () => {
         { action: 'watch_start', signals: [{ path: '/root/G', signal: 'wave_started' }] },
         ctx
       );
-      expect(result).not.toContain('0 fields resolved');
+      expect(structuredOf(result).warnings).toEqual([]);
     });
 
     it('still warns when specs were requested but none resolved', async () => {
@@ -329,7 +346,67 @@ describe('runtimeState tool', () => {
         { action: 'watch_start', specs: [{ path: '/root/Nope', fields: ['pos.x'] }] },
         ctx
       );
-      expect(result).toContain('0 fields resolved');
+      expect(structuredOf(result).warnings.some((w: string) => w.includes('0 fields resolved'))).toBe(true);
+    });
+
+    it('detects an addon that predates the timeline (signals silently ignored)', async () => {
+      // Old game bridge: response has no connected_signals key at all.
+      mock.mockResponse({ started: true, resolved_fields: 1 });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        {
+          action: 'watch_start',
+          specs: [{ path: '/root/Player', fields: ['pos.x'] }],
+          signals: [{ path: '/root/G', signal: 'wave_started' }],
+        },
+        ctx
+      );
+      const data = structuredOf(result);
+      expect(data.warnings.some((w: string) => w.includes('update the godot-mcp addon'))).toBe(true);
+    });
+
+    it('detects a stale editor relay dropping signal specs in transit', async () => {
+      // New bridge (keys present) but fewer accounted-for signals than requested:
+      // the editor-loaded relay predates the 4th wire element.
+      mock.mockResponse({ started: true, resolved_fields: 0, connected_signals: 0, unresolved_signals: [] });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        {
+          action: 'watch_start',
+          signals: [
+            { path: '/root/G', signal: 'wave_started' },
+            { path: '/root/G', signal: 'score_changed' },
+          ],
+        },
+        ctx
+      );
+      const data = structuredOf(result);
+      expect(data.warnings.some((w: string) => w.includes('restart the Godot editor'))).toBe(true);
+    });
+
+    it('raises no skew warning when every requested signal is accounted for', async () => {
+      mock.mockResponse({
+        started: true,
+        resolved_fields: 0,
+        connected_signals: 1,
+        unresolved_signals: [{ path: '/root/Bogus', signal: 'nope', reason: 'node_not_found' }],
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        {
+          action: 'watch_start',
+          signals: [
+            { path: '/root/G', signal: 'wave_started' },
+            { path: '/root/Bogus', signal: 'nope' },
+          ],
+        },
+        ctx
+      );
+      const data = structuredOf(result);
+      expect(data.warnings.some((w: string) => w.includes('restart') || w.includes('update'))).toBe(false);
     });
   });
 

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -523,6 +523,21 @@ describe('buildTimeline', () => {
     ]);
   });
 
+  it('preserves emission order for same-millisecond signal bursts (stable sort)', () => {
+    const events = [
+      { t_ms: 100, source: '/root/G', signal: 'score_changed', args: '[111]' },
+      { t_ms: 100, source: '/root/G', signal: 'wave_changed', args: '[2]' },
+      { t_ms: 100, source: '/root/G', signal: 'score_changed', args: '[222]' },
+    ];
+    // An alphabetical tiebreak would reorder to score, score, wave and destroy
+    // the real emission order — buffer order must survive the sort.
+    expect(buildTimeline(events, {}).map((e) => (e.kind === 'signal' ? e.args : ''))).toEqual([
+      '[111]',
+      '[2]',
+      '[222]',
+    ]);
+  });
+
   it('ignores numeric field summaries entirely', () => {
     const fields = {
       '/root/P:vel.x': {

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -9,6 +9,7 @@ import {
   runtimeState,
   summarizeNumericField,
   summarizeStringField,
+  buildTimeline,
 } from '../../tools/runtime-state.js';
 
 describe('runtimeState tool', () => {
@@ -84,6 +85,43 @@ describe('runtimeState tool', () => {
     it('accepts watch_collect and watch_stop with no params', () => {
       expect(runtimeState.schema.safeParse({ action: 'watch_collect' }).success).toBe(true);
       expect(runtimeState.schema.safeParse({ action: 'watch_stop' }).success).toBe(true);
+    });
+
+    it('accepts a signals-only watch_start (no specs)', () => {
+      expect(
+        runtimeState.schema.safeParse({
+          action: 'watch_start',
+          signals: [{ path: '/root/G', signal: 'wave_started' }],
+        }).success
+      ).toBe(true);
+    });
+
+    it('accepts watch_start with both specs and signals', () => {
+      expect(
+        runtimeState.schema.safeParse({
+          action: 'watch_start',
+          specs: [{ path: '/root/Player', fields: ['pos.x'] }],
+          signals: [{ path: '/root/Player', signal: 'died' }],
+        }).success
+      ).toBe(true);
+    });
+
+    it('rejects watch_start with neither specs nor signals (incl. empty arrays)', () => {
+      expect(runtimeState.schema.safeParse({ action: 'watch_start' }).success).toBe(false);
+      expect(
+        runtimeState.schema.safeParse({ action: 'watch_start', specs: [], signals: [] }).success
+      ).toBe(false);
+    });
+
+    it('rejects more than 16 signals', () => {
+      const signals = Array.from({ length: 17 }, (_, i) => ({ path: `/root/E${i}`, signal: 'fired' }));
+      expect(runtimeState.schema.safeParse({ action: 'watch_start', signals }).success).toBe(false);
+    });
+
+    it('rejects a signal entry missing the signal name', () => {
+      expect(
+        runtimeState.schema.safeParse({ action: 'watch_start', signals: [{ path: '/root/G' }] }).success
+      ).toBe(false);
     });
   });
 
@@ -219,6 +257,80 @@ describe('runtimeState tool', () => {
       expect(mock.calls[0].params.hz).toBe(20);
       expect(mock.calls[0].params.duration_ms).toBe(1000);
     });
+
+    it('passes signals through and defaults them to [] when omitted', async () => {
+      mock.mockResponse({ started: true, resolved_fields: 1 });
+      const ctx = createToolContext(mock);
+
+      await runtimeState.execute(
+        { action: 'watch_start', specs: [{ path: '/root/Player', fields: ['pos.x'] }] },
+        ctx
+      );
+      expect(mock.calls[0].params.signals).toEqual([]);
+
+      mock.mockResponse({ started: true, connected_signals: 1, unresolved_signals: [] });
+      await runtimeState.execute(
+        { action: 'watch_start', signals: [{ path: '/root/G', signal: 'wave_started' }] },
+        ctx
+      );
+      expect(mock.calls[1].params.signals).toEqual([{ path: '/root/G', signal: 'wave_started' }]);
+      expect(mock.calls[1].params.specs).toEqual([]);
+    });
+
+    it('reports connected signal count in the confirmation text', async () => {
+      mock.mockResponse({ started: true, resolved_fields: 0, connected_signals: 2, unresolved_signals: [] });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        {
+          action: 'watch_start',
+          signals: [
+            { path: '/root/G', signal: 'wave_started' },
+            { path: '/root/Player', signal: 'died' },
+          ],
+        },
+        ctx
+      );
+      expect(result).toContain('Connected 2 signal(s)');
+    });
+
+    it('names unresolved signals with their reasons', async () => {
+      mock.mockResponse({
+        started: true,
+        resolved_fields: 0,
+        connected_signals: 0,
+        unresolved_signals: [{ path: '/root/Bogus', signal: 'died', reason: 'node_not_found' }],
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        { action: 'watch_start', signals: [{ path: '/root/Bogus', signal: 'died' }] },
+        ctx
+      );
+      expect(result).toContain('/root/Bogus:died (node_not_found)');
+    });
+
+    it('does not warn about 0 fields on a signals-only watch', async () => {
+      mock.mockResponse({ started: true, resolved_fields: 0, connected_signals: 1, unresolved_signals: [] });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        { action: 'watch_start', signals: [{ path: '/root/G', signal: 'wave_started' }] },
+        ctx
+      );
+      expect(result).not.toContain('0 fields resolved');
+    });
+
+    it('still warns when specs were requested but none resolved', async () => {
+      mock.mockResponse({ started: true, resolved_fields: 0 });
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute(
+        { action: 'watch_start', specs: [{ path: '/root/Nope', fields: ['pos.x'] }] },
+        ctx
+      );
+      expect(result).toContain('0 fields resolved');
+    });
   });
 
   // ── watch_collect ────────────────────────────────────────────────────────
@@ -277,6 +389,76 @@ describe('runtimeState tool', () => {
       expect(summary.changes).toHaveLength(1);
       expect(summary.changes[0]).toEqual({ t_ms: 350, from: 'idle', to: 'run' });
     });
+
+    it('merges signal events and string transitions into a time-sorted timeline', async () => {
+      const raw = {
+        window_ms: 1000,
+        sample_count: 4,
+        fields: {
+          '/root/Player:anim': [
+            { t_ms: 0, value: 'idle' },
+            { t_ms: 400, value: 'run' },
+          ],
+          '/root/Player:state': [
+            { t_ms: 0, value: 'alive' },
+            { t_ms: 900, value: 'dead' },
+          ],
+          // Numeric events (zero_cross here) must stay per-field only.
+          '/root/Player:vel.x': [
+            { t_ms: 0, value: 0 },
+            { t_ms: 600, value: 5 },
+          ],
+        },
+        events: [
+          { t_ms: 120, source: '/root/G', signal: 'wave_started', args: '[2]' },
+          { t_ms: 880, source: '/root/Player', signal: 'died' },
+        ],
+        events_truncated: false,
+      };
+      mock.mockResponse(raw);
+      const ctx = createToolContext(mock);
+
+      const result = await runtimeState.execute({ action: 'watch_collect' }, ctx);
+      const data = structuredOf(result);
+
+      expect(data.timeline.map((e: { kind: string; t_ms: number }) => [e.t_ms, e.kind])).toEqual([
+        [120, 'signal'],
+        [400, 'anim_transition'],
+        [880, 'signal'],
+        [900, 'field_change'],
+      ]);
+      expect(data.timeline[0].args).toBe('[2]');
+      expect(data.timeline[1]).toEqual({
+        t_ms: 400, kind: 'anim_transition', source: '/root/Player', from: 'idle', to: 'run',
+      });
+      expect(data.timeline[3].field).toBe('state');
+      expect(data.timeline_truncated).toBe(false);
+      // numeric zero_cross stayed per-field
+      expect(data.fields['/root/Player:vel.x'].events).toHaveLength(1);
+    });
+
+    it('keeps a stable shape against pre-timeline addons (no events key)', async () => {
+      mock.mockResponse({ window_ms: 500, sample_count: 0, fields: {} });
+      const ctx = createToolContext(mock);
+
+      const data = structuredOf(await runtimeState.execute({ action: 'watch_collect' }, ctx));
+      expect(data.timeline).toEqual([]);
+      expect(data.timeline_truncated).toBe(false);
+    });
+
+    it('surfaces event truncation as timeline_truncated', async () => {
+      mock.mockResponse({
+        window_ms: 500,
+        sample_count: 0,
+        fields: {},
+        events: [{ t_ms: 1, source: '/root/A', signal: 'spam' }],
+        events_truncated: true,
+      });
+      const ctx = createToolContext(mock);
+
+      const data = structuredOf(await runtimeState.execute({ action: 'watch_collect' }, ctx));
+      expect(data.timeline_truncated).toBe(true);
+    });
   });
 
   // ── watch_stop ───────────────────────────────────────────────────────────
@@ -304,6 +486,51 @@ describe('runtimeState tool', () => {
       expect(summary.end).toBe(200);
       expect(typeof summary.slope).toBe('number');
     });
+  });
+});
+
+// ── buildTimeline unit tests ─────────────────────────────────────────────────
+
+describe('buildTimeline', () => {
+  it('returns [] for no events and no fields', () => {
+    expect(buildTimeline([], {})).toEqual([]);
+  });
+
+  it('omits args when the event carries none', () => {
+    const [entry] = buildTimeline([{ t_ms: 5, source: '/root/A', signal: 'fired' }], {});
+    expect(entry).toEqual({ t_ms: 5, kind: 'signal', source: '/root/A', name: 'fired' });
+    expect('args' in entry).toBe(false);
+  });
+
+  it('splits field keys on the LAST colon (paths may contain colons)', () => {
+    const fields = {
+      '/root/Player:anim': { start: 'a', end: 'b', changes: [{ t_ms: 10, from: 'a', to: 'b' }] },
+    };
+    const [entry] = buildTimeline([], fields);
+    expect(entry).toEqual({ t_ms: 10, kind: 'anim_transition', source: '/root/Player', from: 'a', to: 'b' });
+  });
+
+  it('orders t_ms ties deterministically: signal < anim_transition < field_change', () => {
+    const fields = {
+      '/root/P:state': { start: 'x', end: 'y', changes: [{ t_ms: 100, from: 'x', to: 'y' }] },
+      '/root/P:anim': { start: 'a', end: 'b', changes: [{ t_ms: 100, from: 'a', to: 'b' }] },
+    };
+    const events = [{ t_ms: 100, source: '/root/P', signal: 'tick' }];
+    expect(buildTimeline(events, fields).map((e) => e.kind)).toEqual([
+      'signal',
+      'anim_transition',
+      'field_change',
+    ]);
+  });
+
+  it('ignores numeric field summaries entirely', () => {
+    const fields = {
+      '/root/P:vel.x': {
+        start: 0, end: 5, min: 0, max: 5, mean: 2.5, slope: 5,
+        events: [{ t_ms: 50, from: 0, to: 5, kind: 'zero_cross' as const }],
+      },
+    };
+    expect(buildTimeline([], fields)).toEqual([]);
   });
 });
 

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -40,10 +40,20 @@ interface WatchRawSample {
   value: number | string;
 }
 
+interface WatchRawEvent {
+  t_ms: number;
+  source: string;
+  signal: string;
+  args?: string;
+}
+
 interface WatchRawResponse {
   window_ms: number;
   sample_count: number;
   fields: Record<string, WatchRawSample[]>;
+  // Absent from pre-timeline addon versions.
+  events?: WatchRawEvent[];
+  events_truncated?: boolean;
 }
 
 // ── Server-side summarization helpers ───────────────────────────────────────
@@ -124,6 +134,77 @@ function summarizeWatchRaw(raw: WatchRawResponse): Record<string, NumericFieldSu
       : summarizeStringField(samples);
   }
   return result;
+}
+
+export type TimelineEntry =
+  | { t_ms: number; kind: 'signal'; source: string; name: string; args?: string }
+  | { t_ms: number; kind: 'anim_transition'; source: string; from: string; to: string }
+  | { t_ms: number; kind: 'field_change'; source: string; field: string; from: string; to: string };
+
+const TIMELINE_KIND_RANK: Record<TimelineEntry['kind'], number> = {
+  // Signal timestamps are exact emission times; sampled transitions are
+  // detected at sample time — exact events lead on t_ms ties.
+  signal: 0,
+  anim_transition: 1,
+  field_change: 2,
+};
+
+export function buildTimeline(
+  events: WatchRawEvent[],
+  fields: Record<string, NumericFieldSummary | StringFieldSummary>
+): TimelineEntry[] {
+  const timeline: TimelineEntry[] = [];
+
+  for (const e of events) {
+    timeline.push({
+      t_ms: e.t_ms,
+      kind: 'signal',
+      source: e.source,
+      name: e.signal,
+      ...(e.args !== undefined && { args: e.args }),
+    });
+  }
+
+  for (const [key, summary] of Object.entries(fields)) {
+    if (!('changes' in summary)) continue; // numeric events stay per-field only
+    // full_key is node_path + ":" + field_key; lastIndexOf guards colons in paths.
+    const sep = key.lastIndexOf(':');
+    const source = sep >= 0 ? key.slice(0, sep) : key;
+    const field = sep >= 0 ? key.slice(sep + 1) : key;
+    for (const change of summary.changes) {
+      timeline.push(
+        field === 'anim'
+          ? { t_ms: change.t_ms, kind: 'anim_transition', source, from: change.from, to: change.to }
+          : { t_ms: change.t_ms, kind: 'field_change', source, field, from: change.from, to: change.to }
+      );
+    }
+  }
+
+  timeline.sort((a, b) => {
+    if (a.t_ms !== b.t_ms) return a.t_ms - b.t_ms;
+    if (TIMELINE_KIND_RANK[a.kind] !== TIMELINE_KIND_RANK[b.kind]) {
+      return TIMELINE_KIND_RANK[a.kind] - TIMELINE_KIND_RANK[b.kind];
+    }
+    if (a.source !== b.source) return a.source < b.source ? -1 : 1;
+    const aLabel = a.kind === 'signal' ? a.name : a.kind === 'field_change' ? a.field : '';
+    const bLabel = b.kind === 'signal' ? b.name : b.kind === 'field_change' ? b.field : '';
+    return aLabel < bLabel ? -1 : aLabel > bLabel ? 1 : 0;
+  });
+
+  return timeline;
+}
+
+function summarizeWatchResponse(raw: WatchRawResponse) {
+  const fields = summarizeWatchRaw(raw);
+  return structured({
+    window_ms: raw.window_ms,
+    sample_count: raw.sample_count,
+    fields,
+    // Always present (empty array included) so the shape is stable for
+    // structured readers; `?? []` degrades gracefully against older addons.
+    timeline: buildTimeline(raw.events ?? [], fields),
+    timeline_truncated: raw.events_truncated ?? false,
+  });
 }
 
 // ── Schema ───────────────────────────────────────────────────────────────────
@@ -208,7 +289,29 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
             .describe('Field keys to sample (e.g. ["pos.x", "vel.x", "health"])'),
         })
       )
-      .describe('Which nodes and fields to watch'),
+      .optional()
+      .describe('Which nodes and fields to watch. Optional when signals is provided.'),
+    signals: z
+      .array(
+        z.object({
+          path: z
+            .string()
+            .describe('Node path; absolute /root/... paths reach autoloads (e.g. "/root/G")'),
+          signal: z
+            .string()
+            .describe('Signal name on that node — script or built-in (e.g. "body_entered")'),
+        })
+      )
+      .max(16)
+      .optional()
+      .describe(
+        'Signals to record as discrete timeline events during the window. Each emission is ' +
+        'buffered as {t_ms, source, signal, args} (max 200 events/window, then truncated with a ' +
+        'flag; args stringified to ~100 chars). watch_collect merges these with string-field ' +
+        'transitions into a time-sorted `timeline`. Signals with more than 5 parameters are ' +
+        'skipped and reported in unresolved_signals, as are bad paths/names. Connections stay ' +
+        'live until duration_ms elapses or watch_stop.'
+      ),
     hz: z
       .number()
       .int()
@@ -223,22 +326,27 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
       .max(5000)
       .optional()
       .describe('Auto-stop after this many milliseconds (default: 1000)'),
+  }).refine((v) => (v.specs?.length ?? 0) > 0 || (v.signals?.length ?? 0) > 0, {
+    message: 'watch_start requires at least one of specs or signals',
   }),
   z.object({
     action: z
       .literal('watch_collect')
       .describe(
-        'Collect the current sampler buffer and return a per-field summary: ' +
-        'start/end/min/max/mean/slope for numeric fields; transition events for string fields. ' +
-        'Safe to call before auto-stop — returns whatever has been sampled so far.'
+        'Collect the current sampler buffer and return a per-field summary ' +
+        '(start/end/min/max/mean/slope for numeric fields; transition events for string fields) ' +
+        'plus a time-sorted `timeline` merging watched signal emissions with string-field ' +
+        'transitions (kinds: signal, anim_transition, field_change). ' +
+        'Safe to call before auto-stop — returns whatever has been recorded so far; ' +
+        'signal connections stay live until the window ends.'
       ),
   }),
   z.object({
     action: z
       .literal('watch_stop')
       .describe(
-        'Stop the sampler early and return the final per-field summary. ' +
-        'Equivalent to watch_collect + stopping the sampler.'
+        'Stop the sampler early (disconnecting watched signals) and return the final ' +
+        'per-field summary and merged `timeline`. Equivalent to watch_collect + stopping the sampler.'
       ),
   }),
 ]);
@@ -278,28 +386,42 @@ export const runtimeState = defineTool({
       }
 
       case 'watch_start': {
-        const watchResult = await godot.sendCommand<{ started: boolean; resolved_fields?: number }>('watch_start', {
-          specs: args.specs,
+        const watchResult = await godot.sendCommand<{
+          started: boolean;
+          resolved_fields?: number;
+          connected_signals?: number;
+          unresolved_signals?: Array<{ path: string; signal: string; reason: string }>;
+        }>('watch_start', {
+          specs: args.specs ?? [],
           hz: args.hz ?? 20,
           duration_ms: args.duration_ms ?? 1000,
+          signals: args.signals ?? [],
         });
-        const base = `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`;
-        if ((watchResult.resolved_fields ?? 1) === 0) {
-          return base + ' Warning: 0 fields resolved — verify that all node paths in specs exist in the running scene.';
+        const wantFields = (args.specs?.length ?? 0) > 0;
+        const wantSignals = (args.signals?.length ?? 0) > 0;
+        let msg = `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`;
+        if (wantFields) {
+          msg += (watchResult.resolved_fields ?? 0) === 0
+            ? ' Warning: 0 fields resolved — verify that all node paths in specs exist in the running scene.'
+            : ` Tracking ${watchResult.resolved_fields} field(s).`;
         }
-        return `${base} Tracking ${watchResult.resolved_fields} field(s).`;
+        if (wantSignals) {
+          msg += ` Connected ${watchResult.connected_signals ?? 0} signal(s).`;
+          const unresolved = watchResult.unresolved_signals ?? [];
+          if (unresolved.length > 0) {
+            const named = unresolved.map((u) => `${u.path}:${u.signal} (${u.reason})`).join(', ');
+            msg += ` Warning: unresolved signals: ${named}.`;
+          }
+        }
+        return msg;
       }
 
       case 'watch_collect': {
-        const raw = await godot.sendCommand<WatchRawResponse>('watch_collect');
-        const fields = summarizeWatchRaw(raw);
-        return structured({ window_ms: raw.window_ms, sample_count: raw.sample_count, fields });
+        return summarizeWatchResponse(await godot.sendCommand<WatchRawResponse>('watch_collect'));
       }
 
       case 'watch_stop': {
-        const raw = await godot.sendCommand<WatchRawResponse>('watch_stop');
-        const fields = summarizeWatchRaw(raw);
-        return structured({ window_ms: raw.window_ms, sample_count: raw.sample_count, fields });
+        return summarizeWatchResponse(await godot.sendCommand<WatchRawResponse>('watch_stop'));
       }
     }
   },

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -180,15 +180,13 @@ export function buildTimeline(
     }
   }
 
+  // No further tiebreakers on purpose: sort() is spec-stable (ES2019), so
+  // same-t_ms same-kind entries keep buffer order — which for signals IS
+  // emission order, real information a name/source tiebreak would destroy
+  // (sub-ms bursts land on one t_ms).
   timeline.sort((a, b) => {
     if (a.t_ms !== b.t_ms) return a.t_ms - b.t_ms;
-    if (TIMELINE_KIND_RANK[a.kind] !== TIMELINE_KIND_RANK[b.kind]) {
-      return TIMELINE_KIND_RANK[a.kind] - TIMELINE_KIND_RANK[b.kind];
-    }
-    if (a.source !== b.source) return a.source < b.source ? -1 : 1;
-    const aLabel = a.kind === 'signal' ? a.name : a.kind === 'field_change' ? a.field : '';
-    const bLabel = b.kind === 'signal' ? b.name : b.kind === 'field_change' ? b.field : '';
-    return aLabel < bLabel ? -1 : aLabel > bLabel ? 1 : 0;
+    return TIMELINE_KIND_RANK[a.kind] - TIMELINE_KIND_RANK[b.kind];
   });
 
   return timeline;

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -142,8 +142,10 @@ export type TimelineEntry =
   | { t_ms: number; kind: 'field_change'; source: string; field: string; from: string; to: string };
 
 const TIMELINE_KIND_RANK: Record<TimelineEntry['kind'], number> = {
-  // Signal timestamps are exact emission times; sampled transitions are
-  // detected at sample time — exact events lead on t_ms ties.
+  // PRESENTATION order for same-t_ms entries, not chronology: cross-kind order
+  // at a tie is unknowable (signal t_ms is emission time, sampled t_ms is
+  // detection time — the change may have happened earlier). Any fixed choice
+  // is fine; what matters is determinism.
   signal: 0,
   anim_transition: 1,
   field_change: 2,
@@ -294,9 +296,11 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         z.object({
           path: z
             .string()
+            .min(1)
             .describe('Node path; absolute /root/... paths reach autoloads (e.g. "/root/G")'),
           signal: z
             .string()
+            .min(1)
             .describe('Signal name on that node — script or built-in (e.g. "body_entered")'),
         })
       )
@@ -308,7 +312,9 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'flag; args stringified to ~100 chars). watch_collect merges these with string-field ' +
         'transitions into a time-sorted `timeline`. Signals with more than 5 parameters are ' +
         'skipped and reported in unresolved_signals, as are bad paths/names. Connections stay ' +
-        'live until duration_ms elapses or watch_stop.'
+        'live until duration_ms elapses or watch_stop. Signals must be emitted on the main ' +
+        'thread (worker-thread emissions are unsupported). At least one of specs/signals is ' +
+        'required.'
       ),
     hz: z
       .number()
@@ -334,7 +340,10 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'Collect the current sampler buffer and return a per-field summary ' +
         '(start/end/min/max/mean/slope for numeric fields; transition events for string fields) ' +
         'plus a time-sorted `timeline` merging watched signal emissions with string-field ' +
-        'transitions (kinds: signal, anim_transition, field_change). ' +
+        'transitions (kinds: signal, anim_transition, field_change). TIMESTAMPS: signal t_ms is ' +
+        'emission time (ms resolution); anim/field t_ms is DETECTION time at the sample rate — ' +
+        'the change happened up to one sample interval earlier, so do not infer cross-kind ' +
+        'ordering from nearby timestamps. ' +
         'Safe to call before auto-stop — returns whatever has been recorded so far; ' +
         'signal connections stay live until the window ends.'
       ),
@@ -396,22 +405,42 @@ export const runtimeState = defineTool({
           signals: args.signals ?? [],
         });
         const wantFields = (args.specs?.length ?? 0) > 0;
-        const wantSignals = (args.signals?.length ?? 0) > 0;
-        let msg = `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`;
-        if (wantFields) {
-          msg += (watchResult.resolved_fields ?? 0) === 0
-            ? ' Warning: 0 fields resolved — verify that all node paths in specs exist in the running scene.'
-            : ` Tracking ${watchResult.resolved_fields} field(s).`;
+        const requestedSignals = args.signals?.length ?? 0;
+        const unresolved = watchResult.unresolved_signals ?? [];
+        const warnings: string[] = [];
+        if (wantFields && (watchResult.resolved_fields ?? 0) === 0) {
+          warnings.push('0 fields resolved — verify that all node paths in specs exist in the running scene.');
         }
-        if (wantSignals) {
-          msg += ` Connected ${watchResult.connected_signals ?? 0} signal(s).`;
-          const unresolved = watchResult.unresolved_signals ?? [];
+        if (requestedSignals > 0) {
+          // Version-skew detection: without it, dropped signal specs read as
+          // "Connected 0 signal(s)" + an empty timeline, and the agent
+          // concludes the signals never fired — a confident lie about game
+          // behavior. Both stale layers are precisely distinguishable here.
+          if (watchResult.connected_signals === undefined) {
+            warnings.push(
+              'signals were IGNORED: the running addon predates the signal timeline feature — update the godot-mcp addon.'
+            );
+          } else if (watchResult.connected_signals + unresolved.length < requestedSignals) {
+            warnings.push(
+              `${requestedSignals - watchResult.connected_signals - unresolved.length} signal spec(s) were dropped in ` +
+              'transit: the addon on disk is newer than what the editor has loaded — restart the Godot editor.'
+            );
+          }
           if (unresolved.length > 0) {
-            const named = unresolved.map((u) => `${u.path}:${u.signal} (${u.reason})`).join(', ');
-            msg += ` Warning: unresolved signals: ${named}.`;
+            warnings.push(`unresolved signals: ${unresolved.map((u) => `${u.path}:${u.signal} (${u.reason})`).join(', ')}.`);
           }
         }
-        return msg;
+        // Structured with a stable shape (unresolved_signals/warnings always
+        // arrays): an agent must branch on unresolved reasons to retry
+        // correctly, which prose can't carry reliably.
+        return structured({
+          started: watchResult.started,
+          note: `Sampler started. Call watch_collect after ~${args.duration_ms ?? 1000}ms to get results.`,
+          resolved_fields: watchResult.resolved_fields ?? 0,
+          connected_signals: watchResult.connected_signals ?? 0,
+          unresolved_signals: unresolved,
+          warnings,
+        });
       }
 
       case 'watch_collect': {


### PR DESCRIPTION
Closes #198 (perception spike #191, Direction 4 / Phase 3).

## What

`runtime_state watch_start` gains an opt-in `signals: [{path, signal}]` allowlist. The in-game sampler connects to those signals for the watch window and buffers `{t_ms, source, signal, args}` per emission; `watch_collect`/`watch_stop` now return a merged, time-sorted `timeline` alongside the per-field summaries, answering "what discrete things happened, and in what order" — the question a 20Hz sampler structurally cannot (one-frame events fall between samples, and signals are the game's own semantic vocabulary).

Timeline kinds: `signal` (emission-time stamps, ms resolution), `anim_transition` (string changes on the `anim` field), `field_change` (any other string field, so `_mcp_state()` state machines ride along). Numeric `sign_change`/`zero_cross` events stay per-field. The bridge stays thin (raw event buffer); the merge/sort lives server-side per the repo's pre-processing split.

## Design points

- **Guards:** 16 connections per watch, 200 events per window with an honest `timeline_truncated` flag, args stringified at record time (~100 chars) so no object refs are held. The recorder only appends to an array — safe inside main-thread physics callbacks (worker-thread emission is a documented limitation). Bad paths/names, duplicates (by resolved node instance, so alias spellings cannot double-connect), and >5-parameter signals are skipped and reported by reason in `unresolved_signals`.
- **Lifecycle:** connections live for the whole window — mid-window `watch_collect` does not disconnect; auto-stop, `watch_stop`, restart, and `_exit_tree` all tear down. Freed emitters are handled (Godot drops their connections; teardown guards the dead entries).
- **Arity:** `connect()` requires a matching Callable arity, so the recorder dispatches per-arity lambdas (0-5 args) using the count from `get_signal_list()` — built-in signals work the same as script signals.
- **Version-skew detection:** the worst real-world misconfiguration (addon updated on disk, editor not restarted) silently drops signal specs at the stale relay — and the disk-read version handshake cannot see it. watch_start now distinguishes both stale layers from data already in hand: a missing `connected_signals` key means the addon predates the feature ("update the addon"); fewer accounted-for signals than requested means a stale relay ("restart the editor"). Without this the tool would confidently report "Connected 0 signal(s)" + an empty timeline and the agent would conclude the signals never fired.
- **Resolver fix (enabling work):** the sampler's `_resolve_node` now resolves absolute `/root/*` paths independently of `current_scene`, so autoload signals AND autoload fields (e.g. `/root/G:score` over time) are watchable — game-state signals overwhelmingly live on autoloads. Existing relative/scene-name behavior is preserved.
- **AnimationTree:** the `anim` field now reads state-machine state via `parameters/playback`, per the issue's acceptance criteria (non-state-machine roots silently yield nothing, matching the other inapplicable-field arms).
- **Wire compat:** `signals` is an optional 4th positional element of the watch_start message; every old/new addon-server pairing degrades gracefully, and the two lying cells are detected (above).

## Deliberate deviations from the issue text

- The issue sketches a "ring buffer"; this ships cap-and-keep-FIRST-200 with an explicit truncation flag (the issue's own guard wording: "cap events per window and drop with a truncated marker"). Keep-earliest vs keep-latest is a real semantic choice — follow-up issue tracks ring/fairness semantics.
- The issue's `MAX_SIGNAL_CONNECTIONS = 200` was an analogy to the existing enumeration cap for the EVENT budget — `MAX_EVENTS = 200` matches it exactly. The CONNECTION cap is a new, stricter `MAX_SIGNALS = 16`, sized for an explicit opt-in allowlist.

## Bugs found while building (all fixed and pinned by tests)

- Assigning a freed instance to a typed `var node: Node` is itself a script error in Godot 4 — it aborted the sampler's freed-node handling before `is_instance_valid` ever ran (pre-existing in the `_process` sampling pass; caught by the new headless test).
- Sub-millisecond signal bursts land on one `t_ms`; an alphabetical tiebreaker destroyed real emission order (caught live). Sort is spec-stable, so buffer order — which IS emission order — survives with the t_ms + kind comparator alone.
- `stop()` after auto-stop clobbered the window timestamp, inflating `window_ms` to the call time (615 reported for a 100ms window; caught live, proven by probe).
- Alias-spelled duplicate signal specs double-connected and recorded 4 events for 2 emissions (proven by adversarial probe); dedupe now keys on the resolved instance.

## Adversarial review

Beyond unit/headless tests, the sampler was probed empirically with throwaway headless scripts: reentrant emission chains (a watched handler emitting another watched signal), emitters freeing themselves mid-emission, freed Objects as signal arguments, 300-emission cap floods, start()-from-inside-a-handler, and path-resolution edges — all clean or engine-attributed. A design review traced the full server/relay/bridge skew matrix (result: the detection above), API honesty (structured watch_start; detection-time vs emission-time caveats now in the tool description and guide), and thread-safety stance (CONNECT_DEFERRED rejected deliberately: it would quantize t_ms to frame boundaries, destroying the feature's differentiator; main-thread emission documented instead).

## Tests

- `watch_timeline_headless_test.gd` (new, 61 checks): arities/args, caps + truncation reset, window semantics (collect keeps connections, stop/auto-stop/restart tear down, window_ms honesty under late stop), freed emitter + freed field node, alias dedupe, unresolved reporting incl. the connection cap, absolute-path field resolution with `current_scene == null`, resolution preservation, AnimationTree state read + travel transition + BlendTree null.
- vitest: 330 passing (schema refine incl. signals-only watches and blank-entry rejection, structured watch_start shape, both skew detections + the no-false-positive case, timeline merge/tie-ordering/truncation, old-addon compat, `buildTimeline` units incl. emission-order stability).
- Live on NEON RAMPAGE: raw bridge protocol (18/18: frozen launch -> `godot_exec` emitting `G` autoload signals deterministically -> order/args/sources, mid-window collect kept connections, stop disconnected, 250 emissions truncated to 200 with the flag, signals-only watch, bogus path reported `node_not_found`) plus an end-to-end pass through the real MCP server returning the merged timeline.