### PR TITLE
feat: joypad button, axis, and stick injection for input sequences and game-time steps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ This server provides **14 tools** and **3 resources** for AI-assisted Godot deve
 | [Resource](tools/resource.md) | 1 | Resource inspection tools for SpriteFrames, TileSet, Materials, etc. |
 | [Scene3D](tools/scene3d.md) | 1 | 3D spatial information and bounding box tools |
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |
-| [Input](tools/input.md) | 1 | Input injection for testing running games (action-based, no mouse/coordinates yet) |
+| [Input](tools/input.md) | 1 | Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input) |
 | [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
 | [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots. |
 | [Game Script Execution](tools/exec.md) | 1 | Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard. |

--- a/docs/design/mouse-input-spike.md
+++ b/docs/design/mouse-input-spike.md
@@ -148,6 +148,17 @@ state to confirm an effect by state-delta.
   problem (actions are state, not coordinates). For "drive my game to test it,"
   this already covers a large fraction of the need — and is the right place to
   invest the energy this decision frees up.
+- **Controller/analog injection shipped after this decision (#233).** Joypad
+  buttons, analog axes, and stick vectors inject through the same `sequence`
+  timing model — and unlike the mouse cursor, injected joypad events DO drive
+  the polled Input singletons (`get_joy_axis` / `is_joy_button_pressed`), so
+  the gamepad-native genres in the matrix below (platformer, fighting, racing,
+  sports, twin-stick) are fully drivable, analog included. One bounded
+  exception, same in spirit to the polled-cursor ceiling but far narrower:
+  `Input.joy_connection_changed` is not script-bindable, so
+  `get_connected_joypads()` never reports a virtual pad — a game that gates
+  controller mode on pad *detection* cannot be switched into it (games keying
+  off received joypad events or InputMap actions, the common patterns, work).
 - **A real bug fix ships.** The investigation found that
   `MCPGameBridge.execute_input_sequence` dropped unfired action *releases* when it
   cleared its queue mid-flight, latching the action "pressed" forever. Fixed and

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -59,9 +59,9 @@ Fetch Godot Engine documentation with smart extraction
 
 ## [Input](input.md)
 
-Input injection for testing running games (action-based, no mouse/coordinates yet)
+Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input)
 
-- `godot_input` - Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.
+- `godot_input` - Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, and stick vectors. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).
 
 ## [Profiler](profiler.md)
 

--- a/docs/tools/input.md
+++ b/docs/tools/input.md
@@ -1,6 +1,6 @@
 # Input Tools
 
-Input injection for testing running games (action-based, no mouse/coordinates yet)
+Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input)
 
 ## Tools
 
@@ -10,14 +10,14 @@ Input injection for testing running games (action-based, no mouse/coordinates ye
 
 ## godot_input
 
-Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.
+Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, and stick vectors. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | `get_map`, `sequence`, `type_text` | Yes |  |
-| `inputs` | object[] | No | Array of inputs to execute |
+| `inputs` | array | No | Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), or a STICK vector (stick + x/y) — mix freely on one timeline. Joypad events drive bound actions (with real deadzone math), raw _input handlers, and the polled Input singletons (get_joy_axis / is_joy_button_pressed); no physical pad is needed. Limitation: Input.get_connected_joypads() never reports a virtual pad, so games that gate controller mode on pad DETECTION cannot be switched into it. |
 | `report` | string[] | No | Optional effect probe: GDScript expressions evaluated once before the first input and again after the last, to prove the inputs actually changed something (vs. falling into the void — player dead, UI focus elsewhere, wrong action). Reference autoloads by name (e.g. "G.shots", "G.wave") plus `tree`/`root` (e.g. "tree.get_nodes_in_group('enemies').size()"), same context as godot_game_time step_until. Each expression returns {before, after, changed}; the result also carries any_changed. Expressions do NOT short-circuit and a parse/eval error rejects the call. The after-reading is sampled a couple frames past the final input, so only near-immediate effects register — for slower effects use godot_game_time or runtime_state watch. |
 | `screenshot_at_ms` | integer[] | No | Optional: millisecond offsets (from sequence start) at which to capture a lossless PNG frame DURING the real-time run. The bridge owns the sequence clock, so it grabs each frame at the right moment and returns them with the result — letting you catch transient visuals (muzzle flashes, explosions, kill banners) that fade long before a separate screenshot call could land. Up to 8 frames, each returned as an image labeled with its actual offset; an offset (like the whole sequence) must fall within the 40000ms single-call window. COST: each frame costs vision tokens by RESOLUTION (~width*height/750), independent of format, and persists in context on every following turn — so prefer a few frames at a modest screenshot_max_width over many large ones. For frozen/precise inspection prefer godot_game_time step + screenshot_game instead. |
 | `screenshot_max_width` | integer | No | Max width in px for captured frames (default 640). Resolution is the real vision-token lever (cost ~width*height/750 per frame); lower it to spend less context, raise it only when fine detail matters. |

--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -137,10 +137,12 @@ func _event_to_string(event: InputEvent) -> String:
 				return "Mouse Button %d" % mouse_event.button_index
 	elif event is InputEventJoypadButton:
 		var joy_event := event as InputEventJoypadButton
-		return "Joypad Button %d" % joy_event.button_index
+		return "Joypad Button %d (%s)" % [joy_event.button_index, MCPJoyNames.button_name(joy_event.button_index)]
 	elif event is InputEventJoypadMotion:
+		# The signed axis_value is the direction bit an agent needs to lift the
+		# binding straight into an injection (e.g. move_left = left_x, value -1.0).
 		var joy_motion := event as InputEventJoypadMotion
-		return "Joypad Axis %d" % joy_motion.axis
+		return "Joypad Axis %d (%s, value %+.1f)" % [joy_motion.axis, MCPJoyNames.axis_name(joy_motion.axis), joy_motion.axis_value]
 	return event.as_text()
 
 

--- a/godot/addons/godot_mcp/game_bridge/joy_names.gd
+++ b/godot/addons/godot_mcp/game_bridge/joy_names.gd
@@ -1,0 +1,68 @@
+@tool
+class_name MCPJoyNames
+extends RefCounted
+## Canonical joypad name<->index tables, shared by the game bridge (event
+## injection) and the editor input commands (get_input_map display) so the
+## wire vocabulary and the displayed names can never drift apart.
+
+const BUTTONS := {
+	"a": JOY_BUTTON_A,
+	"b": JOY_BUTTON_B,
+	"x": JOY_BUTTON_X,
+	"y": JOY_BUTTON_Y,
+	"back": JOY_BUTTON_BACK,
+	"guide": JOY_BUTTON_GUIDE,
+	"start": JOY_BUTTON_START,
+	"left_stick": JOY_BUTTON_LEFT_STICK,
+	"right_stick": JOY_BUTTON_RIGHT_STICK,
+	"left_shoulder": JOY_BUTTON_LEFT_SHOULDER,
+	"right_shoulder": JOY_BUTTON_RIGHT_SHOULDER,
+	"dpad_up": JOY_BUTTON_DPAD_UP,
+	"dpad_down": JOY_BUTTON_DPAD_DOWN,
+	"dpad_left": JOY_BUTTON_DPAD_LEFT,
+	"dpad_right": JOY_BUTTON_DPAD_RIGHT,
+	"misc1": JOY_BUTTON_MISC1,
+	"paddle1": JOY_BUTTON_PADDLE1,
+	"paddle2": JOY_BUTTON_PADDLE2,
+	"paddle3": JOY_BUTTON_PADDLE3,
+	"paddle4": JOY_BUTTON_PADDLE4,
+	"touchpad": JOY_BUTTON_TOUCHPAD,
+}
+
+const AXES := {
+	"left_x": JOY_AXIS_LEFT_X,
+	"left_y": JOY_AXIS_LEFT_Y,
+	"right_x": JOY_AXIS_RIGHT_X,
+	"right_y": JOY_AXIS_RIGHT_Y,
+	"trigger_left": JOY_AXIS_TRIGGER_LEFT,
+	"trigger_right": JOY_AXIS_TRIGGER_RIGHT,
+}
+
+
+## Resolve a wire value (name string, or raw index as an escape hatch) to a
+## JoyButton index. Returns -1 for anything unknown.
+static func button_index(value: Variant) -> int:
+	if value is int or value is float:
+		var i := int(value)
+		return i if i >= 0 and i < JOY_BUTTON_SDL_MAX else -1
+	return int(BUTTONS.get(str(value), -1))
+
+
+## Resolve a wire axis name to a JoyAxis index. Names only — the name itself
+## is what tells an agent trigger (0..1) from stick (-1..1). Returns -1 if unknown.
+static func axis_index(value: Variant) -> int:
+	return int(AXES.get(str(value), -1))
+
+
+static func button_name(idx: int) -> String:
+	for n in BUTTONS:
+		if int(BUTTONS[n]) == idx:
+			return n
+	return "button_%d" % idx
+
+
+static func axis_name(idx: int) -> String:
+	for n in AXES:
+		if int(AXES[n]) == idx:
+			return n
+	return "axis_%d" % idx

--- a/godot/addons/godot_mcp/game_bridge/joy_names.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/joy_names.gd.uid
@@ -1,0 +1,1 @@
+uid://row4hmo5gdem

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1203,6 +1203,11 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	var screenshot_offsets: Array = data[2] if data.size() > 2 and data[2] is Array else []
 	var cap_max_width: int = int(data[3]) if data.size() > 3 else 640
 
+	# Reset the skew echo up front: the result's input_kinds must reflect THIS
+	# call's compile, never a stale value from a prior sequence (its absence is
+	# how a new server detects an old bridge — a stale dict would mask that).
+	_sequence_input_kinds = {"action": 0, "joy_button": 0, "axis": 0}
+
 	if inputs.is_empty():
 		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
 			"error": "No inputs provided",
@@ -1515,6 +1520,10 @@ func _handle_game_time_step(data: Array) -> void:
 		_send_game_time_response("game_time_step", {"error": "Step already in progress"})
 		return
 
