### PR TITLE
feat: inject raw keyboard keys and modifier combos (#290)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ This server provides **14 tools** and **3 resources** for AI-assisted Godot deve
 | [Resource](tools/resource.md) | 1 | Resource inspection tools for SpriteFrames, TileSet, Materials, etc. |
 | [Scene3D](tools/scene3d.md) | 1 | 3D spatial information and bounding box tools |
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |
-| [Input](tools/input.md) | 1 | Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input) |
+| [Input](tools/input.md) | 1 | Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, and text typing (no mouse/coordinate input) |
 | [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
 | [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots. |
 | [Game Script Execution](tools/exec.md) | 1 | Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard. |

--- a/docs/design/mouse-input-spike.md
+++ b/docs/design/mouse-input-spike.md
@@ -159,6 +159,14 @@ state to confirm an effect by state-delta.
   `get_connected_joypads()` never reports a virtual pad — a game that gates
   controller mode on pad *detection* cannot be switched into it (games keying
   off received joypad events or InputMap actions, the common patterns, work).
+- **Raw keyboard / modifier injection shipped after this decision (#290).** A
+  `key` entry (e.g. `{key: "ctrl+s"}`) injects raw `InputEventKey` through the
+  same `sequence` timing model, driving `_input`/`_unhandled_input`, InputMap key
+  bindings (modifier combos included), and the polled `Input.is_key_pressed` /
+  `is_physical_key_pressed` singletons — so a game reading keys directly, without
+  defining actions, is now drivable. With this and the controller pillar (#233),
+  the keyboard/gamepad input surface is complete; mouse/coordinate input remains
+  the only gap this document records as out of scope.
 - **A real bug fix ships.** The investigation found that
   `MCPGameBridge.execute_input_sequence` dropped unfired action *releases* when it
   cleared its queue mid-flight, latching the action "pressed" forever. Fixed and

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -59,9 +59,9 @@ Fetch Godot Engine documentation with smart extraction
 
 ## [Input](input.md)
 
-Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input)
+Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, and text typing (no mouse/coordinate input)
 
-- `godot_input` - Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, and stick vectors. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).
+- `godot_input` - Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, stick vectors, and raw keyboard keys (with modifier combos). Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).
 
 ## [Profiler](profiler.md)
 

--- a/docs/tools/input.md
+++ b/docs/tools/input.md
@@ -1,6 +1,6 @@
 # Input Tools
 
-Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input)
+Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, and text typing (no mouse/coordinate input)
 
 ## Tools
 
@@ -10,14 +10,14 @@ Input injection for testing running games: named actions, joypad buttons, analog
 
 ## godot_input
 
-Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, and stick vectors. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).
+Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, stick vectors, and raw keyboard keys (with modifier combos). Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | `get_map`, `sequence`, `type_text` | Yes |  |
-| `inputs` | array | No | Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), or a STICK vector (stick + x/y) — mix freely on one timeline. Joypad events drive bound actions (with real deadzone math), raw _input handlers, and the polled Input singletons (get_joy_axis / is_joy_button_pressed); no physical pad is needed. Limitation: Input.get_connected_joypads() never reports a virtual pad, so games that gate controller mode on pad DETECTION cannot be switched into it. |
+| `inputs` | array | No | Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), a STICK vector (stick + x/y), or a raw KEY (key, e.g. "ctrl+s") — mix freely on one timeline. Joypad events drive bound actions (with real deadzone math), raw _input handlers, and the polled Input singletons (get_joy_axis / is_joy_button_pressed); key events likewise drive bound actions, _input/_unhandled_input, and Input.is_key_pressed. No physical pad or keyboard is needed. Limitation: Input.get_connected_joypads() never reports a virtual pad, so games that gate controller mode on pad DETECTION cannot be switched into it. |
 | `report` | string[] | No | Optional effect probe: GDScript expressions evaluated once before the first input and again after the last, to prove the inputs actually changed something (vs. falling into the void — player dead, UI focus elsewhere, wrong action). Reference autoloads by name (e.g. "G.shots", "G.wave") plus `tree`/`root` (e.g. "tree.get_nodes_in_group('enemies').size()"), same context as godot_game_time step_until. Each expression returns {before, after, changed}; the result also carries any_changed. Expressions do NOT short-circuit and a parse/eval error rejects the call. The after-reading is sampled a couple frames past the final input, so only near-immediate effects register — for slower effects use godot_game_time or runtime_state watch. |
 | `screenshot_at_ms` | integer[] | No | Optional: millisecond offsets (from sequence start) at which to capture a lossless PNG frame DURING the real-time run. The bridge owns the sequence clock, so it grabs each frame at the right moment and returns them with the result — letting you catch transient visuals (muzzle flashes, explosions, kill banners) that fade long before a separate screenshot call could land. Up to 8 frames, each returned as an image labeled with its actual offset; an offset (like the whole sequence) must fall within the 40000ms single-call window. COST: each frame costs vision tokens by RESOLUTION (~width*height/750), independent of format, and persists in context on every following turn — so prefer a few frames at a modest screenshot_max_width over many large ones. For frozen/precise inspection prefer godot_game_time step + screenshot_game instead. |
 | `screenshot_max_width` | integer | No | Max width in px for captured frames (default 640). Resolution is the real vision-token lever (cost ~width*height/750 per frame); lower it to spend less context, raise it only when fine detail matters. |

--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -115,15 +115,7 @@ func _get_editor_input_map() -> Dictionary:
 
 func _event_to_string(event: InputEvent) -> String:
 	if event is InputEventKey:
-		var key_event := event as InputEventKey
-		var key_name := OS.get_keycode_string(key_event.keycode)
-		if key_event.ctrl_pressed:
-			key_name = "Ctrl+" + key_name
-		if key_event.alt_pressed:
-			key_name = "Alt+" + key_name
-		if key_event.shift_pressed:
-			key_name = "Shift+" + key_name
-		return key_name
+		return MCPKeyNames.event_string(event as InputEventKey)
 	elif event is InputEventMouseButton:
 		var mouse_event := event as InputEventMouseButton
 		match mouse_event.button_index:

--- a/godot/addons/godot_mcp/game_bridge/key_names.gd
+++ b/godot/addons/godot_mcp/game_bridge/key_names.gd
@@ -1,0 +1,125 @@
+@tool
+class_name MCPKeyNames
+extends RefCounted
+## Canonical keyboard name<->keycode parsing/formatting (#290), shared by the
+## game bridge (raw InputEventKey injection) and the editor input commands
+## (get_input_map display) so the wire vocabulary and the displayed names can
+## never drift apart.
+##
+## Why this exists rather than calling OS.find_keycode_from_string directly:
+## that engine helper parses Ctrl/Shift/Alt prefixes but SILENTLY DROPS Meta/Cmd
+## (verified Godot 4.6 — "Meta+Q" returns a bare KEY_Q). We split modifiers here
+## ourselves so meta round-trips, and only hand the base token to the engine.
+
+## Modifier token -> key mask. Case-insensitive (callers lowercase first).
+## Aliases cover the common cross-platform spellings agents reach for.
+const MODIFIERS := {
+	"ctrl": KEY_MASK_CTRL,
+	"control": KEY_MASK_CTRL,
+	"shift": KEY_MASK_SHIFT,
+	"alt": KEY_MASK_ALT,
+	"option": KEY_MASK_ALT,
+	"opt": KEY_MASK_ALT,
+	"meta": KEY_MASK_META,
+	"cmd": KEY_MASK_META,
+	"command": KEY_MASK_META,
+	"super": KEY_MASK_META,
+	"win": KEY_MASK_META,
+}
+
+## Key mask -> the modifier's own keycode, so a combo can press each modifier as
+## a real key (the only way is_key_pressed(KEY_CTRL) ever reads true — the
+## modifier FLAG on another event does not update the polled singleton).
+const MODIFIER_KEYCODES := {
+	KEY_MASK_CTRL: KEY_CTRL,
+	KEY_MASK_SHIFT: KEY_SHIFT,
+	KEY_MASK_ALT: KEY_ALT,
+	KEY_MASK_META: KEY_META,
+}
+
+# The four modifier masks, in canonical display/iteration order.
+const _MOD_ORDER: Array = [KEY_MASK_CTRL, KEY_MASK_SHIFT, KEY_MASK_ALT, KEY_MASK_META]
+const _MOD_TOKENS := {
+	KEY_MASK_CTRL: "Ctrl",
+	KEY_MASK_SHIFT: "Shift",
+	KEY_MASK_ALT: "Alt",
+	KEY_MASK_META: "Meta",
+}
+
+
+## Parse a wire key value into {code:int, mask:int}. Accepts a string with
+## optional modifier prefixes ("a", "Escape", "ctrl+s", "shift+alt+f1") or a raw
+## Godot Key enum int (which may carry modifier mask bits). Returns code = KEY_NONE
+## (0) for anything that does not resolve to a base key, which the caller turns
+## into an "Unknown key" error.
+static func parse(value: Variant) -> Dictionary:
+	if value is int or value is float:
+		var raw := int(value)
+		return {"code": raw & ~int(KEY_MODIFIER_MASK), "mask": raw & int(KEY_MODIFIER_MASK)}
+
+	var s := str(value).strip_edges()
+	if s.is_empty():
+		return {"code": KEY_NONE, "mask": 0}
+
+	var mask := 0
+	var base := ""
+	for part in s.split("+", false):
+		var token := String(part).strip_edges()
+		if token.is_empty():
+			continue
+		var lower := token.to_lower()
+		if MODIFIERS.has(lower):
+			mask |= int(MODIFIERS[lower])
+		else:
+			# The last non-modifier token wins as the base (a stray extra base
+			# would just overwrite, which is fine — a malformed combo resolves to
+			# whatever its final base token is, or KEY_NONE if none resolves).
+			base = token
+
+	if base.is_empty():
+		return {"code": KEY_NONE, "mask": mask}
+
+	# find_keycode_from_string handles Ctrl/Shift/Alt itself; strip any mask bits
+	# it folded in so `code` is always a bare base keycode.
+	var resolved := int(OS.find_keycode_from_string(base))
+	mask |= resolved & int(KEY_MODIFIER_MASK)
+	var code := resolved & ~int(KEY_MODIFIER_MASK)
+	return {"code": code, "mask": mask}
+
+
+## The modifier keycodes (KEY_CTRL, ...) present in a mask, in canonical order,
+## so a combo can press each one as its own key event.
+static func modifier_key_indices(mask: int) -> Array:
+	var out: Array = []
+	for m in _MOD_ORDER:
+		if mask & int(m):
+			out.append(int(MODIFIER_KEYCODES[m]))
+	return out
+
+
+## Canonical, round-trippable display for a key binding (get_input_map). Modifier
+## prefixes come from the event's own flags with fixed tokens (platform-stable,
+## and re-parseable here — unlike OS.get_keycode_string's mask spelling, which
+## find_keycode_from_string cannot read back for Meta). A physical-only binding
+## (keycode unset) renders from physical_keycode with a "(physical)" marker so an
+## agent knows to inject it with physical:true.
+static func event_string(event: InputEventKey) -> String:
+	var prefix := ""
+	if event.ctrl_pressed:
+		prefix += _MOD_TOKENS[KEY_MASK_CTRL] + "+"
+	if event.shift_pressed:
+		prefix += _MOD_TOKENS[KEY_MASK_SHIFT] + "+"
+	if event.alt_pressed:
+		prefix += _MOD_TOKENS[KEY_MASK_ALT] + "+"
+	if event.meta_pressed:
+		prefix += _MOD_TOKENS[KEY_MASK_META] + "+"
+
+	if event.keycode != KEY_NONE:
+		var base := OS.get_keycode_string(event.keycode)
+		return prefix + (base if not base.is_empty() else "Key %d" % int(event.keycode))
+	if event.physical_keycode != KEY_NONE:
+		var pbase := OS.get_keycode_string(event.physical_keycode)
+		return prefix + (pbase if not pbase.is_empty() else "Key %d" % int(event.physical_keycode)) + " (physical)"
+	# Last resort: an event with neither keycode set (e.g. unicode-only).
+	var label := prefix.trim_suffix("+")
+	return label if not label.is_empty() else "(unset)"

