### PR TITLE
feat: surface 3D world nodes in the digest auto/fallback tier

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ This server provides **14 tools** and **3 resources** for AI-assisted Godot deve
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |
 | [Input](tools/input.md) | 1 | Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, relative mouse-look, and text typing (no absolute cursor positioning) |
 | [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
-| [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots. |
+| [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots. |
 | [Game Script Execution](tools/exec.md) | 1 | Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard. |
 
 ## Installation

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ This server provides **14 tools** and **3 resources** for AI-assisted Godot deve
 | [Documentation](tools/docs.md) | 1 | Fetch Godot Engine documentation with smart extraction |
 | [Input](tools/input.md) | 1 | Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, relative mouse-look, and text typing (no absolute cursor positioning) |
 | [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
-| [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots. |
+| [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots. |
 | [Game Script Execution](tools/exec.md) | 1 | Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard. |
 
 ## Installation

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -71,7 +71,7 @@ Performance profiling: snapshots, per-frame time series with spike detection, ac
 
 ## [Runtime State](runtime-state.md)
 
-Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.
+Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots.
 
 - `godot_runtime_state` - Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -71,7 +71,7 @@ Performance profiling: snapshots, per-frame time series with spike detection, ac
 
 ## [Runtime State](runtime-state.md)
 
-Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots.
+Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots.
 
 - `godot_runtime_state` - Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
 

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -1,6 +1,6 @@
 # Runtime State Tools
 
-Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots.
+Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots.
 
 ## Tools
 
@@ -17,7 +17,7 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | `digest`, `watch_start`, `watch_collect`, `watch_stop` | Yes |  |
-| `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → a visibility fallback that surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, lights, and physics bodies), "none" = no automatic selection; return only the nodes named in paths |
+| `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → a visibility fallback that surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), "none" = no automatic selection; return only the nodes named in paths |
 | `group` | string | No | Group name to use when select="group" or "auto" (default: "mcp_watch") |
 | `paths` | string[] | No | Explicit absolute node paths to include in addition to tier selection, e.g. ["/root/GameState"]. The digest walks the current scene only, so autoload singletons — where global game state often lives (cash, score, settings) — are otherwise unreachable. Each path returns _mcp_state() if present, else a snapshot of the node's script variables (scalars/arrays, ~1 KB cap). Paths that do not resolve are returned in unresolved_paths. |
 | `name` | string | No | Glob filter on node name (e.g. "Player*") |

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -1,6 +1,6 @@
 # Runtime State Tools
 
-Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.
+Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots.
 
 ## Tools
 
@@ -17,7 +17,7 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | `digest`, `watch_start`, `watch_collect`, `watch_stop` | Yes |  |
-| `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → visible CanvasItems), "none" = no automatic selection; return only the nodes named in paths |
+| `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → a visibility fallback that surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, lights, and physics bodies), "none" = no automatic selection; return only the nodes named in paths |
 | `group` | string | No | Group name to use when select="group" or "auto" (default: "mcp_watch") |
 | `paths` | string[] | No | Explicit absolute node paths to include in addition to tier selection, e.g. ["/root/GameState"]. The digest walks the current scene only, so autoload singletons — where global game state often lives (cash, score, settings) — are otherwise unreachable. Each path returns _mcp_state() if present, else a snapshot of the node's script variables (scalars/arrays, ~1 KB cap). Paths that do not resolve are returned in unresolved_paths. |
 | `name` | string | No | Glob filter on node name (e.g. "Player*") |

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -787,7 +787,9 @@ func _handle_get_runtime_state(data: Array) -> void:
 
 	var hint := ""
 	if actual_selection == "fallback":
-		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected. " +
+		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected; " +
+			"showing visible 2D and 3D world nodes (meshes, gridmaps, cameras, lights, " +
+			"physics bodies, and on-screen CanvasItems). " +
 			"For richer data: add key nodes to the '%s' group, then implement " +
 			"`func _mcp_state() -> Dictionary` on them. " +
 			"In _mcp_state(), include both live runtime values (position, health, score) " +
@@ -846,7 +848,25 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 		"method":
 			include_node = node.has_method("_mcp_state")
 		"fallback":
-			include_node = (node is CanvasItem and (node as CanvasItem).is_visible_in_tree())
+			# Visible world nodes, by dimension. 2D = any visible CanvasItem.
+			# 3D = a curated set of the entities an agent actually cares about:
+			# rendered geometry (VisualInstance3D covers MeshInstance3D,
+			# MultiMeshInstance3D, GPUParticles3D, Sprite3D, Label3D AND Light3D),
+			# GridMap (extends Node3D directly — NOT a VisualInstance3D — so it must
+			# be named explicitly), Camera3D (also Node3D, not a VisualInstance3D),
+			# and physics bodies / areas (CollisionObject3D — the gameplay entities,
+			# e.g. an FPS's enemies and player). Pure-structure Node3Ds (Marker3D,
+			# Skeleton3D, bone attachments, audio emitters, bare pivots) are skipped
+			# so they don't crowd the max_nodes budget. This mirrors the 2D tier,
+			# where CharacterBody2D is itself a CanvasItem and so already surfaces.
+			if node is CanvasItem:
+				include_node = (node as CanvasItem).is_visible_in_tree()
+			elif node is Node3D:
+				include_node = (node as Node3D).is_visible_in_tree() and (
+					node is VisualInstance3D
+					or node is GridMap
+					or node is Camera3D
+					or node is CollisionObject3D)
 
 	if include_node:
 		if not name_filter.is_empty() and not node.name.matchn(name_filter):

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -789,7 +789,7 @@ func _handle_get_runtime_state(data: Array) -> void:
 	if actual_selection == "fallback":
 		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected; " +
 			"showing visible 2D and 3D world nodes (meshes, gridmaps, cameras, lights, " +
-			"physics bodies, and on-screen CanvasItems). " +
+			"physics bodies and trigger areas, and visible CanvasItems). " +
 			"For richer data: add key nodes to the '%s' group, then implement " +
 			"`func _mcp_state() -> Dictionary` on them. " +
 			"In _mcp_state(), include both live runtime values (position, health, score) " +
@@ -850,21 +850,29 @@ func _collect_runtime_state(node: Node, scene_root: Node, selection: String, gro
 		"fallback":
 			# Visible world nodes, by dimension. 2D = any visible CanvasItem.
 			# 3D = a curated set of the entities an agent actually cares about:
-			# rendered geometry (VisualInstance3D covers MeshInstance3D,
-			# MultiMeshInstance3D, GPUParticles3D, Sprite3D, Label3D AND Light3D),
-			# GridMap (extends Node3D directly — NOT a VisualInstance3D — so it must
-			# be named explicitly), Camera3D (also Node3D, not a VisualInstance3D),
-			# and physics bodies / areas (CollisionObject3D — the gameplay entities,
-			# e.g. an FPS's enemies and player). Pure-structure Node3Ds (Marker3D,
-			# Skeleton3D, bone attachments, audio emitters, bare pivots) are skipped
-			# so they don't crowd the max_nodes budget. This mirrors the 2D tier,
-			# where CharacterBody2D is itself a CanvasItem and so already surfaces.
+			# rendered geometry (GeometryInstance3D covers MeshInstance3D,
+			# MultiMeshInstance3D, GPUParticles3D, Sprite3D, Label3D, CSG, SoftBody3D)
+			# plus Light3D (a VisualInstance3D, NOT a GeometryInstance3D, so named
+			# separately). GeometryInstance3D is deliberately narrower than its parent
+			# VisualInstance3D, which also drags in bake/helper nodes (ReflectionProbe,
+			# VoxelGI, LightmapGI, OccluderInstance3D, Decal, FogVolume, particle
+			# field nodes, VisibleOnScreenNotifier3D) — all default-visible noise that
+			# would crowd the max_nodes budget. GridMap (extends Node3D directly, NOT a
+			# VisualInstance3D) is checked by string because the gridmap module can be
+			# compiled out independently — `is GridMap` would be an unresolved parse-time
+			# identifier that fails the whole autoload in such a build. Camera3D (also a
+			# bare Node3D), and physics bodies / trigger areas (CollisionObject3D — the
+			# gameplay entities, e.g. an FPS's enemies and player) round out the set.
+			# Pure-structure Node3Ds (Marker3D, Skeleton3D, bone attachments, audio
+			# emitters, bare pivots) are skipped. This mirrors the 2D tier, where
+			# CharacterBody2D is itself a CanvasItem and so already surfaces.
 			if node is CanvasItem:
 				include_node = (node as CanvasItem).is_visible_in_tree()
 			elif node is Node3D:
 				include_node = (node as Node3D).is_visible_in_tree() and (
-					node is VisualInstance3D
-					or node is GridMap
+					node is GeometryInstance3D
+					or node is Light3D
+					or node.is_class("GridMap")
 					or node is Camera3D
 					or node is CollisionObject3D)
 

--- a/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd
+++ b/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd
@@ -1,0 +1,227 @@
+extends SceneTree
+
+## Headless test for the 3D-aware digest fallback tier (godot-mcp #230).
+##
+## The `digest` fallback tier — what an un-instrumented project hits via
+## select="auto" — historically selected only visible CanvasItems, so a 3D scene
+## with no mcp_watch group and no _mcp_state() returned zero world entities. This
+## test pins the fix: the fallback now also selects visible 3D WORLD nodes —
+## VisualInstance3D (meshes/particles/sprites/labels/lights), GridMap, Camera3D,
+## and CollisionObject3D (physics bodies + areas) — while skipping pure-structure
+## Node3Ds (Marker3D, Skeleton3D, bare pivots) and honoring visibility, max_nodes,
+## and the type filter. 2D behavior is unchanged.
+##
+## A real MCPGameBridge is instantiated WITHOUT adding it to the tree (so _ready's
+## bridge setup never runs); _collect_runtime_state / _extract_node_state /
+## _has_mcp_state_nodes are pure with respect to bridge state, so this is safe.
+##
+## Not wired into CI (CI has no Godot). Run on demand against any project with the
+## addon present (the run-n-gun junction is the standard host):
+##
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/digest_fallback_3d_test.gd"
+##
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const Bridge := preload("res://addons/godot_mcp/game_bridge/mcp_game_bridge.gd")
+
+var _count := 0
+var _failures := 0
+
+var _bridge: Node
+var _scene: Node3D
+
+
+func _initialize() -> void:
+	# Coroutine so the Camera3D can register/apply before onscreen is sampled.
+	_run()
+
+
+func _run() -> void:
+	_bridge = Bridge.new() # NOT added to the tree — no _ready side effects.
+	_build_scene()
+	# Let the camera become current and the viewport settle (mirrors the
+	# onscreen headless test, which the 3D frustum path here also relies on).
+	for i in 3:
+		await process_frame
+
+	_test_selection_and_exclusion()
+	_test_entity_data_and_onscreen()
+	_test_max_nodes_and_type_filter()
+	_test_auto_resolves_to_fallback()
+
+	print("1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+# ── Scene under test ───────────────────────────────────────────────────────────
+#
+# A Node3D root (like a real 3D scene) holding a curated mix of selectable world
+# nodes, noise that must be skipped, a hidden mesh, and a 2D UI subtree.
+
+func _build_scene() -> void:
+	_scene = Node3D.new()
+	_scene.name = "Scene" # a bare Node3D root — itself must NOT be selected
+	root.add_child(_scene)
+
+	var cam := Camera3D.new()
+	cam.name = "Cam"
+	_scene.add_child(cam)
+	cam.current = true # identity transform → at origin looking down -Z
+
+	var mesh_front := MeshInstance3D.new()
+	mesh_front.name = "MeshFront"
+	_scene.add_child(mesh_front)
+	mesh_front.global_position = Vector3(0, 0, -10) # in front of the camera
+
+	var mesh_behind := MeshInstance3D.new()
+	mesh_behind.name = "MeshBehind"
+	_scene.add_child(mesh_behind)
+	mesh_behind.global_position = Vector3(0, 0, 10) # behind the camera
+
+	var mesh_hidden := MeshInstance3D.new()
+	mesh_hidden.name = "MeshHidden"
+	mesh_hidden.visible = false
+	_scene.add_child(mesh_hidden)
+
+	var gridmap := GridMap.new() # extends Node3D directly — the regression guard
+	gridmap.name = "Grid"
+	_scene.add_child(gridmap)
+
+	var light := OmniLight3D.new()
+	light.name = "Light"
+	_scene.add_child(light)
+
+	var body := CharacterBody3D.new() # a gameplay entity (FPS enemy/player)
+	body.name = "Body"
+	_scene.add_child(body)
+	body.velocity = Vector3(1, 2, 3)
+
+	# Noise: pure-structure Node3Ds that must be skipped.
+	var marker := Marker3D.new()
+	marker.name = "Marker"
+	_scene.add_child(marker)
+	var skel := Skeleton3D.new()
+	skel.name = "Skel"
+	_scene.add_child(skel)
+
+	# 2D UI subtree (CanvasLayer is not a CanvasItem, so it is itself skipped, but
+	# its visible Control children must still surface — 2D parity).
+	var ui := CanvasLayer.new()
+	ui.name = "UI"
+	_scene.add_child(ui)
+	var label := Label.new()
+	label.name = "Score"
+	ui.add_child(label)
+	var button := Button.new()
+	button.name = "Start"
+	ui.add_child(button)
+
+
+# ── Collection helper ──────────────────────────────────────────────────────────
+
+func _collect(max_nodes: int, type_filter: String) -> Array:
+	var results: Array = []
+	_bridge._collect_runtime_state(_scene, _scene, "fallback", "mcp_watch",
+		"", type_filter, [], max_nodes, results)
+	return results
+
+
+func _has_type(results: Array, t: String) -> bool:
+	for e in results:
+		if str(e.get("type", "")) == t:
+			return true
+	return false
+
+
+func _find_by_name(results: Array, suffix: String) -> Variant:
+	for e in results:
+		if str(e.get("path", "")).ends_with(suffix):
+			return e
+	return null
+
+
+# ── Checks ─────────────────────────────────────────────────────────────────────
+
+func _test_selection_and_exclusion() -> void:
+	var r := _collect(40, "")
+
+	# 3D world nodes are selected (the whole point of #230).
+	_check("MeshInstance3D selected", _find_by_name(r, "/MeshFront") != null, true)
+	_check("GridMap selected (regression guard — NOT a VisualInstance3D)",
+		_has_type(r, "GridMap"), true)
+	_check("Camera3D selected", _has_type(r, "Camera3D"), true)
+	_check("OmniLight3D selected", _has_type(r, "OmniLight3D"), true)
+	_check("CharacterBody3D (physics body) selected", _has_type(r, "CharacterBody3D"), true)
+
+	# Pure-structure Node3D noise is skipped.
+	_check("Marker3D excluded (noise)", _has_type(r, "Marker3D"), false)
+	_check("Skeleton3D excluded (noise)", _has_type(r, "Skeleton3D"), false)
+
+	# Visibility gating: a hidden mesh is excluded; the bare Node3D root too.
+	_check("hidden MeshInstance3D excluded", _find_by_name(r, "/MeshHidden") == null, true)
+	_check("bare Node3D root excluded", _find_by_name(r, "/root/Scene") == null, true)
+
+	# 2D parity: visible Controls still surface, unchanged.
+	_check("2D Label still selected", _has_type(r, "Label"), true)
+	_check("2D Button still selected", _has_type(r, "Button"), true)
+
+
+func _test_entity_data_and_onscreen() -> void:
+	var r := _collect(40, "")
+
+	# Selected 3D entities carry real data through the tier (extraction wiring).
+	var front: Variant = _find_by_name(r, "/MeshFront")
+	var has_pos: bool = front != null and (front as Dictionary).has("pos") \
+		and ((front as Dictionary)["pos"] as Dictionary).has("z")
+	_check("selected mesh carries 3D pos {x,y,z}", has_pos, true)
+	if front != null:
+		_check("mesh pos.z reflects placement", (front as Dictionary)["pos"]["z"], -10.0)
+
+	var body: Variant = _find_by_name(r, "/Body")
+	var vel_ok: bool = body != null and (body as Dictionary).has("vel") \
+		and (body as Dictionary)["vel"]["z"] == 3.0
+	_check("CharacterBody3D reports velocity", vel_ok, true)
+
+	# onscreen flag is present and correct for 3D (current Camera3D resolved).
+	if front != null:
+		_check("mesh in front is onscreen", (front as Dictionary).get("onscreen", null), true)
+	var behind: Variant = _find_by_name(r, "/MeshBehind")
+	if behind != null:
+		_check("mesh behind camera is offscreen", (behind as Dictionary).get("onscreen", null), false)
+
+
+func _test_max_nodes_and_type_filter() -> void:
+	# max_nodes still bounds the result.
+	var capped := _collect(2, "")
+	_check("max_nodes caps the result", capped.size(), 2)
+
+	# type filter still narrows post-selection.
+	var grids := _collect(40, "GridMap")
+	var all_grid := grids.size() > 0
+	for e in grids:
+		if str(e.get("type", "")) != "GridMap":
+			all_grid = false
+	_check("type filter narrows to GridMap only", all_grid and grids.size() == 1, true)
+
+
+func _test_auto_resolves_to_fallback() -> void:
+	# On this untagged 3D tree, auto resolves to the fallback tier: no mcp_watch
+	# members and no _mcp_state() nodes (the two conditions in the resolver).
+	_check("no mcp_watch group members", get_nodes_in_group("mcp_watch").size(), 0)
+	_check("no _mcp_state() nodes", _bridge._has_mcp_state_nodes(_scene), false)
+
+
+# ── Tiny TAP-ish harness ──────────────────────────────────────────────────────
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd
+++ b/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd
@@ -48,7 +48,7 @@ func _run() -> void:
 	_test_selection_and_exclusion()
 	_test_entity_data_and_onscreen()
 	_test_max_nodes_and_type_filter()
-	_test_auto_resolves_to_fallback()
+	_test_fallback_branch_conditions_hold()
 
 	print("1..%d" % _count)
 	if _failures == 0:
@@ -73,15 +73,19 @@ func _build_scene() -> void:
 	_scene.add_child(cam)
 	cam.current = true # identity transform → at origin looking down -Z
 
+	# Local position, not global_position: _build_scene runs in _initialize() before
+	# the tree is live, where global_position would hit the !is_inside_tree() guard
+	# (spurious ERROR + silent degrade to local). Every parent is identity, so the
+	# effective world position is identical once the node is in-tree.
 	var mesh_front := MeshInstance3D.new()
 	mesh_front.name = "MeshFront"
 	_scene.add_child(mesh_front)
-	mesh_front.global_position = Vector3(0, 0, -10) # in front of the camera
+	mesh_front.position = Vector3(0, 0, -10) # in front of the camera
 
 	var mesh_behind := MeshInstance3D.new()
 	mesh_behind.name = "MeshBehind"
 	_scene.add_child(mesh_behind)
-	mesh_behind.global_position = Vector3(0, 0, 10) # behind the camera
+	mesh_behind.position = Vector3(0, 0, 10) # behind the camera
 
 	var mesh_hidden := MeshInstance3D.new()
 	mesh_hidden.name = "MeshHidden"
@@ -101,13 +105,23 @@ func _build_scene() -> void:
 	_scene.add_child(body)
 	body.velocity = Vector3(1, 2, 3)
 
-	# Noise: pure-structure Node3Ds that must be skipped.
+	var area := Area3D.new() # a CollisionObject3D that is NOT a PhysicsBody3D (trigger volume)
+	area.name = "Trigger"
+	_scene.add_child(area)
+
+	# Noise: nodes that must be skipped — pure-structure Node3Ds AND a bake/helper
+	# VisualInstance3D. Decal is a VisualInstance3D but NOT a GeometryInstance3D, so
+	# the narrowed predicate must exclude it (guards against reverting to the broader
+	# VisualInstance3D check, which would drag in decals/probes/occluders/etc).
 	var marker := Marker3D.new()
 	marker.name = "Marker"
 	_scene.add_child(marker)
 	var skel := Skeleton3D.new()
 	skel.name = "Skel"
 	_scene.add_child(skel)
+	var decal := Decal.new()
+	decal.name = "Decal"
+	_scene.add_child(decal)
 
 	# 2D UI subtree (CanvasLayer is not a CanvasItem, so it is itself skipped, but
 	# its visible Control children must still surface — 2D parity).
@@ -155,12 +169,15 @@ func _test_selection_and_exclusion() -> void:
 	_check("GridMap selected (regression guard — NOT a VisualInstance3D)",
 		_has_type(r, "GridMap"), true)
 	_check("Camera3D selected", _has_type(r, "Camera3D"), true)
-	_check("OmniLight3D selected", _has_type(r, "OmniLight3D"), true)
+	_check("OmniLight3D selected (Light3D — VisualInstance3D, not GeometryInstance3D)",
+		_has_type(r, "OmniLight3D"), true)
 	_check("CharacterBody3D (physics body) selected", _has_type(r, "CharacterBody3D"), true)
+	_check("Area3D (CollisionObject3D, not PhysicsBody3D) selected", _has_type(r, "Area3D"), true)
 
-	# Pure-structure Node3D noise is skipped.
+	# Noise is skipped: pure-structure Node3Ds AND bake/helper VisualInstance3Ds.
 	_check("Marker3D excluded (noise)", _has_type(r, "Marker3D"), false)
 	_check("Skeleton3D excluded (noise)", _has_type(r, "Skeleton3D"), false)
+	_check("Decal excluded (VisualInstance3D but not GeometryInstance3D)", _has_type(r, "Decal"), false)
 
 	# Visibility gating: a hidden mesh is excluded; the bare Node3D root too.
 	_check("hidden MeshInstance3D excluded", _find_by_name(r, "/MeshHidden") == null, true)
@@ -209,11 +226,14 @@ func _test_max_nodes_and_type_filter() -> void:
 	_check("type filter narrows to GridMap only", all_grid and grids.size() == 1, true)
 
 
-func _test_auto_resolves_to_fallback() -> void:
-	# On this untagged 3D tree, auto resolves to the fallback tier: no mcp_watch
-	# members and no _mcp_state() nodes (the two conditions in the resolver).
-	_check("no mcp_watch group members", get_nodes_in_group("mcp_watch").size(), 0)
-	_check("no _mcp_state() nodes", _bridge._has_mcp_state_nodes(_scene), false)
+func _test_fallback_branch_conditions_hold() -> void:
+	# The real resolver (_handle_get_runtime_state) is not directly callable in this
+	# SceneTree harness — it reads tree.current_scene (null here) and replies via
+	# EngineDebugger. So rather than exercise the auto→fallback branch itself, this
+	# pins its two INPUT conditions: with no mcp_watch members and no _mcp_state()
+	# nodes, auto would resolve to fallback (per the resolver order in the bridge).
+	_check("no mcp_watch members (auto would pick fallback)", get_nodes_in_group("mcp_watch").size(), 0)
+	_check("no _mcp_state() nodes (auto would pick fallback)", _bridge._has_mcp_state_nodes(_scene), false)
 
 
 # ── Tiny TAP-ish harness ──────────────────────────────────────────────────────

--- a/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd.uid
+++ b/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cjyjryd5ra7nc

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -45,7 +45,7 @@ const categories: ToolCategory[] = [
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },
   { name: 'Input', filename: 'input', description: 'Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, relative mouse-look, and text typing (no absolute cursor positioning)', tools: inputTools },
   { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
-  { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots.', tools: runtimeStateTools },
+  { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots.', tools: runtimeStateTools },
   { name: 'Game Script Execution', filename: 'exec', description: 'Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard.', tools: execTools },
 ];
 

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -45,7 +45,7 @@ const categories: ToolCategory[] = [
   { name: 'Documentation', filename: 'docs', description: 'Fetch Godot Engine documentation with smart extraction', tools: docsTools },
   { name: 'Input', filename: 'input', description: 'Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, relative mouse-look, and text typing (no absolute cursor positioning)', tools: inputTools },
   { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
-  { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Much cheaper than screenshots.', tools: runtimeStateTools },
+  { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies — not just UI). Much cheaper than screenshots.', tools: runtimeStateTools },
   { name: 'Game Script Execution', filename: 'exec', description: 'Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard.', tools: execTools },
 ];
 

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -11,6 +11,7 @@ import {
   summarizeStringField,
   buildTimeline,
 } from '../../tools/runtime-state.js';
+import { toInputSchema } from '../../core/schema.js';
 
 describe('runtimeState tool', () => {
   let mock: MockGodotConnection;
@@ -43,6 +44,19 @@ describe('runtimeState tool', () => {
 
     it('rejects digest with invalid select value', () => {
       expect(runtimeState.schema.safeParse({ action: 'digest', select: 'invalid' }).success).toBe(false);
+    });
+
+    it('select describe documents the 3D-aware auto fallback (#230, regression guard)', () => {
+      // The fallback tier now surfaces 3D world nodes, not just CanvasItems
+      // (mcp_game_bridge.gd). The schema is the only contract an agent reads, so
+      // this guards the describe from silently regressing to "CanvasItems"-only.
+      const serialized = JSON.stringify(toInputSchema(runtimeState.schema));
+      expect(serialized).toContain('3D');
+      expect(serialized).toContain('physics bodies');
+      // Schema shape is unchanged — select stays the same enum (note "fallback"
+      // is the internal tier auto resolves to, NOT a user-facing select value).
+      expect(runtimeState.schema.safeParse({ action: 'digest', select: 'auto' }).success).toBe(true);
+      expect(runtimeState.schema.safeParse({ action: 'digest', select: 'fallback' }).success).toBe(false);
     });
 
     it('accepts select="none" with explicit paths', () => {

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -233,8 +233,9 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
       .optional()
       .describe(
         'Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), ' +
-        '"auto" = best available (default: auto picks group → method → visible CanvasItems), ' +
-        '"none" = no automatic selection; return only the nodes named in paths'
+        '"auto" = best available (default: auto picks group → method → a visibility fallback that ' +
+        'surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, ' +
+        'lights, and physics bodies), "none" = no automatic selection; return only the nodes named in paths'
       ),
     group: z
       .string()

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -235,7 +235,7 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), ' +
         '"auto" = best available (default: auto picks group → method → a visibility fallback that ' +
         'surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, ' +
-        'lights, and physics bodies), "none" = no automatic selection; return only the nodes named in paths'
+        'lights, physics bodies and areas), "none" = no automatic selection; return only the nodes named in paths'
       ),
     group: z
       .string()


### PR DESCRIPTION
## What

The `godot_runtime_state` `digest` fallback tier — the tier an un-instrumented project hits via `select=auto` (group → method → fallback) — selected **only visible `CanvasItem`s**. On a **3D** scene with no `mcp_watch` group and no `_mcp_state()`, the auto digest therefore returned **zero world entities**: cameras, meshes, gridmaps, lights and physics bodies were all invisible, leaving an agent unable to observe the scene without already knowing exact node paths.

This broadens the fallback to also select **visible 3D world nodes**:

- `VisualInstance3D` (meshes, multimeshes, particles, `Sprite3D`, `Label3D`, and `Light3D`)
- `GridMap`
- `Camera3D`
- `CollisionObject3D` (physics bodies + `Area3D` — the gameplay entities)

gated on `Node3D.is_visible_in_tree()`. Pure-structure `Node3D`s (`Marker3D`, `Skeleton3D`, bone attachments, bare pivots) are skipped so they don't crowd `max_nodes`. This mirrors the 2D tier, where `CharacterBody2D` is itself a `CanvasItem` and so already surfaces.

Extraction (`_extract_node_state` already emits Node3D `pos`/`rot` + body `vel`) and `Onscreen.compute` (already does the 3D frustum test) were **already 3D-aware**, so this is the selection predicate plus a hint and schema-describe update. **2D behavior is unchanged.**

## Why GridMap and Camera3D are named explicitly

Verified against ClassDB (Godot 4.6): `GridMap` and `Camera3D` extend `Node3D` **directly** — neither is a `VisualInstance3D`. A `VisualInstance3D`-only check would silently miss every GridMap, i.e. the entire dungeon of a GridMap-built scene. (`Light3D` *is* a `VisualInstance3D`, so it needs no separate mention.)

## Verification

**Headless mechanism gate** — new `test/digest_fallback_3d_test.gd`, **20/20**: 3D nodes selected, GridMap-appears regression guard, noise/hidden/bare-root excluded, 2D parity, `pos`/`vel` data through the tier, `onscreen` true/false, `max_nodes` cap, `type` filter, `auto`→`fallback` resolution. `onscreen_headless_test.gd` regression **15/15**. Server suite **365/365** (incl. a new describe-regression guard).

**Live dogfood** on a real, untagged 3D project (drpg-gd dungeon — Forward+, 6 GridMaps + Camera3D + OmniLight3D), `digest select=auto`, only the bridge swapped:

| | `entity_count` | 3D world nodes |
| --- | --- | --- |
| Before | 8 | none (UI only) |
| After | 16 | all 6 GridMaps + Camera3D + OmniLight3D (with `pos`/`rot`/`onscreen`) |

## Scope

Out of scope (unchanged): a dedicated top-level 3D `camera` convenience field (the Camera3D now appears in `entities`); GridMap *cells* stay dict data; the unresolved-path "did you mean" companion idea remains a separate future issue.

Closes #230