+	# Reset the skew echo up front (see _handle_execute_input_sequence): the
+	# step result's input_kinds must reflect this call, never a prior step's.
+	_step_input_kinds = {"action": 0, "joy_button": 0, "axis": 0}
+
 	var duration_ms: int = int(params.get("duration_ms", 0))
 	var frames: int = int(params.get("frames", 0))
 	if duration_ms <= 0 and frames <= 0:
@@ -1580,6 +1589,12 @@ func _compile_input_events(inputs: Array) -> Dictionary:
 	for input in inputs:
 		var start_ms: int = int(input.get("start_ms", 0))
 		var dur: int = int(input.get("duration_ms", 0))
+		# An instant tap (duration 0 — the schema default) must still emit its end
+		# event STRICTLY AFTER its start, or the equal-time (time, phase) sort below
+		# orders the release/zero-set before the press/set and the input latches
+		# (press never paired with a release). One ms is enough: the time sort then
+		# fires start-before-end even when both land in the same process frame.
+		var end_ms: int = start_ms + maxi(dur, 1)
 		if input.has("axis"):
 			var axis := MCPJoyNames.axis_index(input["axis"])
 			if axis < 0:
@@ -1589,7 +1604,7 @@ func _compile_input_events(inputs: Array) -> Dictionary:
 			kinds["axis"] += 1
 			events.append({"time": start_ms, "phase": 1, "complete": 0,
 				"kind": "axis", "axis": axis, "device": device, "value": value})
-			events.append({"time": start_ms + dur, "phase": 0, "complete": 1,
+			events.append({"time": end_ms, "phase": 0, "complete": 1,
 				"kind": "axis", "axis": axis, "device": device, "value": 0.0})
 		elif input.has("joy_button"):
 			var button := MCPJoyNames.button_index(input["joy_button"])
@@ -1599,7 +1614,7 @@ func _compile_input_events(inputs: Array) -> Dictionary:
 			kinds["joy_button"] += 1
 			events.append({"time": start_ms, "phase": 1, "complete": 0,
 				"kind": "joy_button", "button": button, "device": bdevice, "is_press": true})
-			events.append({"time": start_ms + dur, "phase": 0, "complete": 1,
+			events.append({"time": end_ms, "phase": 0, "complete": 1,
 				"kind": "joy_button", "button": button, "device": bdevice, "is_press": false})
 		else:
 			var action_name: String = input.get("action_name", "")
@@ -1611,7 +1626,7 @@ func _compile_input_events(inputs: Array) -> Dictionary:
 			kinds["action"] += 1
 			events.append({"time": start_ms, "phase": 1, "complete": 0,
 				"kind": "action", "action": action_name, "strength": strength, "is_press": true})
-			events.append({"time": start_ms + dur, "phase": 0, "complete": 1,
+			events.append({"time": end_ms, "phase": 0, "complete": 1,
 				"kind": "action", "action": action_name, "strength": strength, "is_press": false})
 	# Releases/zero-sets fire before presses/sets at equal time, so a same-time
 	# axis zero can never clobber a follow-on set of the same axis.
@@ -1767,6 +1782,9 @@ func _handle_game_time_step_until(data: Array) -> void:
 	if _step_active:
 		_send_game_time_response("game_time_step_until", {"error": "Step already in progress"})
 		return
+
+	# Reset the skew echo up front (see _handle_execute_input_sequence).
+	_step_input_kinds = {"action": 0, "joy_button": 0, "axis": 0}
 
 	var src: String = str(params.get("until", "")).strip_edges()
 	if src.is_empty():

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -137,16 +137,7 @@ func _sequence_process(delta: float) -> void:
 
 	while _sequence_events.size() > 0 and _sequence_events[0].time <= elapsed:
 		var seq_event: Dictionary = _sequence_events.pop_front()
-		var input_event := InputEventAction.new()
-		input_event.action = seq_event.action
-		input_event.pressed = seq_event.is_press
-		input_event.strength = 1.0 if seq_event.is_press else 0.0
-		Input.parse_input_event(input_event)
-		if seq_event.is_press:
-			_held_actions[seq_event.action] = true
-		else:
-			_held_actions.erase(seq_event.action)
-			_actions_completed += 1
+		_actions_completed += _inject_timeline_event(seq_event)
 
 	# Trigger any frame captures whose offset has arrived (#239). Capture is
 	# deferred to frame_post_draw, so it completes a frame or two later; the
@@ -191,6 +182,7 @@ func _emit_sequence_result() -> void:
 		"frozen": _frozen,
 		"gameplay_ms": roundi(_sequence_gameplay_ms),
 		"wall_ms": Time.get_ticks_msec() - _sequence_start_time,
+		"input_kinds": _sequence_input_kinds,
 	}
 
 	if not _sequence_report.is_empty():
@@ -262,6 +254,11 @@ var _sequence_start_time: int = 0
 var _sequence_running: bool = false
 var _actions_completed: int = 0
 var _actions_total: int = 0
+# Entry counts by kind ({action, joy_button, axis}) for the current sequence /
+# step window. Echoed in results: its PRESENCE is the version-skew signal a new
+# server uses to detect an old bridge that silently dropped joypad entries.
+var _sequence_input_kinds: Dictionary = {}
+var _step_input_kinds: Dictionary = {}
 # Game time (unpaused, scaled) accumulated across the sequence window — compared
 # against wall time in the result to flag a sequence that ran under a pause/freeze.
 var _sequence_gameplay_ms: float = 0.0
@@ -295,13 +292,19 @@ const SEQUENCE_MAX_CAPTURE_OFFSET_MS := 300000
 # (new sequence) or the node leaves the tree — otherwise the dropped release
 # latches the action "pressed" in the Input singleton (the stuck-held bug).
 var _held_actions: Dictionary = {}
+# Same guarantee for joypad state (#233): buttons whose press has fired
+# (key "device:button") and axes whose last-set value is nonzero
+# (key "device:axis") — a dropped end event would otherwise latch the polled
+# Input singletons (is_joy_button_pressed / get_joy_axis) until game restart.
+var _held_joy_buttons: Dictionary = {}
+var _active_axes: Dictionary = {}
 
 
-# Release any action still held from an interrupted sequence. A release here is a
-# guaranteed cleanup, never a queued step that a clear could drop. Safe to call
-# when nothing is held.
+# Release any action/button still held and re-zero any active axis from an
+# interrupted sequence. A release here is a guaranteed cleanup, never a queued
+# step that a clear could drop. Safe to call when nothing is held.
 func _release_held_actions() -> void:
-	if _held_actions.is_empty():
+	if _held_actions.is_empty() and _held_joy_buttons.is_empty() and _active_axes.is_empty():
 		return
 	for action in _held_actions.keys():
 		var release := InputEventAction.new()
@@ -309,10 +312,26 @@ func _release_held_actions() -> void:
 		release.pressed = false
 		release.strength = 0.0
 		Input.parse_input_event(release)
+	for bkey in _held_joy_buttons.keys():
+		var binfo = _held_joy_buttons[bkey]
+		var brel := InputEventJoypadButton.new()
+		brel.device = int(binfo["device"])
+		brel.button_index = int(binfo["button"]) as JoyButton
+		brel.pressed = false
+		Input.parse_input_event(brel)
+	for akey in _active_axes.keys():
+		var ainfo = _active_axes[akey]
+		var azero := InputEventJoypadMotion.new()
+		azero.device = int(ainfo["device"])
+		azero.axis = int(ainfo["axis"]) as JoyAxis
+		azero.axis_value = 0.0
+		Input.parse_input_event(azero)
 	# Flush so the release takes effect immediately — _exit_tree may not get
 	# another frame, and a cleanup should be deterministic, not deferred.
 	Input.flush_buffered_events()
 	_held_actions.clear()
+	_held_joy_buttons.clear()
+	_active_axes.clear()
 
 
 func _on_debugger_message(message: String, data: Array) -> bool:
@@ -1169,10 +1188,12 @@ func _event_to_string(event: InputEvent) -> String:
 				return "Mouse Button %d" % mouse_event.button_index
 	elif event is InputEventJoypadButton:
 		var joy_event := event as InputEventJoypadButton
-		return "Joypad Button %d" % joy_event.button_index
+		return "Joypad Button %d (%s)" % [joy_event.button_index, MCPJoyNames.button_name(joy_event.button_index)]
 	elif event is InputEventJoypadMotion:
+		# The signed axis_value is the direction bit an agent needs to lift the
+		# binding straight into an injection (e.g. move_left = left_x, value -1.0).
 		var joy_motion := event as InputEventJoypadMotion
-		return "Joypad Axis %d" % joy_motion.axis
+		return "Joypad Axis %d (%s, value %+.1f)" % [joy_motion.axis, MCPJoyNames.axis_name(joy_motion.axis), joy_motion.axis_value]
 	return event.as_text()
 
 
@@ -1233,34 +1254,14 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	_sequence_captures_pending = 0
 	_sequence_capture_max_width = cap_max_width
 
-	for input in inputs:
-		var action_name: String = input.get("action_name", "")
-		var start_ms: int = int(input.get("start_ms", 0))
-		var duration_ms: int = int(input.get("duration_ms", 0))
-
-		if action_name.is_empty():
-			continue
-
-		if not InputMap.has_action(action_name):
-			EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
-				"error": "Unknown action: %s" % action_name,
-			}])
-			return
-
-		_sequence_events.append({
-			"time": start_ms,
-			"action": action_name,
-			"is_press": true,
-		})
-		_sequence_events.append({
-			"time": start_ms + duration_ms,
-			"action": action_name,
-			"is_press": false,
-		})
-
-	_sequence_events.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
-		return a.time < b.time
-	)
+	var compiled := _compile_input_events(inputs)
+	if compiled.has("error"):
+		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
+			"error": compiled["error"],
+		}])
+		return
+	_sequence_events = compiled["events"]
+	_sequence_input_kinds = compiled["kinds"]
 
 	# Baseline the effect probe at the last possible moment before any input fires.
 	_sequence_report = report_compiled