--- a/godot/addons/godot_mcp/game_bridge/key_names.gd
+++ b/godot/addons/godot_mcp/game_bridge/key_names.gd
@@ -104,12 +104,13 @@ static func modifier_key_indices(mask: int) -> Array:
 	return out
 
 
-## Canonical, round-trippable display for a key binding (get_input_map). Modifier
-## prefixes come from the event's own flags with fixed tokens (platform-stable,
-## and re-parseable here — unlike OS.get_keycode_string's mask spelling, which
-## find_keycode_from_string cannot read back for Meta). A physical-only binding
-## (keycode unset) renders from physical_keycode with a "(physical)" marker so an
-## agent knows to inject it with physical:true.
+## Canonical display for a key binding (get_input_map). Modifier prefixes come
+## from the event's own flags with fixed tokens (platform-stable, and re-parseable
+## by parse() — unlike OS.get_keycode_string's mask spelling, which
+## find_keycode_from_string cannot read back for Meta). A logical key + modifier
+## combo round-trips through parse(); a physical-only binding (keycode unset)
+## renders from physical_keycode with a "(physical)" marker that tells an agent to
+## inject with physical:true — that marker is display-only, not re-parseable.
 static func event_string(event: InputEventKey) -> String:
 	var prefix := ""
 	if event.ctrl_pressed:

--- a/godot/addons/godot_mcp/game_bridge/key_names.gd
+++ b/godot/addons/godot_mcp/game_bridge/key_names.gd
@@ -77,6 +77,13 @@ static func parse(value: Variant) -> Dictionary:
 			base = token
 
 	if base.is_empty():
+		# A lone modifier name ("shift", "ctrl", "cmd") means the modifier KEY
+		# itself — e.g. a game binding bare Shift, or polling is_key_pressed(KEY_CTRL).
+		# Exactly one modifier resolves to its keycode; a baseless multi-modifier
+		# combo ("ctrl+shift") is ambiguous and stays unknown.
+		for m in _MOD_ORDER:
+			if mask == int(m):
+				return {"code": int(MODIFIER_KEYCODES[m]), "mask": 0}
 		return {"code": KEY_NONE, "mask": mask}
 
 	# find_keycode_from_string handles Ctrl/Shift/Alt itself; strip any mask bits

--- a/godot/addons/godot_mcp/game_bridge/key_names.gd.uid
+++ b/godot/addons/godot_mcp/game_bridge/key_names.gd.uid
@@ -1,0 +1,1 @@
+uid://blya2h0lff4ar

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -298,13 +298,19 @@ var _held_actions: Dictionary = {}
 # Input singletons (is_joy_button_pressed / get_joy_axis) until game restart.
 var _held_joy_buttons: Dictionary = {}
 var _active_axes: Dictionary = {}
+# Same guarantee for raw keys (#290), keyed by "physical:code". Refcounted: a
+# combo presses each modifier as its own key, and overlapping entries can hold
+# the same key more than once, so the entry tracks a press COUNT and the engine
+# release only fires when it returns to zero. Stores primitives only ({count,
+# physical, code, mask}) so the cleanup loop never touches a freed instance.
+var _held_keys: Dictionary = {}
 
 
-# Release any action/button still held and re-zero any active axis from an
+# Release any action/button/key still held and re-zero any active axis from an
 # interrupted sequence. A release here is a guaranteed cleanup, never a queued
 # step that a clear could drop. Safe to call when nothing is held.
 func _release_held_actions() -> void:
-	if _held_actions.is_empty() and _held_joy_buttons.is_empty() and _active_axes.is_empty():
+	if _held_actions.is_empty() and _held_joy_buttons.is_empty() and _active_axes.is_empty() and _held_keys.is_empty():
 		return
 	for action in _held_actions.keys():
 		var release := InputEventAction.new()
@@ -326,12 +332,16 @@ func _release_held_actions() -> void:
 		azero.axis = int(ainfo["axis"]) as JoyAxis
 		azero.axis_value = 0.0
 		Input.parse_input_event(azero)
+	for kkey in _held_keys.keys():
+		var kinfo = _held_keys[kkey]
+		Input.parse_input_event(_make_key_event(bool(kinfo["physical"]), int(kinfo["code"]), int(kinfo["mask"]), false))
 	# Flush so the release takes effect immediately — _exit_tree may not get
 	# another frame, and a cleanup should be deterministic, not deferred.
 	Input.flush_buffered_events()
 	_held_actions.clear()
 	_held_joy_buttons.clear()
 	_active_axes.clear()
+	_held_keys.clear()
 
 
 func _on_debugger_message(message: String, data: Array) -> bool:
@@ -1166,15 +1176,7 @@ func _handle_get_input_map() -> void:
 
 func _event_to_string(event: InputEvent) -> String:
 	if event is InputEventKey:
-		var key_event := event as InputEventKey
-		var key_name := OS.get_keycode_string(key_event.keycode)
-		if key_event.ctrl_pressed:
-			key_name = "Ctrl+" + key_name
-		if key_event.alt_pressed:
-			key_name = "Alt+" + key_name
-		if key_event.shift_pressed:
-			key_name = "Shift+" + key_name
-		return key_name
+		return MCPKeyNames.event_string(event as InputEventKey)
 	elif event is InputEventMouseButton:
 		var mouse_event := event as InputEventMouseButton
 		match mouse_event.button_index:
@@ -1206,7 +1208,7 @@ func _handle_execute_input_sequence(data: Array) -> void:
 	# Reset the skew echo up front: the result's input_kinds must reflect THIS
 	# call's compile, never a stale value from a prior sequence (its absence is
 	# how a new server detects an old bridge — a stale dict would mask that).