@@ -1526,10 +1527,11 @@ func _handle_game_time_step(data: Array) -> void:
 	# from window start). Inputs must ride inside the step: an event injected
 	# while frozen lands on a frame gameplay never processes, so its
 	# is_action_just_pressed edge would be silently missed.
-	var compiled := _compile_step_events(params.get("inputs", []))
+	var compiled := _compile_input_events(params.get("inputs", []))
 	if compiled.has("error"):
 		_send_game_time_response("game_time_step", {"error": compiled["error"]})
 		return
+	_step_input_kinds = compiled["kinds"]
 
 	# Step from a running game is allowed — it freezes first, so "advance
 	# 500ms then wait for me" is a single atomic call.
@@ -1564,24 +1566,130 @@ func _handle_game_time_step(data: Array) -> void:
 	_update_processing()
 
 
-func _compile_step_events(inputs: Array) -> Dictionary:
-	# Builds the press/release timeline shared by step and step_until. start_ms
-	# is game time from window start; returns {"error": ...} on an unknown action.
+func _compile_input_events(inputs: Array) -> Dictionary:
+	# Builds the typed input timeline shared by input sequences and game-time
+	# steps (#233). Each entry is discriminated by which key it carries:
+	# `axis` (analog joypad axis), `joy_button`, or `action_name` (with optional
+	# fractional `strength`). Returns {"events": [...], "kinds": {...}} or
+	# {"error": ...} on an unknown action/button/axis. Every event carries:
+	#   time     - ms offset from sequence/window start
+	#   phase    - 0 = release/zero-set, 1 = press/set (the equal-time tie-break)
+	#   complete - completion credit, counted when the event fires (1 on ends)
 	var events: Array = []
+	var kinds := {"action": 0, "joy_button": 0, "axis": 0}
 	for input in inputs:
-		var action_name: String = input.get("action_name", "")
-		if action_name.is_empty():
-			continue
-		if not InputMap.has_action(action_name):
-			return {"error": "Unknown action: %s" % action_name}
 		var start_ms: int = int(input.get("start_ms", 0))
 		var dur: int = int(input.get("duration_ms", 0))
-		events.append({"time": start_ms, "action": action_name, "is_press": true})
-		events.append({"time": start_ms + dur, "action": action_name, "is_press": false})
+		if input.has("axis"):
+			var axis := MCPJoyNames.axis_index(input["axis"])
+			if axis < 0:
+				return {"error": "Unknown joypad axis: %s (valid: %s)" % [str(input["axis"]), ", ".join(MCPJoyNames.AXES.keys())]}
+			var device: int = int(input.get("device", 0))
+			var value: float = clampf(float(input.get("value", 0.0)), -1.0, 1.0)
+			kinds["axis"] += 1
+			events.append({"time": start_ms, "phase": 1, "complete": 0,
+				"kind": "axis", "axis": axis, "device": device, "value": value})
+			events.append({"time": start_ms + dur, "phase": 0, "complete": 1,
+				"kind": "axis", "axis": axis, "device": device, "value": 0.0})
+		elif input.has("joy_button"):
+			var button := MCPJoyNames.button_index(input["joy_button"])
+			if button < 0:
+				return {"error": "Unknown joypad button: %s (valid: %s, or a raw index)" % [str(input["joy_button"]), ", ".join(MCPJoyNames.BUTTONS.keys())]}
+			var bdevice: int = int(input.get("device", 0))
+			kinds["joy_button"] += 1
+			events.append({"time": start_ms, "phase": 1, "complete": 0,
+				"kind": "joy_button", "button": button, "device": bdevice, "is_press": true})
+			events.append({"time": start_ms + dur, "phase": 0, "complete": 1,
+				"kind": "joy_button", "button": button, "device": bdevice, "is_press": false})
+		else:
+			var action_name: String = input.get("action_name", "")
+			if action_name.is_empty():
+				continue
+			if not InputMap.has_action(action_name):
+				return {"error": "Unknown action: %s" % action_name}
+			var strength: float = clampf(float(input.get("strength", 1.0)), 0.0, 1.0)
+			kinds["action"] += 1
+			events.append({"time": start_ms, "phase": 1, "complete": 0,
+				"kind": "action", "action": action_name, "strength": strength, "is_press": true})
+			events.append({"time": start_ms + dur, "phase": 0, "complete": 1,
+				"kind": "action", "action": action_name, "strength": strength, "is_press": false})
+	# Releases/zero-sets fire before presses/sets at equal time, so a same-time
+	# axis zero can never clobber a follow-on set of the same axis.
 	events.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
-		return a.time < b.time
+		if a.time != b.time:
+			return a.time < b.time
+		return a.phase < b.phase
 	)
-	return {"events": events}
+	_cancel_redundant_axis_zeroes(events)
+	return {"events": events, "kinds": kinds}
+
+
+func _cancel_redundant_axis_zeroes(events: Array) -> void:
+	# Abutting same-axis entries (sweep ramps) must not bounce through zero:
+	# both the zero-set and the next set pop in the same frame's while-loop, so
+	# sort order alone cannot hide the transient zero from InputMap edge
+	# detection (is_action_just_released would fire mid-sweep). Drop a zero-set
+	# that lands at the same time as a follow-on set of the same (device, axis),
+	# moving its completion credit to the survivor so counts stay exact.
+	# Actions and buttons are deliberately NOT cancelled: release+press at the
+	# same ms is a legitimate double-tap edge.
+	var i := 0
+	while i < events.size():
+		var ev: Dictionary = events[i]
+		if ev.kind == "axis" and ev.phase == 0:
+			var j := i + 1
+			while j < events.size() and events[j].time == ev.time:
+				var nx: Dictionary = events[j]
+				if nx.kind == "axis" and nx.phase == 1 and nx.axis == ev.axis and nx.device == ev.device:
+					nx.complete = int(nx.complete) + int(ev.complete)
+					events.remove_at(i)
+					i -= 1
+					break
+				j += 1
+		i += 1
+
+
+func _inject_timeline_event(ev: Dictionary) -> int:
+	# Build and parse the engine event for one timeline entry, maintaining the
+	# held-state registries that _release_held_actions uses for guaranteed
+	# cleanup. Returns the event's completion credit. Joypad events drive the
+	# polled Input singletons too (get_joy_axis / is_joy_button_pressed): unlike
+	# the mouse cursor, parse_input_event updates joypad state for any device id
+	# with no physical pad required.
+	match str(ev.kind):
+		"action":
+			var ae := InputEventAction.new()
+			ae.action = ev.action
+			ae.pressed = ev.is_press
+			ae.strength = float(ev.strength) if ev.is_press else 0.0
+			Input.parse_input_event(ae)
+			if ev.is_press:
+				_held_actions[ev.action] = true
+			else:
+				_held_actions.erase(ev.action)
+		"joy_button":
+			var be := InputEventJoypadButton.new()
+			be.device = ev.device
+			be.button_index = ev.button as JoyButton
+			be.pressed = ev.is_press
+			Input.parse_input_event(be)
+			var bkey := "%d:%d" % [ev.device, ev.button]
+			if ev.is_press:
+				_held_joy_buttons[bkey] = {"device": ev.device, "button": ev.button}
+			else:
+				_held_joy_buttons.erase(bkey)
+		"axis":
+			var me := InputEventJoypadMotion.new()
+			me.device = ev.device
+			me.axis = ev.axis as JoyAxis
+			me.axis_value = ev.value
+			Input.parse_input_event(me)
+			var akey := "%d:%d" % [ev.device, ev.axis]
+			if absf(float(ev.value)) > 0.0001:
+				_active_axes[akey] = {"device": ev.device, "axis": ev.axis}
+			else:
+				_active_axes.erase(akey)
+	return int(ev.get("complete", 0))
 
 
 func _build_predicate_context() -> Dictionary:
@@ -1693,14 +1801,17 @@ func _handle_game_time_step_until(data: Array) -> void:
 		return
 	var report_compiled: Array = report_result["report"]
 
-	var compiled := _compile_step_events(params.get("inputs", []))
+	var compiled := _compile_input_events(params.get("inputs", []))
 	if compiled.has("error"):
 		_send_game_time_response("game_time_step_until", {"error": compiled["error"]})
 		return
+	_step_input_kinds = compiled["kinds"]
 
 	_engage_freeze()
 
 	# Predicate already holds: advance nothing, stay frozen, report it.
+	# input_kinds still rides along — its absence is the version-skew signal a
+	# new server reads, so every success shape must carry it.
 	if bool(first_value):
 		var sc_result: Dictionary = {
 			"completed": true,
@@ -1711,6 +1822,7 @@ func _handle_game_time_step_until(data: Array) -> void:
 			"physics_ticks": 0,
 			"game_paused": _game_paused,
 			"predicate_met": true,
+			"input_kinds": _step_input_kinds,
 		}
 		if not report_compiled.is_empty():
 			sc_result["report"] = _evaluate_report(report_compiled, ctx_inputs)
@@ -1772,17 +1884,9 @@ func _step_process(delta: float) -> void:
 
 	while _step_events.size() > 0 and _step_events[0].time <= _step_elapsed_ms:
 		var ev: Dictionary = _step_events.pop_front()
-		var input_event := InputEventAction.new()
-		input_event.action = ev.action
-		input_event.pressed = ev.is_press
-		input_event.strength = 1.0 if ev.is_press else 0.0
-		Input.parse_input_event(input_event)
+		_inject_timeline_event(ev)
 		_step_events_fired += 1
 		_step_needs_settle = true
-		if ev.is_press:
-			_held_actions[ev.action] = true
-		else:
-			_held_actions.erase(ev.action)
 
 	var done := false
 	if _step_target_frames > 0:
@@ -1822,7 +1926,7 @@ func _step_process(delta: float) -> void:
 func _finish_step() -> void:
 	# Releases are guaranteed cleanup, never queued steps: no holds survive
 	# across the freeze boundary (cross-step holds are a deliberate non-goal).
-	var forced := _held_actions.size()
+	var forced := _held_actions.size() + _held_joy_buttons.size() + _active_axes.size()
 	_release_held_actions()
 	var dropped := _step_events.size()
 	_step_events.clear()