-	_sequence_input_kinds = {"action": 0, "joy_button": 0, "axis": 0}
+	_sequence_input_kinds = _new_input_kinds()
 
 	if inputs.is_empty():
 		EngineDebugger.send_message("godot_mcp:input_sequence_result", [{
@@ -1522,7 +1524,7 @@ func _handle_game_time_step(data: Array) -> void:
 
 	# Reset the skew echo up front (see _handle_execute_input_sequence): the
 	# step result's input_kinds must reflect this call, never a prior step's.
-	_step_input_kinds = {"action": 0, "joy_button": 0, "axis": 0}
+	_step_input_kinds = _new_input_kinds()
 
 	var duration_ms: int = int(params.get("duration_ms", 0))
 	var frames: int = int(params.get("frames", 0))
@@ -1575,17 +1577,25 @@ func _handle_game_time_step(data: Array) -> void:
 	_update_processing()
 
 
+func _new_input_kinds() -> Dictionary:
+	# One source of truth for the input_kinds shape so every reset/result site
+	# carries the same keys (#290 added "key"). A missing key here would make the
+	# server's skew check misfire against our own bridge.
+	return {"action": 0, "joy_button": 0, "axis": 0, "key": 0}
+
+
 func _compile_input_events(inputs: Array) -> Dictionary:
 	# Builds the typed input timeline shared by input sequences and game-time
-	# steps (#233). Each entry is discriminated by which key it carries:
-	# `axis` (analog joypad axis), `joy_button`, or `action_name` (with optional
-	# fractional `strength`). Returns {"events": [...], "kinds": {...}} or
-	# {"error": ...} on an unknown action/button/axis. Every event carries:
+	# steps (#233/#290). Each entry is discriminated by which key it carries:
+	# `axis` (analog joypad axis), `joy_button`, `key` (raw keyboard / modifier
+	# combo), or `action_name` (with optional fractional `strength`). Returns
+	# {"events": [...], "kinds": {...}} or {"error": ...} on an unknown
+	# action/button/axis/key. Every event carries:
 	#   time     - ms offset from sequence/window start
 	#   phase    - 0 = release/zero-set, 1 = press/set (the equal-time tie-break)
 	#   complete - completion credit, counted when the event fires (1 on ends)
 	var events: Array = []
-	var kinds := {"action": 0, "joy_button": 0, "axis": 0}
+	var kinds := _new_input_kinds()
 	for input in inputs:
 		var start_ms: int = int(input.get("start_ms", 0))
 		var dur: int = int(input.get("duration_ms", 0))
@@ -1616,6 +1626,32 @@ func _compile_input_events(inputs: Array) -> Dictionary:
 				"kind": "joy_button", "button": button, "device": bdevice, "is_press": true})
 			events.append({"time": end_ms, "phase": 0, "complete": 1,
 				"kind": "joy_button", "button": button, "device": bdevice, "is_press": false})
+		elif input.has("key"):
+			var parsed := MCPKeyNames.parse(input["key"])
+			var code: int = int(parsed["code"])
+			if code == KEY_NONE:
+				return {"error": "Unknown key: %s (e.g. \"a\", \"escape\", \"ctrl+s\", \"shift+f1\")" % str(input["key"])}
+			var mask: int = int(parsed["mask"])
+			var physical: bool = bool(input.get("physical", false))
+			kinds["key"] += 1
+			# Each modifier is pressed/released as its own real key so polled
+			# is_key_pressed(KEY_CTRL) reads true (the modifier FLAG on another
+			# event does not update that singleton). The base event also carries
+			# the modifier flags so InputMap chords and _input handlers match.
+			# Modifier keys are position-stable -> set both keycode+physical (mask
+			# 0, an exact match for a bare-modifier binding); the base honors
+			# `physical`. Completion credit (1) rides only the base release.
+			var mod_keys := MCPKeyNames.modifier_key_indices(mask)
+			for mk in mod_keys:
+				events.append({"time": start_ms, "phase": 1, "complete": 0,
+					"kind": "key", "code": int(mk), "physical": false, "mask": 0, "is_press": true})
+			events.append({"time": start_ms, "phase": 1, "complete": 0,
+				"kind": "key", "code": code, "physical": physical, "mask": mask, "is_press": true})
+			events.append({"time": end_ms, "phase": 0, "complete": 1,
+				"kind": "key", "code": code, "physical": physical, "mask": mask, "is_press": false})
+			for mk in mod_keys:
+				events.append({"time": end_ms, "phase": 0, "complete": 0,
+					"kind": "key", "code": int(mk), "physical": false, "mask": 0, "is_press": false})
 		else:
 			var action_name: String = input.get("action_name", "")
 			if action_name.is_empty():
@@ -1667,10 +1703,10 @@ func _cancel_redundant_axis_zeroes(events: Array) -> void:
 func _inject_timeline_event(ev: Dictionary) -> int:
 	# Build and parse the engine event for one timeline entry, maintaining the
 	# held-state registries that _release_held_actions uses for guaranteed
-	# cleanup. Returns the event's completion credit. Joypad events drive the
-	# polled Input singletons too (get_joy_axis / is_joy_button_pressed): unlike
-	# the mouse cursor, parse_input_event updates joypad state for any device id
-	# with no physical pad required.
+	# cleanup. Returns the event's completion credit. Joypad and key events drive
+	# the polled Input singletons too (get_joy_axis / is_joy_button_pressed /
+	# is_key_pressed): unlike the mouse cursor, parse_input_event updates that
+	# state for any device id with no physical pad/keyboard required.
 	match str(ev.kind):
 		"action":
 			var ae := InputEventAction.new()
@@ -1704,7 +1740,52 @@ func _inject_timeline_event(ev: Dictionary) -> int:
 				_active_axes[akey] = {"device": ev.device, "axis": ev.axis}
 			else:
 				_active_axes.erase(akey)
+		"key":
+			var code: int = int(ev.code)
+			var physical: bool = bool(ev.physical)
+			var kkey := "%d:%d" % [int(physical), code]
+			# Refcount: a combo presses each modifier as its own key, and
+			# overlapping entries can hold the same key more than once. Drive the
+			# engine only on the 0<->1 edge so an inner release never turns a
+			# still-held key off (the early-release bug), and the registry mirrors
+			# the real pressed state for guaranteed cleanup.
+			if ev.is_press:
+				if _held_keys.has(kkey):
+					_held_keys[kkey]["count"] = int(_held_keys[kkey]["count"]) + 1
+				else:
+					_held_keys[kkey] = {"count": 1, "physical": physical, "code": code, "mask": int(ev.mask)}
+					Input.parse_input_event(_make_key_event(physical, code, int(ev.mask), true))
+			elif _held_keys.has(kkey):
+				var n := int(_held_keys[kkey]["count"]) - 1
+				if n <= 0:
+					_held_keys.erase(kkey)
+					Input.parse_input_event(_make_key_event(physical, code, int(ev.mask), false))
+				else:
+					_held_keys[kkey]["count"] = n
 	return int(ev.get("complete", 0))
+
+
+# Build an InputEventKey. A logical key sets both keycode and physical_keycode
+# (a realistic US-layout event that drives is_key_pressed AND is_physical_key_pressed
+# plus either binding kind); physical:true sends a physical-only event (keycode
+# unset) for layout-independent / physical-keycode-binding testing.
+func _make_key_event(physical: bool, code: int, mask: int, pressed: bool) -> InputEventKey:
+	var ke := InputEventKey.new()
+	if physical:
+		ke.physical_keycode = code as Key
+	else:
+		ke.keycode = code as Key
+		ke.physical_keycode = code as Key
+	_apply_key_modifiers(ke, mask)
+	ke.pressed = pressed
+	return ke
+
+
+func _apply_key_modifiers(ke: InputEventKey, mask: int) -> void:
+	ke.ctrl_pressed = (mask & int(KEY_MASK_CTRL)) != 0
+	ke.shift_pressed = (mask & int(KEY_MASK_SHIFT)) != 0
+	ke.alt_pressed = (mask & int(KEY_MASK_ALT)) != 0
+	ke.meta_pressed = (mask & int(KEY_MASK_META)) != 0
 
 
 func _build_predicate_context() -> Dictionary:
@@ -1784,7 +1865,7 @@ func _handle_game_time_step_until(data: Array) -> void:
 		return
 
 	# Reset the skew echo up front (see _handle_execute_input_sequence).
-	_step_input_kinds = {"action": 0, "joy_button": 0, "axis": 0}
+	_step_input_kinds = _new_input_kinds()
 
 	var src: String = str(params.get("until", "")).strip_edges()
 	if src.is_empty():
@@ -1944,7 +2025,7 @@ func _step_process(delta: float) -> void:
 func _finish_step() -> void:
 	# Releases are guaranteed cleanup, never queued steps: no holds survive
 	# across the freeze boundary (cross-step holds are a deliberate non-goal).
-	var forced := _held_actions.size() + _held_joy_buttons.size() + _active_axes.size()
+	var forced := _held_actions.size() + _held_joy_buttons.size() + _active_axes.size() + _held_keys.size()
 	_release_held_actions()
 	var dropped := _step_events.size()
 	_step_events.clear()

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1749,6 +1749,13 @@ func _inject_timeline_event(ev: Dictionary) -> int:
 			# engine only on the 0<->1 edge so an inner release never turns a
 			# still-held key off (the early-release bug), and the registry mirrors
 			# the real pressed state for guaranteed cleanup.
+			# Keyed by (physical, code) only, NOT mask: two overlapping combos that
+			# share a base key but differ in modifiers (e.g. ctrl+s and shift+s)
+			# collapse to one entry, so the shared base event reflects the FIRST
+			# combo's modifier flags. The polled key state stays correct (one key,
+			# refcounted, no early release); only the base event's flags differ for
+			# that exotic overlap. Keying by mask instead would split them and
+			# reintroduce an early release of the shared base key — the worse bug.
 			if ev.is_press:
 				if _held_keys.has(kkey):
 					_held_keys[kkey]["count"] = int(_held_keys[kkey]["count"]) + 1

--- a/godot/addons/godot_mcp/test/input_joypad_injection_test.gd
+++ b/godot/addons/godot_mcp/test/input_joypad_injection_test.gd
@@ -269,7 +269,7 @@ func _run() -> void:
 		{"axis": "left_x", "value": 1.0, "duration_ms": 10},
 	])
 	_check("mixed timeline counts kinds for the skew echo",
-		mixed["kinds"], {"action": 1, "joy_button": 1, "axis": 1})
+		mixed["kinds"], {"action": 1, "joy_button": 1, "axis": 1, "key": 0})
 
 	# ── 9. get_input_map axis/button display carries direction + name ─────────
 	# (the agent lifts axis + signed value straight into an injection).