@@ -1842,6 +1946,7 @@ func _finish_step() -> void:
 		"frames": _step_frames,
 		"physics_ticks": _step_physics_ticks,
 		"game_paused": _game_paused,
+		"input_kinds": _step_input_kinds,
 	}
 	if _step_events_fired > 0:
 		result["events_fired"] = _step_events_fired

--- a/godot/addons/godot_mcp/test/input_joypad_injection_test.gd
+++ b/godot/addons/godot_mcp/test/input_joypad_injection_test.gd
@@ -21,7 +21,11 @@ extends SceneTree
 ##
 ## Step-window parity is by construction: game_time step compiles through the
 ## same _compile_input_events and injects through the same _inject_timeline_event
-## as the sequence path white-boxed here.
+## as the sequence path white-boxed here. The step path's own freeze/pause
+## semantics make a bare-SceneTree drive hang-prone, so step joypad injection is
+## covered by the shared code paths above, the server vitest, and live MCP
+## validation (a real game_time step with joypad inputs echoing input_kinds),
+## rather than re-driven here.
 ##
 ##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
 ##       --script "res://addons/godot_mcp/test/input_joypad_injection_test.gd"
@@ -81,7 +85,8 @@ func _run() -> void:
 	_check("axis 0.7 drives polled get_joy_axis", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_X), 0.7), true)
 	_check("axis-bound action pressed at 0.7 (deadzone 0.2)", Input.is_action_pressed(AXIS_ACT), true)
 	_check("axis-bound action raw strength is the axis value", is_equal_approx(Input.get_action_raw_strength(AXIS_ACT), 0.7), true)
-	_check("axis-bound action strength is deadzone-adjusted (< raw)", Input.get_action_strength(AXIS_ACT) > 0.0 and Input.get_action_strength(AXIS_ACT) < 0.7, true)
+	# Exact deadzone normalization (raw - dz)/(1 - dz) = (0.7 - 0.2)/0.8 = 0.625.
+	_check("axis-bound action strength is exactly deadzone-normalized", is_equal_approx(Input.get_action_strength(AXIS_ACT), 0.625), true)
 
 	# ── 3. Sub-deadzone value: action NOT pressed, polled axis still moves ───
 	bridge._handle_execute_input_sequence([[
@@ -100,6 +105,26 @@ func _run() -> void:
 	await process_frame
 	_check("fractional strength drives get_action_strength", is_equal_approx(Input.get_action_strength(POS_ACT), 0.5), true)
 	_check("fractional strength drives the get_axis vector read", is_equal_approx(Input.get_axis(NEG_ACT, POS_ACT), 0.5), true)
+
+	# ── 4b. Instant tap (duration_ms = 0 — the SCHEMA DEFAULT) must not latch ──
+	# The end event has to fire strictly after the start, or the (time, phase)
+	# sort would order release-before-press at equal time and the input would
+	# stay held forever (regression guard for the controller-injection PR).
+	var tap_compiled: Dictionary = bridge._compile_input_events([{"action_name": POS_ACT, "start_ms": 0, "duration_ms": 0}])
+	var tap_evts: Array = tap_compiled["events"]
+	_check("instant-tap press is compiled before its release", [bool(tap_evts[0].get("is_press")), int(tap_evts[0]["time"]) < int(tap_evts[1]["time"])], [true, true])
+	bridge._handle_execute_input_sequence([[{"action_name": POS_ACT, "start_ms": 0, "duration_ms": 0}]])
+	for i in 6:
+		await process_frame
+	_check("instant-tap action is NOT latched after the sequence", Input.is_action_pressed(POS_ACT), false)
+	bridge._handle_execute_input_sequence([[{"joy_button": "x", "start_ms": 0, "duration_ms": 0}]])
+	for i in 6:
+		await process_frame
+	_check("instant-tap joy_button is NOT latched after the sequence", Input.is_joy_button_pressed(0, JOY_BUTTON_X), false)
+	bridge._handle_execute_input_sequence([[{"axis": "right_y", "value": 0.9, "start_ms": 0, "duration_ms": 0}]])
+	for i in 6:
+		await process_frame
+	_check("instant-tap axis returns to rest (not latched at value)", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_RIGHT_Y), 0.0), true)
 
 	# ── 5. Zero-bounce: abutting same-axis entries (sweep ramp) ──────────────
 	# White-box first: the boundary zero-set is cancelled at compile time.
@@ -181,6 +206,50 @@ func _run() -> void:
 	root.add_child(bridge)
 	await process_frame
 
+	# ── 6b. Multiple devices are independent (registry keys on device:axis) ──
+	bridge._handle_execute_input_sequence([[
+		{"axis": "left_x", "value": 0.5, "device": 0, "start_ms": 0, "duration_ms": 100000},
+		{"axis": "left_x", "value": -0.9, "device": 1, "start_ms": 0, "duration_ms": 100000},
+		{"joy_button": "a", "device": 1, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("device 0 axis independent of device 1", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_X), 0.5), true)
+	_check("device 1 axis independent of device 0", is_equal_approx(Input.get_joy_axis(1, JOY_AXIS_LEFT_X), -0.9), true)
+	_check("device 1 button does not bleed to device 0", [Input.is_joy_button_pressed(1, JOY_BUTTON_A), Input.is_joy_button_pressed(0, JOY_BUTTON_A)], [true, false])
+	bridge._handle_execute_input_sequence([[{"action_name": POS_ACT, "start_ms": 0, "duration_ms": 10}]])
+	await process_frame
+	_check("interrupt re-zeroed BOTH devices' axes", [Input.get_joy_axis(0, JOY_AXIS_LEFT_X), Input.get_joy_axis(1, JOY_AXIS_LEFT_X)], [0.0, 0.0])
+	_check("interrupt released device 1's button", Input.is_joy_button_pressed(1, JOY_BUTTON_A), false)
+	await create_timer(0.06).timeout
+	for i in 4:
+		await process_frame
+
+	# ── 6c. Abutting same-button entries: documented behavior is two distinct
+	# entries (NOT cancelled like axes), so the button stays effectively held
+	# across the boundary under polling. Pins the deliberate axis/button asymmetry.
+	bridge._handle_execute_input_sequence([[
+		{"joy_button": "y", "start_ms": 0, "duration_ms": 150},
+		{"joy_button": "y", "start_ms": 150, "duration_ms": 150},
+	]])
+	var seg1 := false
+	var seg2 := false
+	var ab_start := Time.get_ticks_msec()
+	var ab_guard := 0
+	while bridge._sequence_running and ab_guard < 600:
+		ab_guard += 1
+		await process_frame
+		var el := Time.get_ticks_msec() - ab_start
+		if el > 40 and el < 130 and Input.is_joy_button_pressed(0, JOY_BUTTON_Y):
+			seg1 = true
+		if el > 170 and el < 280 and Input.is_joy_button_pressed(0, JOY_BUTTON_Y):
+			seg2 = true
+	for i in 3:
+		await process_frame
+	_check("abutting button held through segment 1", seg1, true)
+	_check("abutting button held through segment 2 (boundary did not drop it)", seg2, true)
+	_check("abutting button released after both segments", Input.is_joy_button_pressed(0, JOY_BUTTON_Y), false)
+
 	# ── 7. The documented limitation: no virtual pad in get_connected_joypads ─
 	_check("get_connected_joypads stays empty (pad DETECTION is not fakeable)",
 		Input.get_connected_joypads().is_empty(), true)
@@ -201,6 +270,18 @@ func _run() -> void:
 	])
 	_check("mixed timeline counts kinds for the skew echo",
 		mixed["kinds"], {"action": 1, "joy_button": 1, "axis": 1})
+
+	# ── 9. get_input_map axis/button display carries direction + name ─────────
+	# (the agent lifts axis + signed value straight into an injection).
+	var motion := InputEventJoypadMotion.new()
+	motion.axis = JOY_AXIS_LEFT_X
+	motion.axis_value = -1.0
+	_check("axis binding stringifies with name and signed value",
+		bridge._event_to_string(motion), "Joypad Axis 0 (left_x, value -1.0)")
+	var jbtn := InputEventJoypadButton.new()
+	jbtn.button_index = JOY_BUTTON_A
+	_check("button binding stringifies with name",
+		bridge._event_to_string(jbtn), "Joypad Button 0 (a)")
 
 	root.remove_child(bridge)
 	bridge.free()

--- a/godot/addons/godot_mcp/test/input_joypad_injection_test.gd
+++ b/godot/addons/godot_mcp/test/input_joypad_injection_test.gd
@@ -1,0 +1,228 @@
+extends SceneTree
+
+## Headless pins for joypad/analog input injection (#233), driving the REAL
+## MCPGameBridge sequence engine.
+##
+## WHAT IT PINS (engine ground truth from Godot 4.6 core/input/input.cpp):
+##  - Input.parse_input_event(InputEventJoypadMotion/Button) updates the POLLED
+##    Input singletons (get_joy_axis / is_joy_button_pressed) for any device id,
+##    with no physical pad connected — the property that makes joypad injection
+##    viable where mouse-cursor injection was not.
+##  - Axis-bound actions get REAL InputMap deadzone math; InputEventAction with
+##    fractional strength bypasses it (the two vehicles complement).
+##  - Abutting same-axis entries (sweep ramps) never bounce through zero: the
+##    compile-time zero-cancellation drops the boundary zero-set and transfers
+##    its completion credit (white-boxed against _compile_input_events).
+##  - The held-state registries generalize: an interrupted sequence and a tree
+##    exit re-zero active axes and release joypad buttons, not just actions.
+##  - LIMITATION pin: get_connected_joypads() never reports the virtual pad
+##    (Input.joy_connection_changed is not script-bindable) — documented, and
+##    asserted here so a future engine change surfaces as a test delta.
+##
+## Step-window parity is by construction: game_time step compiles through the
+## same _compile_input_events and injects through the same _inject_timeline_event
+## as the sequence path white-boxed here.
+##
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/input_joypad_injection_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const AXIS_ACT := "mcp_probe_axis_act"   # bound to left_x +1.0, deadzone 0.2
+const NEG_ACT := "mcp_probe_neg"         # unbound pair for the api-strength axis read
+const POS_ACT := "mcp_probe_pos"
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	if not InputMap.has_action(AXIS_ACT):
+		InputMap.add_action(AXIS_ACT, 0.2)
+		var bind := InputEventJoypadMotion.new()
+		bind.axis = JOY_AXIS_LEFT_X
+		bind.axis_value = 1.0
+		InputMap.action_add_event(AXIS_ACT, bind)
+	for a in [NEG_ACT, POS_ACT]:
+		if not InputMap.has_action(a):
+			InputMap.add_action(a)
+
+	print("\n===================== JOYPAD INJECTION TEST (#233) =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var bridge := MCPGameBridge.new()
+	root.add_child(bridge)
+	for i in 3:
+		await process_frame
+
+	# ── 1. Polled button state: by name, and by raw index ────────────────────
+	bridge._handle_execute_input_sequence([[
+		{"joy_button": "a", "start_ms": 0, "duration_ms": 100000},
+		{"joy_button": 1, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("joy_button 'a' drives polled is_joy_button_pressed", Input.is_joy_button_pressed(0, JOY_BUTTON_A), true)
+	_check("raw index 1 drives polled is_joy_button_pressed(B)", Input.is_joy_button_pressed(0, JOY_BUTTON_B), true)
+
+	# ── 2. Polled axis + axis-bound action with REAL deadzone (value 0.7) ────
+	bridge._handle_execute_input_sequence([[
+		{"axis": "left_x", "value": 0.7, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("buttons from the interrupted sequence were force-released", Input.is_joy_button_pressed(0, JOY_BUTTON_A), false)
+	_check("axis 0.7 drives polled get_joy_axis", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_X), 0.7), true)
+	_check("axis-bound action pressed at 0.7 (deadzone 0.2)", Input.is_action_pressed(AXIS_ACT), true)
+	_check("axis-bound action raw strength is the axis value", is_equal_approx(Input.get_action_raw_strength(AXIS_ACT), 0.7), true)
+	_check("axis-bound action strength is deadzone-adjusted (< raw)", Input.get_action_strength(AXIS_ACT) > 0.0 and Input.get_action_strength(AXIS_ACT) < 0.7, true)
+
+	# ── 3. Sub-deadzone value: action NOT pressed, polled axis still moves ───
+	bridge._handle_execute_input_sequence([[
+		{"axis": "left_x", "value": 0.1, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("axis-bound action NOT pressed at 0.1 (under deadzone)", Input.is_action_pressed(AXIS_ACT), false)
+	_check("polled get_joy_axis still reads 0.1 (deadzone is per-action, not per-axis)", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_X), 0.1), true)
+
+	# ── 4. Fractional InputEventAction strength (bypasses deadzone) ──────────
+	bridge._handle_execute_input_sequence([[
+		{"action_name": POS_ACT, "strength": 0.5, "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("fractional strength drives get_action_strength", is_equal_approx(Input.get_action_strength(POS_ACT), 0.5), true)
+	_check("fractional strength drives the get_axis vector read", is_equal_approx(Input.get_axis(NEG_ACT, POS_ACT), 0.5), true)
+
+	# ── 5. Zero-bounce: abutting same-axis entries (sweep ramp) ──────────────
+	# White-box first: the boundary zero-set is cancelled at compile time.
+	var compiled: Dictionary = bridge._compile_input_events([
+		{"axis": "left_x", "value": 0.5, "start_ms": 0, "duration_ms": 200},
+		{"axis": "left_x", "value": 1.0, "start_ms": 200, "duration_ms": 200},
+	])
+	var events: Array = compiled["events"]
+	_check("sweep compiles to 3 events (boundary zero cancelled)", events.size(), 3)
+	_check("surviving boundary set carries the cancelled completion credit", int(events[1].get("complete", -1)), 1)
+	_check("sweep ends with the final zero-set", [int(events[2]["phase"]), float(events[2]["value"])], [0, 0.0])
+
+	# Black-box: drive it for real and sample every frame across the boundary.
+	bridge._handle_execute_input_sequence([[
+		{"axis": "left_x", "value": 0.5, "start_ms": 0, "duration_ms": 200},
+		{"axis": "left_x", "value": 1.0, "start_ms": 200, "duration_ms": 200},
+	]])
+	var seen_nonzero := false
+	var bounced := false
+	var released_mid := false
+	var saw_half := false
+	var saw_full := false
+	var sweep_start := Time.get_ticks_msec()
+	var guard := 0
+	while bridge._sequence_running and guard < 600:
+		guard += 1
+		await process_frame
+		var elapsed := Time.get_ticks_msec() - sweep_start
+		var v := Input.get_joy_axis(0, JOY_AXIS_LEFT_X)
+		if absf(v - 0.5) < 0.01:
+			saw_half = true
+		if absf(v - 1.0) < 0.01:
+			saw_full = true
+		if absf(v) > 0.01:
+			seen_nonzero = true
+		elif seen_nonzero and elapsed < 380:
+			bounced = true
+		if seen_nonzero and elapsed < 380 and not Input.is_action_pressed(AXIS_ACT):
+			released_mid = true
+	await process_frame
+	await process_frame
+	_check("sweep reached the 0.5 segment", saw_half, true)
+	_check("sweep reached the 1.0 segment", saw_full, true)
+	_check("axis never bounced through zero at the segment boundary", bounced, false)
+	_check("axis-bound action never released mid-sweep", released_mid, false)
+	_check("axis returned to rest after the sweep", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_X), 0.0), true)
+	_check("axis-bound action released after the sweep", Input.is_action_pressed(AXIS_ACT), false)
+
+	# ── 6. Guaranteed release, generalized to buttons and axes ───────────────
+	bridge._handle_execute_input_sequence([[
+		{"axis": "left_y", "value": 0.8, "start_ms": 0, "duration_ms": 100000},
+		{"joy_button": "b", "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("long axis hold active", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_Y), 0.8), true)
+	_check("long button hold active", Input.is_joy_button_pressed(0, JOY_BUTTON_B), true)
+	bridge._handle_execute_input_sequence([[
+		{"action_name": POS_ACT, "start_ms": 0, "duration_ms": 10},
+	]])
+	await process_frame
+	_check("interrupted sequence re-zeroed the held axis", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_LEFT_Y), 0.0), true)
+	_check("interrupted sequence released the held button", Input.is_joy_button_pressed(0, JOY_BUTTON_B), false)
+
+	await create_timer(0.06).timeout
+	for i in 4:
+		await process_frame
+	bridge._handle_execute_input_sequence([[
+		{"axis": "right_x", "value": -0.6, "start_ms": 0, "duration_ms": 100000},
+		{"joy_button": "dpad_up", "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("exit-tree case armed (axis)", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_RIGHT_X), -0.6), true)
+	_check("exit-tree case armed (button)", Input.is_joy_button_pressed(0, JOY_BUTTON_DPAD_UP), true)
+	root.remove_child(bridge)
+	_check("tree exit re-zeroed the held axis", is_equal_approx(Input.get_joy_axis(0, JOY_AXIS_RIGHT_X), 0.0), true)
+	_check("tree exit released the held button", Input.is_joy_button_pressed(0, JOY_BUTTON_DPAD_UP), false)
+	root.add_child(bridge)
+	await process_frame
+
+	# ── 7. The documented limitation: no virtual pad in get_connected_joypads ─
+	_check("get_connected_joypads stays empty (pad DETECTION is not fakeable)",
+		Input.get_connected_joypads().is_empty(), true)
+
+	# ── 8. Compile errors and kind counting ──────────────────────────────────
+	var bad_axis: Dictionary = bridge._compile_input_events([{"axis": "left_z", "value": 0.5}])
+	_check("unknown axis name rejected", str(bad_axis.get("error", "")).begins_with("Unknown joypad axis"), true)
+	var bad_button: Dictionary = bridge._compile_input_events([{"joy_button": "zz"}])
+	_check("unknown button name rejected", str(bad_button.get("error", "")).begins_with("Unknown joypad button"), true)
+	var bad_index: Dictionary = bridge._compile_input_events([{"joy_button": 99}])
+	_check("out-of-range button index rejected", str(bad_index.get("error", "")).begins_with("Unknown joypad button"), true)
+	var bad_action: Dictionary = bridge._compile_input_events([{"action_name": "mcp_probe_nonexistent"}])
+	_check("unknown action rejected (unchanged contract)", str(bad_action.get("error", "")).begins_with("Unknown action"), true)
+	var mixed: Dictionary = bridge._compile_input_events([
+		{"action_name": POS_ACT, "duration_ms": 10},
+		{"joy_button": "a", "duration_ms": 10},
+		{"axis": "left_x", "value": 1.0, "duration_ms": 10},
+	])
+	_check("mixed timeline counts kinds for the skew echo",
+		mixed["kinds"], {"action": 1, "joy_button": 1, "axis": 1})
+
+	root.remove_child(bridge)
+	bridge.free()
+
+	if InputMap.has_action(AXIS_ACT):
+		InputMap.erase_action(AXIS_ACT)
+	for a in [NEG_ACT, POS_ACT]:
+		if InputMap.has_action(a):
+			InputMap.erase_action(a)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/input_joypad_injection_test.gd.uid
+++ b/godot/addons/godot_mcp/test/input_joypad_injection_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bsh3wak13ba7d

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -43,7 +43,7 @@ const categories: ToolCategory[] = [
   { name: 'Resource', filename: 'resource', description: 'Resource inspection tools for SpriteFrames, TileSet, Materials, etc.', tools: resourceTools },
   { name: 'Scene3D', filename: 'scene3d', description: '3D spatial information and bounding box tools', tools: scene3dTools },
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },
-  { name: 'Input', filename: 'input', description: 'Input injection for testing running games (action-based, no mouse/coordinates yet)', tools: inputTools },
+  { name: 'Input', filename: 'input', description: 'Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input)', tools: inputTools },
   { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
   { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.', tools: runtimeStateTools },
   { name: 'Game Script Execution', filename: 'exec', description: 'Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard.', tools: execTools },

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -154,7 +154,8 @@ describe('game_time tool', () => {
       ]);
       const data = structuredOf(result);
       expect(data.input_kinds).toEqual({ action: 0, joy_button: 1, axis: 2 });
-      expect(data.warnings).toBeUndefined();
+      // Stable shape (#198 precedent): warnings is always an array, empty here.
+      expect(data.warnings).toEqual([]);
     });
 
     it('warns in the structured result when joypad entries hit an old addon (no input_kinds) (#233)', async () => {

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -129,6 +129,52 @@ describe('game_time tool', () => {
       expect(data.gameplay_ms).toBe(120);
     });
 
+    it('accepts joypad entries, compiles stick sugar onto the wire, and surfaces input_kinds (#233)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,
+        frames: 30, physics_ticks: 30, game_paused: false, events_fired: 6,
+        input_kinds: { action: 0, joy_button: 1, axis: 2 },
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({
+        action: 'step',
+        duration_ms: 500,
+        inputs: [
+          { stick: 'left', x: 0.5, y: -0.5, device: 0, start_ms: 0, duration_ms: 400 },
+          { joy_button: 'a', device: 0, start_ms: 200, duration_ms: 50 },
+        ],
+      }, ctx);
+
+      expect(mock.calls[0].params.inputs).toEqual([
+        { axis: 'left_x', value: 0.5, device: 0, start_ms: 0, duration_ms: 400 },
+        { axis: 'left_y', value: -0.5, device: 0, start_ms: 0, duration_ms: 400 },
+        // Non-stick entries pass through verbatim.
+        { joy_button: 'a', device: 0, start_ms: 200, duration_ms: 50 },
+      ]);
+      const data = structuredOf(result);
+      expect(data.input_kinds).toEqual({ action: 0, joy_button: 1, axis: 2 });
+      expect(data.warnings).toBeUndefined();
+    });
+
+    it('warns in the structured result when joypad entries hit an old addon (no input_kinds) (#233)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,
+        frames: 30, physics_ticks: 30, game_paused: false,
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({
+        action: 'step',
+        duration_ms: 500,
+        inputs: [{ axis: 'left_x', value: 1, device: 0, start_ms: 0, duration_ms: 200 }],
+      }, ctx);
+
+      const data = structuredOf(result);
+      expect(data.warnings).toHaveLength(1);
+      expect((data.warnings as string[])[0]).toContain('predates controller injection');
+    });
+
     it('derives the per-request timeout and pushes the relay/wall budgets to the bridge (#276)', async () => {
       mock.mockResponse({
         completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -476,6 +476,32 @@ describe('input tool', () => {
       expect(result).toContain('predates controller injection');
     });
 
+    it('warns when an action carries strength but the bridge echoed no input_kinds (old addon drops strength)', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1 });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', strength: 0.5, start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      // strength is a new capability an old bridge silently ignores (fires at 1.0).
+      expect(result).toContain('IGNORED');
+      expect(result).toContain('analog action strength');
+    });
+
+    it('does not warn for a plain action (no strength) against an old addon', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1 });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      expect(result).not.toContain('IGNORED');
+    });
+
     it('does not warn when input_kinds is present, or for action-only requests against an old addon', async () => {
       mock.mockResponse({ completed: true, actions_executed: 1, input_kinds: { action: 0, joy_button: 1, axis: 0 } });
       const ctx = createToolContext(mock);

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -149,7 +149,7 @@ describe('input tool', () => {
         inputs: [{ action_name: 'jump', start_ms: 0, duration_ms: 0 }],
       }, ctx);
 
-      expect(result).toContain('1 action(s) executed');
+      expect(result).toContain('1 input(s) executed');
       expect(result).toContain('jump');
       expect(mock.calls[0].params.inputs).toHaveLength(1);
     });
@@ -166,7 +166,7 @@ describe('input tool', () => {
         ],
       }, ctx);
 
-      expect(result).toContain('2 action(s) executed');
+      expect(result).toContain('2 input(s) executed');
       expect(result).toContain('move_forward, jump');
       expect(result).toContain('1000ms');
     });
@@ -355,6 +355,143 @@ describe('input tool', () => {
         inputs: [{ action_name: 'fire', start_ms: 0, duration_ms: INPUT_BUDGET_CAP_MS + 1 }],
       }, ctx)).rejects.toThrow(/single call can cover at most/);
       expect(mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('joypad entries (#233)', () => {
+    describe('schema', () => {
+      it('accepts joy_button by name and by raw index', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ joy_button: 'a' }, { joy_button: 'dpad_up', device: 1 }, { joy_button: 5 }],
+        }).success).toBe(true);
+      });
+
+      it('rejects an unknown axis name and out-of-range values', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ axis: 'left_z', value: 0.5 }],
+        }).success).toBe(false);
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ axis: 'left_x', value: 1.5 }],
+        }).success).toBe(false);
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ axis: 'left_x', value: -0.7 }],
+        }).success).toBe(true);
+      });
+
+      it('rejects a negative value on a trigger axis (triggers range 0..1)', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ axis: 'trigger_right', value: -0.5 }],
+        }).success).toBe(false);
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ axis: 'trigger_right', value: 0.5 }],
+        }).success).toBe(true);
+      });
+
+      it('rejects action strength outside 0..1', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ action_name: 'fire', strength: 1.5 }],
+        }).success).toBe(false);
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ action_name: 'fire', strength: 0.5 }],
+        }).success).toBe(true);
+      });
+
+      it('rejects a mixed-keys entry (the strictObject discriminator pin)', () => {
+        // A stripping schema would silently match the action branch and drop
+        // the axis intent — exactly the bug strictObject exists to prevent.
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ action_name: 'fire', axis: 'left_x', value: 1 }],
+        }).success).toBe(false);
+      });
+
+      it('accepts stick entries and mixed timelines', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [
+            { stick: 'left', x: 0.5, y: 0, duration_ms: 500 },
+            { joy_button: 'a', start_ms: 200 },
+            { action_name: 'pause', start_ms: 900 },
+          ],
+        }).success).toBe(true);
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ stick: 'middle', x: 0, y: 0 }],
+        }).success).toBe(false);
+      });
+    });
+
+    it('compiles a stick entry into a paired _x/_y axis hold on the wire', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 2, input_kinds: { action: 0, joy_button: 0, axis: 2 } });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ stick: 'right', x: 0.866, y: -0.5, device: 0, start_ms: 100, duration_ms: 1500 }],
+      }, ctx);
+
+      expect(mock.calls[0].params.inputs).toEqual([
+        { axis: 'right_x', value: 0.866, device: 0, start_ms: 100, duration_ms: 1500 },
+        { axis: 'right_y', value: -0.5, device: 0, start_ms: 100, duration_ms: 1500 },
+      ]);
+      expect(result).toContain('right_stick(0.866,-0.5)');
+    });
+
+    it('labels joypad entries in the summary line', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 3, input_kinds: { action: 1, joy_button: 1, axis: 1 } });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [
+          { joy_button: 'a', device: 0, start_ms: 0, duration_ms: 100 },
+          { axis: 'trigger_right', value: 1, device: 0, start_ms: 0, duration_ms: 200 },
+          { action_name: 'fire', strength: 0.5, start_ms: 0, duration_ms: 200 },
+        ],
+      }, ctx);
+
+      expect(result).toContain('joy:a');
+      expect(result).toContain('trigger_right=1');
+      expect(result).toContain('fire@0.5');
+    });
+
+    it('warns when joypad entries were requested but the bridge echoed no input_kinds (old addon)', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 0 });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ axis: 'left_x', value: 1, device: 0, start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      expect(result).toContain('IGNORED');
+      expect(result).toContain('predates controller injection');
+    });
+
+    it('does not warn when input_kinds is present, or for action-only requests against an old addon', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1, input_kinds: { action: 0, joy_button: 1, axis: 0 } });
+      const ctx = createToolContext(mock);
+      const withKinds = await input.execute({
+        action: 'sequence',
+        inputs: [{ joy_button: 'a', device: 0, start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+      expect(withKinds).not.toContain('IGNORED');
+
+      const oldMock = createMockGodot();
+      oldMock.mockResponse({ completed: true, actions_executed: 1 });
+      const actionOnly = await input.execute({
+        action: 'sequence',
+        inputs: [{ action_name: 'jump', start_ms: 0, duration_ms: 100 }],
+      }, createToolContext(oldMock));
+      expect(actionOnly).not.toContain('IGNORED');
     });
   });
 

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
 import { structured } from '../core/structured.js';
 import { deriveTimeouts, STEP_BUDGET_CAP_MS } from '../connection/timeouts.js';