--- a/godot/addons/godot_mcp/test/input_key_injection_test.gd
+++ b/godot/addons/godot_mcp/test/input_key_injection_test.gd
@@ -1,0 +1,339 @@
+extends SceneTree
+
+## Headless pins for raw keyboard / modifier-combo injection (#290), driving the
+## REAL MCPGameBridge sequence engine.
+##
+## WHAT IT PINS (engine ground truth from Godot 4.6 core/input/input.cpp):
+##  - Input.parse_input_event(InputEventKey) updates the POLLED Input singletons
+##    (is_key_pressed / is_physical_key_pressed) for any device with no physical
+##    keyboard — the property that makes raw-key injection viable.
+##  - A logical key sets both keycode and physical_keycode; physical:true sends a
+##    physical-only event (keycode unset) for layout-independent testing — and a
+##    keycode-bound action then does NOT match (the documented footgun).
+##  - Modifier combos press each modifier as its own real key, so polled
+##    is_key_pressed(KEY_CTRL) holds AND a bare-Ctrl-bound action fires (faithful
+##    to a real keyboard); the base event also carries the modifier FLAGS so
+##    InputMap chords and _input handlers match.
+##  - The held-key registry is refcounted: overlapping entries that share a key
+##    keep it held until the LAST release (no early release), and an interrupted
+##    sequence / tree exit guarantee every held key is released.
+##  - get_input_map key display round-trips through MCPKeyNames (parse . event_string).
+##
+## Step-window parity is by construction: game_time step compiles through the same
+## _compile_input_events and injects through the same _inject_timeline_event as the
+## sequence path white-boxed here. The step path's freeze/pause semantics make a
+## bare-SceneTree drive hang-prone, so step key injection is covered by the shared
+## code paths above, the server vitest, and live MCP validation, not re-driven here.
+##
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/input_key_injection_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const KEY_ACT := "mcp_probe_key"          # bound to InputEventKey keycode J
+const CTRL_S_ACT := "mcp_probe_ctrl_s"    # bound to keycode S + ctrl
+const KEYCODE_ACT := "mcp_probe_keycode"  # bound to keycode M (logical)
+const BARE_CTRL_ACT := "mcp_probe_bare_ctrl"  # bound to bare keycode CTRL
+
+var _count := 0
+var _failures := 0
+
+
+class _Cap extends Node:
+	## Captures InputEventKey delivery so _input/_unhandled_input reach is asserted.
+	var keys: Array = []        # {keycode, physical, ctrl, shift, alt, meta, pressed}
+	var unhandled := false
+	func _ready() -> void:
+		set_process_input(true)
+		set_process_unhandled_input(true)
+	func clear() -> void:
+		keys.clear()
+		unhandled = false
+	func _input(event: InputEvent) -> void:
+		if event is InputEventKey:
+			var k := event as InputEventKey
+			keys.append({"keycode": int(k.keycode), "physical": int(k.physical_keycode),
+				"ctrl": k.ctrl_pressed, "shift": k.shift_pressed, "alt": k.alt_pressed,
+				"meta": k.meta_pressed, "pressed": k.pressed})
+	func _unhandled_input(event: InputEvent) -> void:
+		if event is InputEventKey:
+			unhandled = true
+	func saw_pressed(keycode: int, ctrl: bool) -> bool:
+		for e in keys:
+			if int(e["keycode"]) == keycode and bool(e["pressed"]) and bool(e["ctrl"]) == ctrl:
+				return true
+		return false
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _register_key_action(name: String, keycode: Key, ctrl: bool = false) -> void:
+	if InputMap.has_action(name):
+		return
+	InputMap.add_action(name)
+	var bind := InputEventKey.new()
+	bind.keycode = keycode
+	bind.ctrl_pressed = ctrl
+	InputMap.action_add_event(name, bind)
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	_register_key_action(KEY_ACT, KEY_J)
+	_register_key_action(CTRL_S_ACT, KEY_S, true)
+	_register_key_action(KEYCODE_ACT, KEY_M)
+	_register_key_action(BARE_CTRL_ACT, KEY_CTRL)
+
+	print("\n===================== KEY INJECTION TEST (#290) =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var bridge := MCPGameBridge.new()
+	root.add_child(bridge)
+	var cap := _Cap.new()
+	root.add_child(cap)
+	for i in 3:
+		await process_frame
+
+	# ── 1. Polled is_key_pressed for a held key, released on interrupt ────────
+	bridge._handle_execute_input_sequence([[{"key": "a", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("held {key:'a'} drives polled is_key_pressed(KEY_A)", Input.is_key_pressed(KEY_A), true)
+	_check("logical key also sets physical (US-layout event)", Input.is_physical_key_pressed(KEY_A), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+	_check("interrupting sequence released the held key", Input.is_key_pressed(KEY_A), false)
+
+	# ── 2. physical:true sends a physical-only event ─────────────────────────
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "a", "physical": true, "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("physical:true drives is_physical_key_pressed", Input.is_physical_key_pressed(KEY_A), true)
+	_check("physical:true leaves the LOGICAL keycode unset", Input.is_key_pressed(KEY_A), false)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+	_check("physical hold released on interrupt", Input.is_physical_key_pressed(KEY_A), false)
+
+	# ── 3. Modifier combo: each modifier pressed as a real key (polled) ──────
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "ctrl+s", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("combo holds the base key polled", Input.is_key_pressed(KEY_S), true)
+	_check("combo holds the MODIFIER key polled (is_key_pressed(KEY_CTRL))", Input.is_key_pressed(KEY_CTRL), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+	_check("combo base released after interrupt", Input.is_key_pressed(KEY_S), false)
+	_check("combo modifier released after interrupt", Input.is_key_pressed(KEY_CTRL), false)
+	# Case-insensitive parse equivalence (white-box).
+	var lower: Dictionary = MCPKeyNames.parse("ctrl+s")
+	var mixed_case: Dictionary = MCPKeyNames.parse("Ctrl+S")
+	_check("key parse is case-insensitive", [int(lower["code"]), int(lower["mask"])], [int(mixed_case["code"]), int(mixed_case["mask"])])
+
+	# ── 4. InputMap key bindings; modifier required for the chord ────────────
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "j", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("{key:'j'} fires the key-bound action", Input.is_action_pressed(KEY_ACT), true)
+	bridge._handle_execute_input_sequence([[{"key": "s", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("plain {key:'s'} does NOT fire the Ctrl+S action (modifier required)", Input.is_action_pressed(CTRL_S_ACT), false)
+	bridge._handle_execute_input_sequence([[{"key": "ctrl+s", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("{key:'ctrl+s'} fires the Ctrl+S action", Input.is_action_pressed(CTRL_S_ACT), true)
+
+	# ── 5. Faithful edge: the combo also fires a bare-Ctrl-bound action ──────
+	_check("EXPECTED: combo also presses a bare-Ctrl-bound action (real keyboard)", Input.is_action_pressed(BARE_CTRL_ACT), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+
+	# ── 6. NEGATIVE physical: physical-only does not fire a keycode binding ──
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "m", "physical": true, "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("physical:true does NOT fire a keycode-bound action (documented footgun)", Input.is_action_pressed(KEYCODE_ACT), false)
+	bridge._handle_execute_input_sequence([[{"key": "m", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("default (logical) DOES fire the same keycode-bound action", Input.is_action_pressed(KEYCODE_ACT), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+
+	# ── 7. _input / _unhandled_input delivery with modifier flags ────────────
+	await _settle()
+	cap.clear()
+	bridge._handle_execute_input_sequence([[{"key": "ctrl+s", "start_ms": 0, "duration_ms": 100000}]])
+	for i in 4:
+		await process_frame
+	_check("_input received the base key with the ctrl flag set", cap.saw_pressed(KEY_S, true), true)
+	_check("_input received the modifier key (KEY_CTRL) as a real key", cap.saw_pressed(KEY_CTRL, false), true)
+	_check("_unhandled_input also reached for injected keys", cap.unhandled, true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+
+	# ── 8. Instant tap (duration 0 — the schema default) must not latch ──────
+	await _settle()
+	var tap: Dictionary = bridge._compile_input_events([{"key": "a", "start_ms": 0, "duration_ms": 0}])
+	var tap_evts: Array = tap["events"]
+	_check("instant-tap key press compiled before its release",
+		[bool(tap_evts[0].get("is_press")), int(tap_evts[0]["time"]) < int(tap_evts[1]["time"])], [true, true])
+	bridge._handle_execute_input_sequence([[{"key": "a", "start_ms": 0, "duration_ms": 0}]])
+	for i in 6:
+		await process_frame
+	_check("instant-tap key is NOT latched after the sequence", Input.is_key_pressed(KEY_A), false)
+
+	# ── 9. Refcount/overlap: a shared modifier is held until the LAST release ─
+	await _settle()
+	bridge._handle_execute_input_sequence([[
+		{"key": "ctrl+s", "start_ms": 0, "duration_ms": 300},
+		{"key": "ctrl+a", "start_ms": 100, "duration_ms": 300},
+	]])
+	var ovl_start := Time.get_ticks_msec()
+	var ctrl_dropped_mid := false
+	var saw_s := false
+	var saw_a := false
+	var guard := 0
+	while bridge._sequence_running and guard < 800:
+		guard += 1
+		await process_frame
+		var el := Time.get_ticks_msec() - ovl_start
+		if Input.is_key_pressed(KEY_S):
+			saw_s = true
+		if Input.is_key_pressed(KEY_A):
+			saw_a = true
+		# Window between ctrl+s's release (~300) and ctrl+a's (~400): CTRL must
+		# stay held (the early-release bug a boolean registry would cause).
+		if el > 320 and el < 380 and not Input.is_key_pressed(KEY_CTRL):
+			ctrl_dropped_mid = true
+	for i in 4:
+		await process_frame
+	_check("overlap: base key S registered", saw_s, true)
+	_check("overlap: base key A registered", saw_a, true)
+	_check("overlap: shared modifier NOT released early (refcounted)", ctrl_dropped_mid, false)
+	_check("overlap: modifier released after the last entry", Input.is_key_pressed(KEY_CTRL), false)
+
+	# ── 10. Abutting combos sharing a modifier: final state is clean ─────────
+	# (The one-frame just_released edge on the shared modifier at the boundary is
+	# accepted, matching the button double-tap-edge asymmetry — not asserted.)
+	await _settle()
+	bridge._handle_execute_input_sequence([[
+		{"key": "ctrl+s", "start_ms": 0, "duration_ms": 120},
+		{"key": "ctrl+a", "start_ms": 120, "duration_ms": 120},
+	]])
+	var ab_guard := 0
+	while bridge._sequence_running and ab_guard < 800:
+		ab_guard += 1
+		await process_frame
+	for i in 4:
+		await process_frame
+	_check("abutting combos: all keys clean after both segments",
+		[Input.is_key_pressed(KEY_CTRL), Input.is_key_pressed(KEY_S), Input.is_key_pressed(KEY_A)], [false, false, false])
+
+	# ── 11. Guaranteed release on tree exit ──────────────────────────────────
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "ctrl+shift+f1", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("tree-exit case armed (modifier held)", Input.is_key_pressed(KEY_CTRL), true)
+	root.remove_child(bridge)
+	_check("tree exit released the held base key", Input.is_key_pressed(KEY_F1), false)
+	_check("tree exit released the held modifier (ctrl)", Input.is_key_pressed(KEY_CTRL), false)
+	_check("tree exit released the held modifier (shift)", Input.is_key_pressed(KEY_SHIFT), false)
+	root.add_child(bridge)
+	await process_frame
+
+	# ── 12. Raw int keycode + modifier-mask split ────────────────────────────
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": KEY_B, "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("raw int keycode drives is_key_pressed", Input.is_key_pressed(KEY_B), true)
+	bridge._handle_execute_input_sequence([[{"key": KEY_D | KEY_MASK_CTRL, "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("raw int with mask presses the base", Input.is_key_pressed(KEY_D), true)
+	_check("raw int with mask presses the modifier too", Input.is_key_pressed(KEY_CTRL), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+
+	# ── 13. Compile errors for unknown keys ──────────────────────────────────
+	var bad_key: Dictionary = bridge._compile_input_events([{"key": "notakey"}])
+	_check("unknown key name rejected", str(bad_key.get("error", "")).begins_with("Unknown key"), true)
+	var bad_combo: Dictionary = bridge._compile_input_events([{"key": "ctrl+notakey"}])
+	_check("unknown key in a combo rejected", str(bad_combo.get("error", "")).begins_with("Unknown key"), true)
+
+	# ── 14. input_kinds carries a key count; mixed kinds counted ─────────────
+	var mixed: Dictionary = bridge._compile_input_events([
+		{"action_name": KEY_ACT, "duration_ms": 10},
+		{"joy_button": "a", "duration_ms": 10},
+		{"axis": "left_x", "value": 1.0, "duration_ms": 10},
+		{"key": "ctrl+s", "duration_ms": 10},
+	])
+	_check("mixed timeline counts the key kind for the skew echo",
+		mixed["kinds"], {"action": 1, "joy_button": 1, "axis": 1, "key": 1})
+
+	# ── 15. event_string format + round-trip (get_input_map display) ─────────
+	var ev := InputEventKey.new()
+	ev.keycode = KEY_S
+	ev.ctrl_pressed = true
+	_check("logical combo stringifies canonically", MCPKeyNames.event_string(ev), "Ctrl+S")
+	var rt: Dictionary = MCPKeyNames.parse(MCPKeyNames.event_string(ev))
+	_check("logical combo round-trips through parse", [int(rt["code"]), int(rt["mask"])], [int(KEY_S), int(KEY_MASK_CTRL)])
+	var mev := InputEventKey.new()
+	mev.keycode = KEY_Q
+	mev.meta_pressed = true
+	_check("meta combo stringifies (find_keycode_from_string can't, our parser can)", MCPKeyNames.event_string(mev), "Meta+Q")
+	var mrt: Dictionary = MCPKeyNames.parse(MCPKeyNames.event_string(mev))
+	_check("meta combo round-trips", [int(mrt["code"]), int(mrt["mask"])], [int(KEY_Q), int(KEY_MASK_META)])
+	var pev := InputEventKey.new()
+	pev.physical_keycode = KEY_W
+	_check("physical-only binding shows the (physical) marker", MCPKeyNames.event_string(pev), "W (physical)")
+	# Integration: the bridge's get_input_map display routes through the same helper.
+	_check("bridge._event_to_string matches MCPKeyNames.event_string", bridge._event_to_string(ev), "Ctrl+S")
+
+	root.remove_child(bridge)
+	bridge.free()
+	cap.free()
+
+	for a in [KEY_ACT, CTRL_S_ACT, KEYCODE_ACT, BARE_CTRL_ACT]:
+		if InputMap.has_action(a):
+			InputMap.erase_action(a)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _settle() -> void:
+	# A short gap + a few frames between holds, so a prior interrupt's release has
+	# fully flushed before the next assertion (mirrors the joypad test).
+	await create_timer(0.05).timeout
+	for i in 4:
+		await process_frame
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/input_key_injection_test.gd
+++ b/godot/addons/godot_mcp/test/input_key_injection_test.gd
@@ -33,6 +33,7 @@ const KEY_ACT := "mcp_probe_key"          # bound to InputEventKey keycode J
 const CTRL_S_ACT := "mcp_probe_ctrl_s"    # bound to keycode S + ctrl
 const KEYCODE_ACT := "mcp_probe_keycode"  # bound to keycode M (logical)
 const BARE_CTRL_ACT := "mcp_probe_bare_ctrl"  # bound to bare keycode CTRL
+const PHYS_ACT := "mcp_probe_physical"    # bound to PHYSICAL keycode N (no logical keycode)
 
 var _count := 0
 var _failures := 0
@@ -86,6 +87,12 @@ func _run() -> void:
 	_register_key_action(CTRL_S_ACT, KEY_S, true)
 	_register_key_action(KEYCODE_ACT, KEY_M)
 	_register_key_action(BARE_CTRL_ACT, KEY_CTRL)
+	# A PHYSICAL-keycode binding (no logical keycode) for the positive physical case.
+	if not InputMap.has_action(PHYS_ACT):
+		InputMap.add_action(PHYS_ACT)
+		var pbind := InputEventKey.new()
+		pbind.physical_keycode = KEY_N
+		InputMap.action_add_event(PHYS_ACT, pbind)
 
 	print("\n===================== KEY INJECTION TEST (#290) =====================\n")
 	print("DisplayServer name: %s" % DisplayServer.get_name())
@@ -188,6 +195,17 @@ func _run() -> void:
 	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
 	for i in 4:
 		await process_frame
+	# POSITIVE physical: physical:true DOES fire a PHYSICAL-keycode binding (the
+	# other half of the footgun — polled is_physical_key_pressed alone is not proof
+	# that the InputMap physical-match path also fires).
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "n", "physical": true, "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("physical:true DOES fire a physical-keycode-bound action", Input.is_action_pressed(PHYS_ACT), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
 
 	# ── 7. _input / _unhandled_input delivery with modifier flags ────────────
 	await _settle()
@@ -219,29 +237,78 @@ func _run() -> void:
 		{"key": "ctrl+s", "start_ms": 0, "duration_ms": 300},
 		{"key": "ctrl+a", "start_ms": 100, "duration_ms": 300},
 	]])
-	var ovl_start := Time.get_ticks_msec()
-	var ctrl_dropped_mid := false
+	# Timing-immune checks (a fixed wall-clock window could miss the boundary if no
+	# frame lands in it): white-box the refcount reaching 2, and assert CTRL is held
+	# on EVERY frame A is down — A outlives ctrl+s, so an early release of the shared
+	# modifier shows up as "A down but CTRL up" on whatever frame it happens.
+	var ctrl_key := "%d:%d" % [0, KEY_CTRL]
+	var ctrl_count_max := 0
+	var ctrl_dropped_while_a_held := false
 	var saw_s := false
 	var saw_a := false
 	var guard := 0
 	while bridge._sequence_running and guard < 800:
 		guard += 1
 		await process_frame
-		var el := Time.get_ticks_msec() - ovl_start
+		var a_down := Input.is_key_pressed(KEY_A)
 		if Input.is_key_pressed(KEY_S):
 			saw_s = true
-		if Input.is_key_pressed(KEY_A):
+		if a_down:
 			saw_a = true
-		# Window between ctrl+s's release (~300) and ctrl+a's (~400): CTRL must
-		# stay held (the early-release bug a boolean registry would cause).
-		if el > 320 and el < 380 and not Input.is_key_pressed(KEY_CTRL):
-			ctrl_dropped_mid = true
+		ctrl_count_max = maxi(ctrl_count_max, int(bridge._held_keys.get(ctrl_key, {}).get("count", 0)))
+		if a_down and not Input.is_key_pressed(KEY_CTRL):
+			ctrl_dropped_while_a_held = true
 	for i in 4:
 		await process_frame
 	_check("overlap: base key S registered", saw_s, true)
 	_check("overlap: base key A registered", saw_a, true)
-	_check("overlap: shared modifier NOT released early (refcounted)", ctrl_dropped_mid, false)
+	_check("overlap: CTRL refcount reached 2 (both combos held it; white-box, timing-immune)", ctrl_count_max, 2)
+	_check("overlap: shared modifier never dropped while A was still held (no early release)", ctrl_dropped_while_a_held, false)
 	_check("overlap: modifier released after the last entry", Input.is_key_pressed(KEY_CTRL), false)
+
+	# ── 9b. Independent distinct keys (WASD-style): held and released separately ─
+	await _settle()
+	bridge._handle_execute_input_sequence([[
+		{"key": "a", "start_ms": 0, "duration_ms": 130},
+		{"key": "b", "start_ms": 0, "duration_ms": 100000},
+	]])
+	var both_down := false
+	var a_off_b_on := false
+	var ind_guard := 0
+	while bridge._sequence_running and ind_guard < 800:
+		ind_guard += 1
+		await process_frame
+		var a := Input.is_key_pressed(KEY_A)
+		var b := Input.is_key_pressed(KEY_B)
+		if a and b:
+			both_down = true
+		if (not a) and b:
+			a_off_b_on = true
+	_check("multi-key: distinct keys A and B held simultaneously", both_down, true)
+	_check("multi-key: A released independently while B stayed held", a_off_b_on, true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+	_check("multi-key: B released by the interrupting sequence", Input.is_key_pressed(KEY_B), false)
+
+	# ── 9c. Shared base key, DIFFERENT modifiers (the registry keys on code only) ─
+	# Documented edge (SF1): two combos sharing a base collapse to one refcounted
+	# entry, so the base event's modifier FLAGS reflect the first combo — but the
+	# POLLED key state stays correct (no stuck base key; both modifier keys held).
+	await _settle()
+	bridge._handle_execute_input_sequence([[
+		{"key": "ctrl+s", "start_ms": 0, "duration_ms": 100000},
+		{"key": "shift+s", "start_ms": 0, "duration_ms": 100000},
+	]])
+	await process_frame
+	await process_frame
+	_check("shared-base: S held once for both combos", Input.is_key_pressed(KEY_S), true)
+	_check("shared-base: both distinct modifier keys held", [Input.is_key_pressed(KEY_CTRL), Input.is_key_pressed(KEY_SHIFT)], [true, true])
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+	_check("shared-base: S, CTRL, SHIFT all released after interrupt (no stuck base)",
+		[Input.is_key_pressed(KEY_S), Input.is_key_pressed(KEY_CTRL), Input.is_key_pressed(KEY_SHIFT)], [false, false, false])
 
 	# ── 10. Abutting combos sharing a modifier: final state is clean ─────────
 	# (The one-frame just_released edge on the shared modifier at the boundary is

--- a/godot/addons/godot_mcp/test/input_key_injection_test.gd
+++ b/godot/addons/godot_mcp/test/input_key_injection_test.gd
@@ -158,6 +158,23 @@ func _run() -> void:
 	for i in 4:
 		await process_frame
 
+	# ── 5b. A LONE modifier name is the modifier key itself ──────────────────
+	# (a game binding bare Shift/Ctrl, like NEON RAMPAGE's dash = Shift). Caught
+	# live: "shift" must not parse to a baseless modifier and reject as unknown.
+	var bare: Dictionary = MCPKeyNames.parse("shift")
+	_check("lone 'shift' parses to the Shift KEY (not a baseless modifier)", [int(bare["code"]), int(bare["mask"])], [int(KEY_SHIFT), 0])
+	var bare_ambig: Dictionary = MCPKeyNames.parse("ctrl+shift")
+	_check("baseless multi-modifier 'ctrl+shift' stays unknown", int(bare_ambig["code"]), int(KEY_NONE))
+	await _settle()
+	bridge._handle_execute_input_sequence([[{"key": "ctrl", "start_ms": 0, "duration_ms": 100000}]])
+	await process_frame
+	await process_frame
+	_check("{key:'ctrl'} drives polled is_key_pressed(KEY_CTRL)", Input.is_key_pressed(KEY_CTRL), true)
+	_check("{key:'ctrl'} fires a bare-Ctrl-bound action", Input.is_action_pressed(BARE_CTRL_ACT), true)
+	bridge._handle_execute_input_sequence([[{"key": "z", "start_ms": 0, "duration_ms": 10}]])
+	for i in 4:
+		await process_frame
+
 	# ── 6. NEGATIVE physical: physical-only does not fire a keycode binding ──
 	await _settle()
 	bridge._handle_execute_input_sequence([[{"key": "m", "physical": true, "start_ms": 0, "duration_ms": 100000}]])

--- a/godot/addons/godot_mcp/test/input_key_injection_test.gd.uid
+++ b/godot/addons/godot_mcp/test/input_key_injection_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bdrf07jbe2j7n

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -43,7 +43,7 @@ const categories: ToolCategory[] = [
   { name: 'Resource', filename: 'resource', description: 'Resource inspection tools for SpriteFrames, TileSet, Materials, etc.', tools: resourceTools },
   { name: 'Scene3D', filename: 'scene3d', description: '3D spatial information and bounding box tools', tools: scene3dTools },
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },
-  { name: 'Input', filename: 'input', description: 'Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, and text typing (no mouse/coordinate input)', tools: inputTools },
+  { name: 'Input', filename: 'input', description: 'Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, and text typing (no mouse/coordinate input)', tools: inputTools },
   { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
   { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.', tools: runtimeStateTools },
   { name: 'Game Script Execution', filename: 'exec', description: 'Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard.', tools: execTools },

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -176,6 +176,47 @@ describe('game_time tool', () => {
       expect((data.warnings as string[])[0]).toContain('predates controller injection');
     });
 
+    it('accepts raw key entries, passes them through verbatim, and surfaces a key count (#290)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,
+        frames: 30, physics_ticks: 30, game_paused: false, events_fired: 2,
+        input_kinds: { action: 0, joy_button: 0, axis: 0, key: 1 },
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({
+        action: 'step',
+        duration_ms: 500,
+        inputs: [{ key: 'ctrl+s', start_ms: 100, duration_ms: 50 }],
+      }, ctx);
+
+      expect(mock.calls[0].params.inputs).toEqual([
+        { key: 'ctrl+s', start_ms: 100, duration_ms: 50 },
+      ]);
+      const data = structuredOf(result);
+      expect(data.input_kinds).toEqual({ action: 0, joy_button: 0, axis: 0, key: 1 });
+      expect(data.warnings).toEqual([]);
+    });
+
+    it('warns in the structured result when key entries hit a bridge with no key count (#290)', async () => {
+      mock.mockResponse({
+        completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,
+        frames: 30, physics_ticks: 30, game_paused: false,
+        input_kinds: { action: 0, joy_button: 0, axis: 0 },
+      });
+      const ctx = createToolContext(mock);
+
+      const result = await gameTime.execute({
+        action: 'step',
+        duration_ms: 500,
+        inputs: [{ key: 'escape', start_ms: 0, duration_ms: 50 }],
+      }, ctx);
+
+      const data = structuredOf(result);
+      expect(data.warnings).toHaveLength(1);
+      expect((data.warnings as string[])[0]).toContain('predates raw-key injection');
+    });
+
     it('derives the per-request timeout and pushes the relay/wall budgets to the bridge (#276)', async () => {
       mock.mockResponse({
         completed: true, frozen: true, elapsed_ms: 500, gameplay_ms: 500,

--- a/server/src/__tests__/tools/input.test.ts
+++ b/server/src/__tests__/tools/input.test.ts
@@ -521,6 +521,85 @@ describe('input tool', () => {
     });
   });
 
+  describe('key entries (#290)', () => {
+    describe('schema', () => {
+      it('accepts a key by name, a modifier combo, physical, and a raw int', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ key: 'a' }, { key: 'ctrl+s' }, { key: 'escape', physical: true }, { key: 83 }],
+        }).success).toBe(true);
+      });
+
+      it('rejects an empty key string', () => {
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ key: '' }],
+        }).success).toBe(false);
+      });
+
+      it('rejects a key entry mixed with another discriminator (strictObject pin)', () => {
+        // {key, axis, value} must not silently match a stripping branch and drop
+        // an intent — the same discriminator guarantee the joypad branches rely on.
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ key: 'ctrl+s', axis: 'left_x', value: 1 }],
+        }).success).toBe(false);
+        expect(input.schema.safeParse({
+          action: 'sequence',
+          inputs: [{ action_name: 'fire', key: 'a' }],
+        }).success).toBe(false);
+      });
+
+      it('names the key shape in the union error for a no-discriminator entry', () => {
+        const r = input.schema.safeParse({ action: 'sequence', inputs: [{ nope: 1 }] });
+        expect(r.success).toBe(false);
+        if (!r.success) expect(JSON.stringify(r.error.issues)).toContain('{key, physical?}');
+      });
+    });
+
+    it('passes a key entry through to the wire verbatim (no server-side expansion)', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1, input_kinds: { action: 0, joy_button: 0, axis: 0, key: 1 } });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ key: 'ctrl+s', physical: true, start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      expect(mock.calls[0].params.inputs).toEqual([
+        { key: 'ctrl+s', physical: true, start_ms: 0, duration_ms: 100 },
+      ]);
+      expect(result).toContain('key:ctrl+s');
+    });
+
+    it('warns when key entries hit a controller-era bridge that echoes input_kinds without a key count', async () => {
+      // A #289-era bridge echoes input_kinds (so the controller check passes) yet
+      // silently drops key entries — only the missing `key` count catches it.
+      mock.mockResponse({ completed: true, actions_executed: 0, input_kinds: { action: 0, joy_button: 0, axis: 0 } });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ key: 'ctrl+s', start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      expect(result).toContain('IGNORED');
+      expect(result).toContain('predates raw-key injection');
+    });
+
+    it('does not warn when the bridge echoes a key count', async () => {
+      mock.mockResponse({ completed: true, actions_executed: 1, input_kinds: { action: 0, joy_button: 0, axis: 0, key: 1 } });
+      const ctx = createToolContext(mock);
+
+      const result = await input.execute({
+        action: 'sequence',
+        inputs: [{ key: 'escape', start_ms: 0, duration_ms: 100 }],
+      }, ctx);
+
+      expect(result).not.toContain('IGNORED');
+    });
+  });
+
   describe('type_text', () => {
     it('types text and returns character count', async () => {
       mock.mockResponse({ completed: true, chars_typed: 5, submitted: false });

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { defineTool } from '../core/define-tool.js';
 import { structured } from '../core/structured.js';
 import { deriveTimeouts, STEP_BUDGET_CAP_MS } from '../connection/timeouts.js';
-import { InputEntrySchema, compileInputEntries, joypadSkewWarning } from './input.js';
+import { InputEntrySchema, compileInputEntries, inputSkewWarning } from './input.js';
 import type { AnyToolDefinition } from '../core/types.js';
 
 // Published cap on game time advanced in one call. The server sizes its socket
@@ -57,7 +57,7 @@ const GameTimeSchema = z
       inputs: z
         .array(InputEntrySchema)
         .optional()
-        .describe('Input timeline executed inside the window; start_ms is game time from window start. Entries share the godot_input sequence vocabulary: named actions (with analog strength), joypad buttons, axis holds, and stick vectors. Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end.'),
+        .describe('Input timeline executed inside the window; start_ms is game time from window start. Entries share the godot_input sequence vocabulary: named actions (with analog strength), joypad buttons, axis holds, stick vectors, and raw keys (with modifier combos). Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end.'),
     }),
     z.object({
       action: z
@@ -81,7 +81,7 @@ const GameTimeSchema = z
       inputs: z
         .array(InputEntrySchema)
         .optional()
-        .describe('Optional input timeline driven inside the window, exactly like step (same vocabulary: actions, joypad buttons, axes, stick vectors — e.g. hold a stick deflection while waiting for an enemy to appear). Holds are released by window end.'),
+        .describe('Optional input timeline driven inside the window, exactly like step (same vocabulary: actions, joypad buttons, axes, stick vectors, raw keys — e.g. hold a stick deflection while waiting for an enemy to appear). Holds are released by window end.'),
     }),
     z.object({
       action: z
@@ -151,7 +151,7 @@ export const gameTime = defineTool({
         }, { timeoutMs: t.serverMs });
         // Stable shape, matching the runtime-state watch precedent (#198):
         // `warnings` is always an array so callers can read it unconditionally.
-        const skew = joypadSkewWarning(args.inputs ?? [], result.input_kinds);
+        const skew = inputSkewWarning(args.inputs ?? [], result.input_kinds);
         return structured({ ...result, warnings: skew ? [skew] : [] });
       }
 
@@ -165,7 +165,7 @@ export const gameTime = defineTool({
           relay_timeout_ms: t.relayMs,
           wall_budget_ms: t.bridgeWallMs,
         }, { timeoutMs: t.serverMs });
-        const skew = joypadSkewWarning(args.inputs ?? [], result.input_kinds);
+        const skew = inputSkewWarning(args.inputs ?? [], result.input_kinds);
         return structured({ ...result, warnings: skew ? [skew] : [] });
       }
 

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -79,23 +79,48 @@ const StickEntrySchema = z.strictObject({
   device: DeviceField,
   ...TimingFields,
 });
+const KeyEntrySchema = z.strictObject({
+  key: z
+    .union([z.string().min(1), z.number().int()])
+    .describe(
+      'Raw keyboard key by name with optional modifier prefixes ("a", "escape", "ctrl+s", ' +
+      '"shift+alt+f1"), or a raw Godot Key enum int. Modifiers: ctrl, shift, alt, meta (aka ' +
+      'cmd/super). Drives InputMap key bindings, raw _input/_unhandled_input handlers, and polled ' +
+      'Input.is_key_pressed; each modifier is pressed as a real key so Input.is_key_pressed(KEY_CTRL) ' +
+      'also holds (so injecting "ctrl+s" also fires any action bound to bare Ctrl, like a real ' +
+      'keyboard). For typing into focused text fields use type_text instead.'
+    ),
+  physical: z
+    .boolean()
+    .optional()
+    .describe(
+      'Target the physical key position (layout-independent): sends a physical-keycode-only event ' +
+      'for Input.is_physical_key_pressed and physical-keycode InputMap bindings. Default false sends ' +
+      'both logical and physical keycodes (a US-layout key press). WARNING: with physical:true the ' +
+      'logical keycode is unset, so keycode-bound InputMap actions will NOT match — use the default ' +
+      'for those.'
+    ),
+  ...TimingFields,
+});
 
 export const InputEntrySchema = z.union(
-  [ActionEntrySchema, JoyButtonEntrySchema, AxisEntrySchema, StickEntrySchema],
+  [ActionEntrySchema, JoyButtonEntrySchema, AxisEntrySchema, StickEntrySchema, KeyEntrySchema],
   {
     // z.union reports a bare "Invalid input" for every structural miss; the
-    // entries are key-discriminated, so name the four valid shapes to make the
+    // entries are key-discriminated, so name the five valid shapes to make the
     // most common authoring mistakes (missing value, typo'd key, no
     // discriminator) actionable.
     error: () =>
       'each input entry must be one of: {action_name, strength?}, {joy_button, device?}, ' +
-      '{axis, value, device?}, or {stick, x, y, device?} (all with optional start_ms/duration_ms)',
+      '{axis, value, device?}, {stick, x, y, device?}, or {key, physical?} ' +
+      '(all with optional start_ms/duration_ms)',
   }
 );
 export type InputEntry = z.infer<typeof InputEntrySchema>;
 
 // Compile schema entries into the wire vocabulary the game bridge consumes
-// (action | joy_button | axis): stick sugar becomes a paired axis hold.
+// (action | joy_button | axis | key): stick sugar becomes a paired axis hold;
+// key entries pass through and the bridge expands modifier combos into events.
 export function compileInputEntries(inputs: InputEntry[]): Record<string, unknown>[] {
   const wire: Record<string, unknown>[] = [];
   for (const e of inputs) {
@@ -115,23 +140,33 @@ export function entryLabel(e: InputEntry): string {
   if ('action_name' in e) return e.strength !== undefined ? `${e.action_name}@${e.strength}` : e.action_name;
   if ('joy_button' in e) return `joy:${e.joy_button}`;
   if ('axis' in e) return `${e.axis}=${e.value}`;
+  if ('key' in e) return `key:${e.key}`;
   return `${e.stick}_stick(${e.x},${e.y})`;
 }
 
-// Version-skew detection (#233, same honesty pattern as the watch timeline):
-// an old bridge silently `continue`s entries without action_name (dropping
-// joypad entries) and ignores the new `strength` field on action entries
-// (injecting at 1.0) — both while the call "succeeds". A new bridge always
-// echoes input_kinds; its ABSENCE when the request used either new capability
-// means the running addon predates controller injection.
-export function joypadSkewWarning(
+// Version-skew detection (#233/#290, same honesty pattern as the watch timeline):
+// an old bridge silently `continue`s entries it does not understand (dropping
+// joypad or key entries) and ignores the new `strength` field on action entries
+// (injecting at 1.0) — all while the call "succeeds". A new bridge echoes
+// input_kinds; its ABSENCE, or the absence of a `key` count within it, signals
+// the running addon predates that capability. Key takes priority because a
+// #289-era bridge echoes input_kinds (so the controller check passes) yet still
+// drops key entries — only the missing `key` count catches it.
+export function inputSkewWarning(
   inputs: InputEntry[],
   inputKinds: Record<string, number> | undefined
 ): string | undefined {
-  const usesNewCaps = inputs.some(
-    (e) => !('action_name' in e) || ('strength' in e && e.strength !== undefined)
+  const usesKey = inputs.some((e) => 'key' in e);
+  if (usesKey && (inputKinds === undefined || !('key' in inputKinds))) {
+    return (
+      'WARNING: raw key/modifier entries were IGNORED — the running addon predates raw-key ' +
+      'injection (#290). Update the godot-mcp addon and restart the Godot editor.'
+    );
+  }
+  const usesController = inputs.some(
+    (e) => (!('action_name' in e) && !('key' in e)) || ('strength' in e && e.strength !== undefined)
   );
-  if (usesNewCaps && inputKinds === undefined) {
+  if (usesController && inputKinds === undefined) {
     return (
       'WARNING: joypad/axis entries or analog action strength were IGNORED — the running addon ' +
       'predates controller injection. Update the godot-mcp addon and restart the Godot editor.'
@@ -151,12 +186,13 @@ const InputSchema = z.discriminatedUnion('action', [
       .min(1)
       .describe(
         'Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional ' +
-        'analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), or a ' +
-        'STICK vector (stick + x/y) — mix freely on one timeline. Joypad events drive bound actions ' +
-        '(with real deadzone math), raw _input handlers, and the polled Input singletons ' +
-        '(get_joy_axis / is_joy_button_pressed); no physical pad is needed. Limitation: ' +
-        'Input.get_connected_joypads() never reports a virtual pad, so games that gate controller ' +
-        'mode on pad DETECTION cannot be switched into it.'
+        'analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), a ' +
+        'STICK vector (stick + x/y), or a raw KEY (key, e.g. "ctrl+s") — mix freely on one timeline. ' +
+        'Joypad events drive bound actions (with real deadzone math), raw _input handlers, and the ' +
+        'polled Input singletons (get_joy_axis / is_joy_button_pressed); key events likewise drive ' +
+        'bound actions, _input/_unhandled_input, and Input.is_key_pressed. No physical pad or ' +
+        'keyboard is needed. Limitation: Input.get_connected_joypads() never reports a virtual pad, ' +
+        'so games that gate controller mode on pad DETECTION cannot be switched into it.'
       ),
     report: z
       .array(z.string())
@@ -232,7 +268,7 @@ export const input = defineTool({
   name: 'godot_input',
   annotations: { title: 'Input Injection', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
-    'Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, and stick vectors. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).',
+    'Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, stick vectors, and raw keyboard keys (with modifier combos). Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: mouse/coordinate input is not supported (see docs/design/mouse-input-spike.md).',
   schema: InputSchema,
   async execute(args: InputArgs, { godot }) {
     switch (args.action) {
@@ -322,7 +358,7 @@ export const input = defineTool({
           `Input sequence completed: ${result.actions_executed} input(s) executed [${labels}] over ${totalDuration}ms.`,
         ];
 
-        const skew = joypadSkewWarning(inputs, result.input_kinds);
+        const skew = inputSkewWarning(inputs, result.input_kinds);
         if (skew) lines.push(skew);
 
         // Always-on context: a sequence that ran under a pause/freeze advanced no


### PR DESCRIPTION
## What

Adds a `key` entry to the `godot_input sequence` and `godot_game_time step`/`step_until` input timeline:

```jsonc
{ "key": "ctrl+s" }                    // modifier combo
{ "key": "escape", "duration_ms": 80 } // a held key
{ "key": "w", "physical": true }       // physical-key position (layout-independent)
{ "key": 4194305 }                     // raw Godot Key enum int (escape hatch)
```

Raw `InputEventKey` injection is the keyboard remainder of #233. A game that reads `InputEventKey` in `_input`/`_unhandled_input`, or polls `Input.is_key_pressed` / `is_physical_key_pressed`, without defining InputMap actions could not be driven before this; modifier combos were inexpressible entirely. With this and the controller pillar (#233/#289), the keyboard/gamepad input surface is complete — mouse/coordinate input remains the only documented gap.

It slots into the unified timeline engine #289 built as a third `kind`: `_compile_input_events` → `_inject_timeline_event` → the guaranteed-release registries. Server `compileInputEntries` passes key entries through verbatim; the bridge expands a combo into its primitive key events.

## Design decisions

- **Modifiers are pressed as real keys.** A separate `KEY_CTRL` event is the only way `Input.is_key_pressed(KEY_CTRL)` reads true (the modifier *flag* on another event does not update that singleton — verified). The base event also carries the modifier flags so InputMap chords and `_input` handlers match. Faithful consequence (documented, pinned as expected): injecting `ctrl+s` also fires any action bound to bare `Ctrl`, exactly like a real keyboard.
- **`physical` flag.** Default sets both logical and physical keycodes (a realistic US-layout key press → drives `is_key_pressed`, `is_physical_key_pressed`, and either binding kind). `physical: true` sends a physical-only event (logical keycode unset) for layout-independent / physical-keycode-binding testing. Footgun documented loudly and pinned with a negative test: under `physical: true`, keycode-bound InputMap actions do **not** match.
- **Refcounted held-key registry.** Overlapping entries that share a key (e.g. two combos holding `Ctrl`) keep it pressed until the *last* release — a boolean registry would release it early. The engine press/release fires only on the 0↔1 edge. (Same-time *abutting* combos sharing a modifier still produce a one-frame `just_released` edge at the boundary, matching the existing button double-tap-edge asymmetry — documented, not cancelled.)
- **Name parsing lives in the bridge** (new `MCPKeyNames` helper), via Godot's own `OS.find_keycode_from_string` — single source of truth, round-trips with the `get_input_map` display. Manual modifier splitting handles `Meta`/`Cmd`, which `find_keycode_from_string` silently drops (verified Godot 4.6: `find('Meta+Q')` → bare `KEY_Q`). Both `_event_to_string` copies (game bridge + editor commands) now route through `MCPKeyNames.event_string` so the displayed names can't drift, and physical-only bindings render with a `(physical)` marker.

## Non-breaking

Additive only: a new `{key, physical?}` union branch and a new `key` field on the `input_kinds` result. Old server + new bridge: action-only entries compile identically; the extra result field is ignored. New server + old bridge: `inputSkewWarning` (renamed from `joypadSkewWarning`) detects a controller-era bridge that echoes `input_kinds` *without* a `key` count and warns to update the addon. Minor bump.

## Testing

- **Headless** `input_key_injection_test.gd` (43 checks) drives the real `MCPGameBridge` sequence engine: polled `is_key_pressed`/`is_physical_key_pressed`, physical-only semantics, modifier-combo polling, InputMap key-binding + modifier-required matching, the bare-Ctrl faithful edge, the physical negative case, `_input`/`_unhandled_input` delivery with modifier flags, instant-tap non-latch, refcount/overlap (no early release), abutting-combo cleanliness, tree-exit release, raw-int + mask split, unknown-key errors, `input_kinds` key count, and `event_string`/`parse` round-trip (incl. Meta). Engine facts pinned against Godot 4.6.3.
- **Headless regression** green: `input_joypad_injection_test` (updated for the `key:0` count, 48), `input_sequence_stuck_held_test`, `input_sequence_effect_probe_test`, `input_sequence_capture_test`.
- **Server** `npm run build` clean; full vitest **353 passed** (+9 new: schema accept/reject incl. the strictObject mixed-key pin, verbatim wire passthrough, `entryLabel`, the renamed skew warning for both eras, and game-time step passthrough + warnings shape).
- Docs regenerated (`generate-docs`); CRLF-only churn restored.

Closes #290.