-import { InputActionSchema } from './input.js';
+import { InputEntrySchema, compileInputEntries, joypadSkewWarning } from './input.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 // Published cap on game time advanced in one call. The server sizes its socket
@@ -55,9 +55,9 @@ const GameTimeSchema = z
         .optional()
         .describe(`Frames to advance instead of a duration (max ${STEP_MAX_FRAMES}). frames: 1 is a single-frame advance.`),
       inputs: z
-        .array(InputActionSchema)
+        .array(InputEntrySchema)
         .optional()
-        .describe('Input timeline executed inside the window; start_ms is game time from window start. Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end.'),
+        .describe('Input timeline executed inside the window; start_ms is game time from window start. Entries share the godot_input sequence vocabulary: named actions (with analog strength), joypad buttons, axis holds, and stick vectors. Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end.'),
     }),
     z.object({
       action: z
@@ -79,9 +79,9 @@ const GameTimeSchema = z
         .optional()
         .describe('Optional GDScript expressions (same scope as `until`) evaluated when stepping stops and returned as a { expression: value } map — e.g. ["G.wave", "tree.get_nodes_in_group(\\"enemies\\").size()"]. Use this to read the state you care about in the same call instead of a separate observation round-trip. Each must parse and evaluate without error up front.'),
       inputs: z
-        .array(InputActionSchema)
+        .array(InputEntrySchema)
         .optional()
-        .describe('Optional input timeline driven inside the window, exactly like step (e.g. hold "move forward" while waiting for an enemy to appear). Holds are released by window end.'),
+        .describe('Optional input timeline driven inside the window, exactly like step (same vocabulary: actions, joypad buttons, axes, stick vectors — e.g. hold a stick deflection while waiting for an enemy to appear). Holds are released by window end.'),
     }),
     z.object({
       action: z
@@ -114,6 +114,7 @@ interface StepResult {
   events_dropped?: number;
   pause_transitions?: Array<{ at_ms: number; paused: boolean }>;
   wall_budget_exceeded?: boolean;
+  input_kinds?: Record<string, number>;
   // step_until only:
   predicate_met?: boolean;
   report?: Record<string, unknown>;
@@ -144,11 +145,12 @@ export const gameTime = defineTool({
         const result = await godot.sendCommand<StepResult>('game_time_step', {
           duration_ms: args.duration_ms,
           frames: args.frames,
-          inputs: args.inputs,
+          inputs: compileInputEntries(args.inputs ?? []),
           relay_timeout_ms: t.relayMs,
           wall_budget_ms: t.bridgeWallMs,
         }, { timeoutMs: t.serverMs });
-        return structured(result);
+        const skew = joypadSkewWarning(args.inputs ?? [], result.input_kinds);
+        return structured(skew ? { ...result, warnings: [skew] } : result);
       }
 
       case 'step_until': {
@@ -157,11 +159,12 @@ export const gameTime = defineTool({
           until: args.until,
           max_ms: args.max_ms ?? STEP_DEFAULT_MS,
           report: args.report,
-          inputs: args.inputs,
+          inputs: compileInputEntries(args.inputs ?? []),
           relay_timeout_ms: t.relayMs,
           wall_budget_ms: t.bridgeWallMs,
         }, { timeoutMs: t.serverMs });
-        return structured(result);
+        const skew = joypadSkewWarning(args.inputs ?? [], result.input_kinds);
+        return structured(skew ? { ...result, warnings: [skew] } : result);
       }
 
       case 'thaw': {

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -149,8 +149,10 @@ export const gameTime = defineTool({
           relay_timeout_ms: t.relayMs,
           wall_budget_ms: t.bridgeWallMs,
         }, { timeoutMs: t.serverMs });
+        // Stable shape, matching the runtime-state watch precedent (#198):
+        // `warnings` is always an array so callers can read it unconditionally.
         const skew = joypadSkewWarning(args.inputs ?? [], result.input_kinds);
-        return structured(skew ? { ...result, warnings: [skew] } : result);
+        return structured({ ...result, warnings: skew ? [skew] : [] });
       }
 
       case 'step_until': {
@@ -164,7 +166,7 @@ export const gameTime = defineTool({
           wall_budget_ms: t.bridgeWallMs,
         }, { timeoutMs: t.serverMs });
         const skew = joypadSkewWarning(args.inputs ?? [], result.input_kinds);
-        return structured(skew ? { ...result, warnings: [skew] } : result);
+        return structured({ ...result, warnings: skew ? [skew] : [] });
       }
 
       case 'thaw': {

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -80,7 +80,18 @@ const StickEntrySchema = z.strictObject({
   ...TimingFields,
 });
 
-export const InputEntrySchema = z.union([ActionEntrySchema, JoyButtonEntrySchema, AxisEntrySchema, StickEntrySchema]);
+export const InputEntrySchema = z.union(
+  [ActionEntrySchema, JoyButtonEntrySchema, AxisEntrySchema, StickEntrySchema],
+  {
+    // z.union reports a bare "Invalid input" for every structural miss; the
+    // entries are key-discriminated, so name the four valid shapes to make the
+    // most common authoring mistakes (missing value, typo'd key, no
+    // discriminator) actionable.
+    error: () =>
+      'each input entry must be one of: {action_name, strength?}, {joy_button, device?}, ' +
+      '{axis, value, device?}, or {stick, x, y, device?} (all with optional start_ms/duration_ms)',
+  }
+);
 export type InputEntry = z.infer<typeof InputEntrySchema>;
 
 // Compile schema entries into the wire vocabulary the game bridge consumes
@@ -108,19 +119,22 @@ export function entryLabel(e: InputEntry): string {
 }
 
 // Version-skew detection (#233, same honesty pattern as the watch timeline):
-// an old bridge silently `continue`s entries without action_name, so joypad
-// entries would be dropped while the call "succeeds". A new bridge always
-// echoes input_kinds; its ABSENCE when joypad entries were requested means the
-// running addon predates controller injection.
+// an old bridge silently `continue`s entries without action_name (dropping
+// joypad entries) and ignores the new `strength` field on action entries
+// (injecting at 1.0) — both while the call "succeeds". A new bridge always
+// echoes input_kinds; its ABSENCE when the request used either new capability
+// means the running addon predates controller injection.
 export function joypadSkewWarning(
   inputs: InputEntry[],
   inputKinds: Record<string, number> | undefined
 ): string | undefined {
-  const joypad = inputs.some((e) => !('action_name' in e));
-  if (joypad && inputKinds === undefined) {
+  const usesNewCaps = inputs.some(
+    (e) => !('action_name' in e) || ('strength' in e && e.strength !== undefined)
+  );
+  if (usesNewCaps && inputKinds === undefined) {
     return (
-      'WARNING: joypad/axis entries were IGNORED — the running addon predates controller injection. ' +
-      'Update the godot-mcp addon and restart the Godot editor.'
+      'WARNING: joypad/axis entries or analog action strength were IGNORED — the running addon ' +
+      'predates controller injection. Update the godot-mcp addon and restart the Godot editor.'
     );
   }
   return undefined;

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -4,11 +4,127 @@ import { deriveTimeouts, INPUT_BUDGET_CAP_MS } from '../connection/timeouts.js';
 import { staleAdvisory, type ProjectStaleness } from './project-staleness.js';
 import type { AnyToolDefinition, ToolResult } from '../core/types.js';
 
-export const InputActionSchema = z.object({
-  action_name: z.string().describe('The input action name from the project Input Map'),
+const TimingFields = {
   start_ms: z.number().int().min(0).optional().default(0).describe('When to start the input (milliseconds from sequence start)'),
-  duration_ms: z.number().int().min(0).optional().default(0).describe('How long to hold the input (0 = instant tap)'),
+  duration_ms: z.number().int().min(0).optional().default(0).describe('How long to hold the input (0 = instant tap; axes return to 0 at the end)'),
+};
+const DeviceField = z
+  .number()
+  .int()
+  .min(0)
+  .optional()
+  .default(0)
+  .describe('Joypad device id (default 0). InputMap bindings use device -1 (all devices) by default, which any id matches.');
+
+export const JOY_BUTTON_NAMES = [
+  'a', 'b', 'x', 'y', 'back', 'guide', 'start', 'left_stick', 'right_stick',
+  'left_shoulder', 'right_shoulder', 'dpad_up', 'dpad_down', 'dpad_left', 'dpad_right',
+  'misc1', 'paddle1', 'paddle2', 'paddle3', 'paddle4', 'touchpad',
+] as const;
+export const JOY_AXIS_NAMES = ['left_x', 'left_y', 'right_x', 'right_y', 'trigger_left', 'trigger_right'] as const;
+
+// The four input-entry shapes are discriminated by WHICH KEY is present
+// (action_name / joy_button / axis / stick), so strictObject is load-bearing:
+// a stripping z.object would silently match a mixed entry like
+// {action_name, axis, value} to the action branch and drop the axis intent.
+const ActionEntrySchema = z.strictObject({
+  action_name: z.string().describe('The input action name from the project Input Map'),
+  strength: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe(
+      'Analog press strength (default 1.0). Drives Input.get_action_strength/get_vector even for ' +
+      'actions with no joypad bindings, but BYPASSES the InputMap deadzone — use an axis entry when ' +
+      'real deadzone behavior matters.'
+    ),
+  ...TimingFields,
 });
+const JoyButtonEntrySchema = z.strictObject({
+  joy_button: z
+    .union([z.enum(JOY_BUTTON_NAMES), z.number().int().min(0).max(20)])
+    .describe('Joypad button by Godot JoyButton name (e.g. "a", "right_shoulder", "dpad_up") or raw index. Drives bound actions, raw _input handlers, and polled Input.is_joy_button_pressed.'),
+  device: DeviceField,
+  ...TimingFields,
+});
+const AxisEntrySchema = z
+  .strictObject({
+    axis: z
+      .enum(JOY_AXIS_NAMES)
+      .describe('Joypad axis by Godot JoyAxis name. Sticks range -1..1 and rest at 0; triggers range 0..1 and rest at 0.'),
+    value: z
+      .number()
+      .min(-1)
+      .max(1)
+      .describe('Axis value held for duration_ms, then returned to 0. Drives axis-bound actions with REAL InputMap deadzone math, raw _input handlers, and polled Input.get_joy_axis.'),
+    device: DeviceField,
+    ...TimingFields,
+  })
+  .superRefine((e, ctx) => {
+    if (e.axis.startsWith('trigger') && e.value < 0) {
+      ctx.addIssue({ code: 'custom', message: `trigger axes range 0..1; got ${e.value}` });
+    }
+  });
+const StickEntrySchema = z.strictObject({
+  stick: z
+    .enum(['left', 'right'])
+    .describe('Stick vector shorthand: compiles into a paired _x/_y axis hold with the same timing.'),
+  x: z.number().min(-1).max(1).describe('Stick x deflection: -1 = left, +1 = right.'),
+  y: z
+    .number()
+    .min(-1)
+    .max(1)
+    .describe('Stick y deflection in Godot joypad convention: -1 = UP, +1 = down. Aim 30 degrees above horizontal-right = {x: 0.866, y: -0.5}; half-tilt right = {x: 0.5, y: 0}.'),
+  device: DeviceField,
+  ...TimingFields,
+});
+
+export const InputEntrySchema = z.union([ActionEntrySchema, JoyButtonEntrySchema, AxisEntrySchema, StickEntrySchema]);
+export type InputEntry = z.infer<typeof InputEntrySchema>;
+
+// Compile schema entries into the wire vocabulary the game bridge consumes
+// (action | joy_button | axis): stick sugar becomes a paired axis hold.
+export function compileInputEntries(inputs: InputEntry[]): Record<string, unknown>[] {
+  const wire: Record<string, unknown>[] = [];
+  for (const e of inputs) {
+    if ('stick' in e) {
+      const base = { device: e.device ?? 0, start_ms: e.start_ms ?? 0, duration_ms: e.duration_ms ?? 0 };
+      wire.push({ axis: `${e.stick}_x`, value: e.x, ...base });
+      wire.push({ axis: `${e.stick}_y`, value: e.y, ...base });
+    } else {
+      wire.push(e);
+    }
+  }
+  return wire;
+}
+
+// Short human label for one entry, for the result summary line.
+export function entryLabel(e: InputEntry): string {
+  if ('action_name' in e) return e.strength !== undefined ? `${e.action_name}@${e.strength}` : e.action_name;
+  if ('joy_button' in e) return `joy:${e.joy_button}`;
+  if ('axis' in e) return `${e.axis}=${e.value}`;
+  return `${e.stick}_stick(${e.x},${e.y})`;
+}
+
+// Version-skew detection (#233, same honesty pattern as the watch timeline):
+// an old bridge silently `continue`s entries without action_name, so joypad
+// entries would be dropped while the call "succeeds". A new bridge always
+// echoes input_kinds; its ABSENCE when joypad entries were requested means the
+// running addon predates controller injection.
+export function joypadSkewWarning(
+  inputs: InputEntry[],
+  inputKinds: Record<string, number> | undefined
+): string | undefined {
+  const joypad = inputs.some((e) => !('action_name' in e));
+  if (joypad && inputKinds === undefined) {
+    return (
+      'WARNING: joypad/axis entries were IGNORED — the running addon predates controller injection. ' +
+      'Update the godot-mcp addon and restart the Godot editor.'
+    );
+  }
+  return undefined;
+}
 
 const InputSchema = z.discriminatedUnion('action', [
   z.object({
@@ -17,9 +133,17 @@ const InputSchema = z.discriminatedUnion('action', [
   z.object({
     action: z.literal('sequence').describe('Execute an input timeline'),
     inputs: z
-      .array(InputActionSchema)
+      .array(InputEntrySchema)
       .min(1)
-      .describe('Array of inputs to execute'),
+      .describe(
+        'Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional ' +
+        'analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), or a ' +
+        'STICK vector (stick + x/y) — mix freely on one timeline. Joypad events drive bound actions ' +
+        '(with real deadzone math), raw _input handlers, and the polled Input singletons ' +
+        '(get_joy_axis / is_joy_button_pressed); no physical pad is needed. Limitation: ' +
+        'Input.get_connected_joypads() never reports a virtual pad, so games that gate controller ' +
+        'mode on pad DETECTION cannot be switched into it.'
+      ),
     report: z
       .array(z.string())
       .optional()
@@ -94,7 +218,7 @@ export const input = defineTool({
   name: 'godot_input',
   annotations: { title: 'Input Injection', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
-    'Inject input into a running Godot game for testing. Use get_map to discover available input actions, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: Mouse/coordinate input not yet supported.',
+    'Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, and stick vectors. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).',
   schema: InputSchema,
   async execute(args: InputArgs, { godot }) {
     switch (args.action) {
@@ -160,9 +284,10 @@ export const input = defineTool({
             height: number;
             error: string;
           }>;
+          input_kinds?: Record<string, number>;
           error?: string;
         }>('execute_input_sequence', {
-          inputs,
+          inputs: compileInputEntries(inputs),
           report: args.report,
           screenshot_at_ms: args.screenshot_at_ms,
           screenshot_max_width: args.screenshot_max_width,
@@ -177,11 +302,14 @@ export const input = defineTool({
         }
 
         const totalDuration = Math.max(...inputs.map((i) => (i.start_ms ?? 0) + (i.duration_ms ?? 0)));
-        const actionNames = [...new Set(inputs.map((i) => i.action_name))].join(', ');
+        const labels = [...new Set(inputs.map(entryLabel))].join(', ');
 
         const lines = [
-          `Input sequence completed: ${result.actions_executed} action(s) executed [${actionNames}] over ${totalDuration}ms.`,
+          `Input sequence completed: ${result.actions_executed} input(s) executed [${labels}] over ${totalDuration}ms.`,
         ];
+
+        const skew = joypadSkewWarning(inputs, result.input_kinds);
+        if (skew) lines.push(skew);
 
         // Always-on context: a sequence that ran under a pause/freeze advanced no
         // gameplay, so its inputs almost certainly did nothing — surface that


### PR DESCRIPTION
## What

Extends the `godot_input` sequence vocabulary (shared by `godot_game_time` step/step_until) beyond named actions:

- **Joypad buttons** (`{joy_button: "a" | index}`) and **analog axis holds** (`{axis: "left_x", value: 0.7}`) injected as real `InputEventJoypadButton`/`InputEventJoypadMotion` — driving bound actions with genuine InputMap deadzone math, raw `_input` handlers, AND the polled Input singletons (`get_joy_axis` / `is_joy_button_pressed`). No physical pad needed.
- **Stick vectors** (`{stick: "right", x: 0.866, y: -0.5}`) — server-compiled into paired axis holds, so an agent expresses the vector it means.
- **Fractional `strength`** on action entries — drives `get_action_strength`/`get_vector` for actions with no joypad bindings (bypasses deadzone; the axis path is the real-deadzone vehicle).

Closes #233 (controller pillar; the keyboard-hardening bullets shipped previously — see closing comment). Delivers what #242 asked for.

## Why injection works here (unlike the mouse)

The mouse spike (#228) died on the polled-cursor ceiling. Verified against Godot 4.6 `core/input/input.cpp` and pinned by the headless test: `parse_input_event` updates polled joypad state (`set_joy_axis`, `joy_buttons_pressed`) for any device id. There is no polled ceiling for joypads.

One bounded limitation, documented and test-pinned: `Input.joy_connection_changed` is not script-bindable, so `get_connected_joypads()` never reports a virtual pad — games gating controller mode on pad *detection* stay undrivable (event/action-reading games, the common patterns, work).

## Design notes

- **One timeline engine.** Sequences and step windows now share `_compile_input_events` + `_inject_timeline_event`; the held-state registries generalize to buttons and axes, so the guaranteed-release contract (interrupt, step finish, tree exit) covers analog state — a latched axis is the analog cousin of the stuck-held action bug (#231).
- **Sweep ramps never bounce through zero.** Abutting same-axis entries cancel the boundary zero-set at compile time (with completion-credit transfer), so `is_action_just_released` can't fire mid-sweep. Tie-break: releases/zero-sets sort before same-time sets.
- **Version-skew honesty** (the #198 pattern): results echo `input_kinds`; a new server warns when joypad entries were requested but the field is absent (old addon silently drops entries it doesn't know).
- **`get_input_map` now prints direction**: `move_left: Joypad Axis 0 (left_x, value -1.0)` — bindings lift straight into injections.
- Entry schemas are strict (discriminated by which key is present); a stripping schema would silently mis-match `{action_name, axis, value}` to the action branch. Consequence: unknown extra keys on entries now reject instead of being silently stripped — a deliberate tightening, not worth a major.

## Testing

- New headless `input_joypad_injection_test.gd`: 48 checks (polled state, exact deadzone normalization, strength-bypass, axis zero-cancellation white+black box, instant-tap non-latch for action/button/axis, generalized release, multi-device independence, abutting-button continuity, get_input_map display format, the detection limitation, compile errors). Full regression battery green (stuck-held 5, effect-probe 15, capture 9, exec-guard 93, watch-timeline 61).
- Vitest 344/344 (schema cases incl. the strictObject mis-match pin, stick compilation, skew warnings for joypad entries and for analog strength, the always-array `warnings` shape, step parity).
- Live on NEON RAMPAGE (controller-first twin-stick, the #242 field-session game): `{stick: "right", x: 0.866, y: -0.5}` produced bullets whose velocity angle measured -30.0/-29.8/-30.1 degrees in screen space (y-down `atan2`), i.e. 30 degrees above horizontal-right — matching the documented stick y-convention. Left-stick `x: 0.43` against the 0.2 deadzone drove the player at the deadzone-normalized strength `(0.43 - 0.2)/(1 - 0.2) = 0.2875`; the exact normalization is pinned by the headless test (`0.7 -> 0.625`). The instant-tap latch fix was re-verified live: a bare `{action_name: "dash"}` (duration 0) left `is_action_pressed("dash") = false` after the sequence.

## Adversarial review round

A pre-merge adversarial review (three parallel reviewers: bridge engine / server+wire / tests+honesty) found one blocker and three should-fixes, all in the second commit:

- **Blocker** — an instant tap (`duration_ms: 0`, the schema default, e.g. `{action_name: "jump"}`) compiled release-before-press under the equal-time `(time, phase)` sort and latched the input. Fixed by emitting the end event at `start_ms + max(dur, 1)` so the time sort orders start-before-end; abutting `dur>0` boundaries (where axis zero-cancellation lives) are untouched. Pinned by non-latch checks for all three kinds and re-verified live.
- **Skew honesty** — an old bridge silently ignores the new `strength` field on action entries (fires at 1.0); the skew detector now warns on that case too, not just joypad entries.
- **Stable shape** — `game_time` step/step_until now always emit `warnings: []` (matching the runtime-state watch precedent) instead of omitting the field.
- **Error quality** — the input-entry union now names the four valid shapes instead of reporting a bare "Invalid input".

Deliberately not changed: abutting same-button/same-action entries produce distinct press/release edges (not merged like abutting axes) — intended, and now pinned by a test documenting the asymmetry.
