### PR TITLE
fix: emit schema-valid action examples and per-action descriptions in generated docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) server for Godot Engine integration.
 
 ## Overview
 
-This server provides **14 tools** and **3 resources** for AI-assisted Godot development.
+This server provides **15 tools** and **3 resources** for AI-assisted Godot development.
 
 ## Quick Links
 
@@ -28,6 +28,7 @@ This server provides **14 tools** and **3 resources** for AI-assisted Godot deve
 | [Input](tools/input.md) | 1 | Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, relative mouse-look, and text typing (no absolute cursor positioning) |
 | [Profiler](tools/profiler.md) | 1 | Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections |
 | [Runtime State](tools/runtime-state.md) | 1 | Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots. |
+| [Game Time Control](tools/game-time.md) | 1 | Deterministic game-clock control: freeze the running game, step a bounded slice of game time (or step until a condition holds) with inputs riding inside the window, then thaw — so observation is not racing ahead between tool calls. |
 | [Game Script Execution](tools/exec.md) | 1 | Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard. |
 
 ## Installation

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -75,6 +75,12 @@ Observe live game entity state as structured JSON — positions, velocities, ani
 
 - `godot_runtime_state` - Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
 
+## [Game Time Control](game-time.md)
+
+Deterministic game-clock control: freeze the running game, step a bounded slice of game time (or step until a condition holds) with inputs riding inside the window, then thaw — so observation is not racing ahead between tool calls.
+
+- `godot_game_time` - Make game time answer to your clock instead of racing ahead between tool calls: freeze the running game, observe it at leisure (screenshots and state digests work while frozen), then step forward a bounded slice of game time (step) — or until a condition you specify holds (step_until) — with inputs riding inside the window. The game's own pause menu is layered correctly: freezing over it, stepping under it, and thawing back to it all preserve the game's pause intent.
+
 ## [Game Script Execution](exec.md)
 
 Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard.

--- a/docs/tools/animation.md
+++ b/docs/tools/animation.md
@@ -12,66 +12,170 @@ Animation query, playback, and editing tools
 
 Query, control, and edit animations. Query: list_players, get_info, get_details, get_keyframes. Playback: play, stop, seek. Edit: create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `list_players`, `get_info`, `get_details`, `get_keyframes`, `play`, `stop`, `seek`, `create`, `delete`, `update_props`, `add_track`, `remove_track`, `add_keyframe`, `remove_keyframe`, `update_keyframe` | Yes |  |
-| `root_path` | string | No | Starting node path (defaults to scene root) |
-| `node_path` | string | No | Path to the AnimationPlayer |
-| `animation_name` | string | No | Animation name |
-| `track_index` | number | No | Track index |
-| `custom_blend` | number | No | Custom blend time, -1 for default |
-| `custom_speed` | number | No | Playback speed, 1.0 default |
-| `from_end` | boolean | No | Play from end for reverse |
-| `keep_state` | boolean | No | Keep current animation state |
-| `seconds` | number | No | Position to seek to |
-| `update` | boolean | No | Update node immediately, default true |
-| `library_name` | string | No | Library name |
-| `length` | number | No | Animation length in seconds |
-| `loop_mode` | `none`, `linear`, `pingpong` | No | Loop mode: none, linear, pingpong |
-| `step` | number | No | Step value for keyframe snapping |
-| `track_type` | `value`, `position_3d`, `rotation_3d`, `scale_3d`, `blend_shape`, `method`, `bezier`, `audio`, `animation` | No | Type of track |
-| `track_path` | string | No | Node path and property, e.g. "Sprite2D:frame" |
-| `insert_at` | number | No | Track index to insert at, -1 for end |
-| `time` | number | No | Keyframe time in seconds |
-| `value` | unknown | No | Keyframe value |
-| `transition` | number | No | Transition curve, 1.0 = linear |
-| `method_name` | string | No | Method name for method tracks |
-| `args` | array | No | Method arguments |
-| `keyframe_index` | number | No | Keyframe index |
-
 ### Actions
 
 #### `list_players`
 
+List AnimationPlayer nodes in the scene
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Starting node path (defaults to scene root) |
+
 #### `get_info`
+
+Get AnimationPlayer state and library list
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
 
 #### `get_details`
 
+Get an animation's tracks and properties
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+
 #### `get_keyframes`
+
+Get keyframes for a track
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
 
 #### `play`
 
+Play an animation
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `custom_blend` | number | No | Custom blend time, -1 for default |
+| `custom_speed` | number | No | Playback speed, 1.0 default |
+| `from_end` | boolean | No | Play from end for reverse |
+
 #### `stop`
+
+Stop playback
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `keep_state` | boolean | No | Keep current animation state |
 
 #### `seek`
 
+Seek to a position in the current animation
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `seconds` | number | Yes | Position to seek to |
+| `update` | boolean | No | Update node immediately, default true |
+
 #### `create`
+
+Create an animation
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `library_name` | string | No | Library name |
+| `length` | number | No | Animation length in seconds |
+| `loop_mode` | `none`, `linear`, `pingpong` | No | Loop mode: none, linear, pingpong |
+| `step` | number | No | Step value for keyframe snapping |
 
 #### `delete`
 
+Delete an animation
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `library_name` | string | No | Library name |
+
 #### `update_props`
+
+Update animation properties
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `length` | number | No | Animation length in seconds |
+| `loop_mode` | `none`, `linear`, `pingpong` | No | Loop mode: none, linear, pingpong |
+| `step` | number | No | Step value for keyframe snapping |
 
 #### `add_track`
 
+Add a track to an animation
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_type` | `value`, `position_3d`, `rotation_3d`, `scale_3d`, `blend_shape`, `method`, `bezier`, `audio`, `animation` | Yes | Type of track |
+| `track_path` | string | Yes | Node path and property, e.g. "Sprite2D:frame" |
+| `insert_at` | number | No | Track index to insert at, -1 for end |
+
 #### `remove_track`
+
+Remove a track
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
 
 #### `add_keyframe`
 
+Add a keyframe to a track
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+| `time` | number | Yes | Keyframe time in seconds |
+| `value` | unknown | No | Keyframe value |
+| `transition` | number | No | Transition curve, 1.0 = linear |
+| `method_name` | string | No | Method name for method tracks |
+| `args` | array | No | Method arguments |
+
 #### `remove_keyframe`
 
+Remove a keyframe
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+| `keyframe_index` | number | Yes | Keyframe index |
+
 #### `update_keyframe`
+
+Update a keyframe
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | Yes | Animation name |
+| `track_index` | number | Yes | Track index |
+| `keyframe_index` | number | Yes | Keyframe index |
+| `time` | number | No | Keyframe time in seconds |
+| `value` | unknown | No | Keyframe value |
+| `transition` | number | No | Transition curve, 1.0 = linear |
 
 ### Examples
 
@@ -85,14 +189,17 @@ Query, control, and edit animations. Query: list_players, get_info, get_details,
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // get_details
 {
-  "action": "get_details"
+  "action": "get_details",
+  "node_path": "/root/Main/Player",
+  "animation_name": "idle"
 }
 ```
 

--- a/docs/tools/docs.md
+++ b/docs/tools/docs.md
@@ -12,21 +12,27 @@ Fetch Godot Engine documentation with smart extraction
 
 Fetch Godot Engine documentation. Use fetch_class for class references (e.g. CharacterBody2D), fetch_page for tutorials/guides. Auto-detects Godot version from editor connection. Returns clean markdown.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `fetch_class`, `fetch_page` | Yes |  |
-| `class_name` | string | No | Class name to fetch, e.g. "CharacterBody2D" |
-| `version` | `stable`, `latest`, `4.5`, `4.4`, `4.3`, `4.2` | No | Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable" |
-| `section` | `full`, `description`, `properties`, `methods`, `signals` | Yes | Which section to return (default: full). Use specific sections to reduce token usage. |
-| `path` | string | No | Documentation path, e.g. "/tutorials/2d/2d_movement.html" |
-
 ### Actions
 
 #### `fetch_class`
 
+Get a class reference by name
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `class_name` | string | Yes | Class name to fetch, e.g. "CharacterBody2D" |
+| `version` | `stable`, `latest`, `4.5`, `4.4`, `4.3`, `4.2` | No | Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable" |
+| `section` | `full`, `description`, `properties`, `methods`, `signals` | Yes | Which section to return (default: full). Use specific sections to reduce token usage. |
+
 #### `fetch_page`
+
+Get any docs page by path
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Documentation path, e.g. "/tutorials/2d/2d_movement.html" |
+| `version` | `stable`, `latest`, `4.5`, `4.4`, `4.3`, `4.2` | No | Godot docs version. If omitted, auto-detects from connected Godot editor or defaults to "stable" |
+| `section` | `full`, `description`, `properties`, `methods`, `signals` | Yes | Which section to return (default: full). Use specific sections to reduce token usage. |
 
 ### Examples
 
@@ -34,6 +40,7 @@ Fetch Godot Engine documentation. Use fetch_class for class references (e.g. Cha
 // fetch_class
 {
   "action": "fetch_class",
+  "class_name": "example",
   "section": "full"
 }
 ```
@@ -42,6 +49,7 @@ Fetch Godot Engine documentation. Use fetch_class for class references (e.g. Cha
 // fetch_page
 {
   "action": "fetch_page",
+  "path": "/root/Main/Player",
   "section": "full"
 }
 ```

--- a/docs/tools/editor.md
+++ b/docs/tools/editor.md
@@ -12,48 +12,94 @@ Editor control, debugging, and screenshot tools
 
 Control the Godot editor: get state, manage selection, run/stop project, restart the editor, capture screenshots, read log messages and stack traces, control 2D viewport
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_state`, `get_selection`, `select`, `run`, `stop`, `restart`, `get_log_messages`, `get_stack_trace`, `screenshot_game`, `screenshot_editor`, `set_viewport_2d` | Yes |  |
-| `node_path` | string | No | Path to node to select |
-| `scene_path` | string | No | Scene to run (optional, defaults to main scene) |
-| `frozen` | boolean | No | Launch with game time frozen from frame 0 (gameplay never starts racing your latency). Use godot_game_time step/thaw to advance. |
-| `save` | boolean | No | Save the project before restarting (default: true). Set false to discard unsaved editor changes. |
-| `clear` | boolean | No | Clear the editor error buffer after reading |
-| `limit` | integer | No | Maximum number of messages to return (default: 50) |
-| `severity` | `all`, `error`, `warning` | No | Filter by severity: "error" drops warnings (the "did anything actually break?" check), "warning" returns only warnings, "all" (default) returns both. |
-| `since` | integer | No | Return only messages newer than this cursor. Pass back the `cursor` from a prior response to see just what is new since then - the incremental check that avoids re-reading the whole buffer (0/omitted = from the beginning). |
-| `max_width` | integer | No | Maximum width in pixels (default: 900). Resolution is the vision-token cost lever (~width*height/750); lower it to spend less context. |
-| `viewport` | `2d`, `3d` | No | Which editor viewport to capture |
-| `center_x` | number | No | X coordinate to center the 2D viewport on |
-| `center_y` | number | No | Y coordinate to center the 2D viewport on |
-| `zoom` | number | No | Zoom level, e.g. 1.0 = 100%, 2.0 = 200% |
-
 ### Actions
 
 #### `get_state`
 
+Get editor state: current scene, play state, version, camera, viewport
+
+*No parameters.*
+
 #### `get_selection`
+
+Get the currently selected nodes
+
+*No parameters.*
 
 #### `select`
 
+Select a node in the editor
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to node to select |
+
 #### `run`
+
+Run the project
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | No | Scene to run (optional, defaults to main scene) |
+| `frozen` | boolean | No | Launch with game time frozen from frame 0 (gameplay never starts racing your latency). Use godot_game_time step/thaw to advance. |
 
 #### `stop`
 
+Stop the running project
+
+*No parameters.*
+
 #### `restart`
+
+Restart the editor, reloading project.godot (autoloads, input map), addon code, and plugins from disk. Use after external edits the running editor would otherwise keep stale. Fire-and-forget: the bridge drops and auto-reconnects within a few seconds. Does not start a cold editor - the editor must already be running.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `save` | boolean | No | Save the project before restarting (default: true). Set false to discard unsaved editor changes. |
 
 #### `get_log_messages`
 
+Get errors and warnings from the EDITOR process - @tool script runtime errors, import failures, addon errors, and failures from editor-side operations (scene/resource edits, reloads). This is the feedback channel for editor-side changes: run it after a mutation to confirm it did not break the editor. It does NOT include errors from the running game - for those, use minimal-godot-mcp's get_console_output (game console via DAP). Filter by severity (errors-only = "did my change break the editor?") and use `since`/`cursor` to read only what is new; every response returns the current `cursor`, even when empty.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `clear` | boolean | No | Clear the editor error buffer after reading |
+| `limit` | integer | No | Maximum number of messages to return (default: 50) |
+| `severity` | `all`, `error`, `warning` | No | Filter by severity: "error" drops warnings (the "did anything actually break?" check), "warning" returns only warnings, "all" (default) returns both. |
+| `since` | integer | No | Return only messages newer than this cursor. Pass back the `cursor` from a prior response to see just what is new since then - the incremental check that avoids re-reading the whole buffer (0/omitted = from the beginning). |
+
 #### `get_stack_trace`
+
+Get the most recent error stack trace
+
+*No parameters.*
 
 #### `screenshot_game`
 
+Capture a lossless PNG screenshot of the running game
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `max_width` | integer | No | Maximum width in pixels (default: 900). Resolution is the vision-token cost lever (~width*height/750); lower it to spend less context. |
+
 #### `screenshot_editor`
 
+Capture a lossless PNG screenshot of an editor viewport
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `viewport` | `2d`, `3d` | No | Which editor viewport to capture |
+| `max_width` | integer | No | Maximum width in pixels (default: 900). Resolution is the vision-token cost lever (~width*height/750); lower it to spend less context. |
+
 #### `set_viewport_2d`
+
+Center and zoom the 2D editor viewport
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `center_x` | number | No | X coordinate to center the 2D viewport on |
+| `center_y` | number | No | Y coordinate to center the 2D viewport on |
+| `zoom` | number | No | Zoom level, e.g. 1.0 = 100%, 2.0 = 200% |
 
 ### Examples
 
@@ -74,7 +120,8 @@ Control the Godot editor: get state, manage selection, run/stop project, restart
 ```json
 // select
 {
-  "action": "select"
+  "action": "select",
+  "node_path": "/root/Main/Player"
 }
 ```
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -12,31 +12,44 @@ Run GDScript inside the running game for test scenario setup: one-shot state mut
 
 Execute GDScript inside the RUNNING game process — the scenario-setup primitive: grant weapons, skip waves, spawn entities, arm persistent test bots, without baking debug hooks into game code. Errors when no game is running. For launch-time setup, compose: godot_editor run frozen=true -> godot_exec run (mutate state, attach bots under `holder`) -> godot_game_time thaw. A static denylist rejects accidental process/file-write escape (OS.execute, DirAccess, write-mode FileAccess, ResourceSaver, ProjectSettings.save, ...) and names the offending token — an accident guard, NOT a security boundary. Compile errors reject the call with the parser message; runtime errors come back in runtime_errors with the call still completing.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `run`, `list`, `remove`, `clear` | Yes |  |
-| `source` | string | No | GDScript statements, compiled as a function body. In scope: every autoload by its own name (e.g. `G.wave = 5`), `tree` (SceneTree), `root` (root Window) — the same context as step_until predicates — plus `holder`, a Node that survives scene reloads: attach nodes under it for behavior that persists between tool calls (a Timer-driven guard, an autofire bot), then manage them with list/remove/clear. Holder children pause with the tree, so a bot armed under a freeze acts only after thaw/step. Use an explicit `return` to get a value back (there is no implicit return): primitives (bool/int/float/String) come back intact; any other type (Array/Dictionary/Object/Vector2) comes back as a str() preview TRUNCATED to 200 chars — return JSON.stringify(...) yourself when you need structure. print() output is not returned — use return values, or minimal-godot-mcp get_console_output. Function bodies cannot declare top-level func/class — use lambdas for callbacks, or build a sub-script with GDScript.new() and set_script() it onto a holder child for _process-driven behavior. No `await` (synchronous-only; compose with godot_game_time to wait). A runtime error or failed assert() breaks the game into the editor debugger mid-call; the relay auto-resumes it and the error comes back in runtime_errors (any debugger break in the call window is resumed, including a breakpoint hit by unrelated game code). |
-| `budget_ms` | integer | No | Wall-clock patience for the call, used to size the timeout cascade (default 10000, max 30000). NOT enforcement: a synchronous script cannot be preempted, so an infinite loop hangs the game past any budget — recover with godot_editor stop. |
-| `name` | string | No | Node name as reported by list |
-
 ### Actions
 
 #### `run`
 
+Run one-shot GDScript inside the running game and return its value
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `source` | string | Yes | GDScript statements, compiled as a function body. In scope: every autoload by its own name (e.g. `G.wave = 5`), `tree` (SceneTree), `root` (root Window) — the same context as step_until predicates — plus `holder`, a Node that survives scene reloads: attach nodes under it for behavior that persists between tool calls (a Timer-driven guard, an autofire bot), then manage them with list/remove/clear. Holder children pause with the tree, so a bot armed under a freeze acts only after thaw/step. Use an explicit `return` to get a value back (there is no implicit return): primitives (bool/int/float/String) come back intact; any other type (Array/Dictionary/Object/Vector2) comes back as a str() preview TRUNCATED to 200 chars — return JSON.stringify(...) yourself when you need structure. print() output is not returned — use return values, or minimal-godot-mcp get_console_output. Function bodies cannot declare top-level func/class — use lambdas for callbacks, or build a sub-script with GDScript.new() and set_script() it onto a holder child for _process-driven behavior. No `await` (synchronous-only; compose with godot_game_time to wait). A runtime error or failed assert() breaks the game into the editor debugger mid-call; the relay auto-resumes it and the error comes back in runtime_errors (any debugger break in the call window is resumed, including a breakpoint hit by unrelated game code). |
+| `budget_ms` | integer | No | Wall-clock patience for the call, used to size the timeout cascade (default 10000, max 30000). NOT enforcement: a synchronous script cannot be preempted, so an infinite loop hangs the game past any budget — recover with godot_editor stop. |
+
 #### `list`
+
+List the nodes currently attached under the exec holder (name, class, age, processing state)
+
+*No parameters.*
 
 #### `remove`
 
+Remove one exec holder child by name (queue_free)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Node name as reported by list |
+
 #### `clear`
+
+Remove every exec holder child (queue_free all)
+
+*No parameters.*
 
 ### Examples
 
 ```json
 // run
 {
-  "action": "run"
+  "action": "run",
+  "source": "example"
 }
 ```
 
@@ -50,7 +63,8 @@ Execute GDScript inside the RUNNING game process — the scenario-setup primitiv
 ```json
 // remove
 {
-  "action": "remove"
+  "action": "remove",
+  "name": "example"
 }
 ```
 

--- a/docs/tools/game-time.md
+++ b/docs/tools/game-time.md
@@ -1,0 +1,84 @@
+# Game Time Control Tools
+
+Deterministic game-clock control: freeze the running game, step a bounded slice of game time (or step until a condition holds) with inputs riding inside the window, then thaw — so observation is not racing ahead between tool calls.
+
+## Tools
+
+- [godot_game_time](#godot_game_time)
+
+---
+
+## godot_game_time
+
+Make game time answer to your clock instead of racing ahead between tool calls: freeze the running game, observe it at leisure (screenshots and state digests work while frozen), then step forward a bounded slice of game time (step) — or until a condition you specify holds (step_until) — with inputs riding inside the window. The game's own pause menu is layered correctly: freezing over it, stepping under it, and thawing back to it all preserve the game's pause intent.
+
+### Actions
+
+#### `freeze`
+
+Pause the game under agent control. All observation tools (screenshots, runtime state, find_nodes) keep working while frozen — take as long as you need.
+
+*No parameters.*
+
+#### `step`
+
+Advance a bounded slice of game time, then re-freeze. Freezes first if the game is running, so step is always a safe first call.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `duration_ms` | integer | No | Game time to advance in milliseconds (max 50000; loop steps for longer). Scaled by Engine.time_scale like normal play. |
+| `frames` | integer | No | Frames to advance instead of a duration (max 1200). frames: 1 is a single-frame advance. |
+| `inputs` | array | No | Input timeline executed inside the window; start_ms is game time from window start. Entries share the godot_input sequence vocabulary: named actions (with analog strength), joypad buttons, axis holds, stick vectors, raw keys (with modifier combos), and relative mouse-look (look: [dx, dy], delivered as InputEventMouseMotion.relative inside the frozen step — the FPS-camera testing path). Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end. |
+
+#### `step_until`
+
+Advance game time until a GDScript predicate becomes true (or a safety cap is hit), then re-freeze. Freezes first if the game is running, so it is a safe first call. Use this instead of step when you do not know how long to advance to reach the state worth observing.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `until` | string | Yes | A GDScript boolean expression, re-evaluated against the running game every frame; stepping stops the frame it is truthy. Autoloads are in scope by name (e.g. `G.wave > 1`, `GameState.tick_count % 12 == 11`), plus `tree` (the SceneTree) and `root` (the root Window) for tree queries (e.g. `tree.get_nodes_in_group("enemies").size() >= 1`). Must parse and evaluate without error against the current state or the call is rejected up front. Expressions do NOT short-circuit (`and`/`or` evaluate both operands), so to read a node that may not exist yet, do not guard with `arr.size() > 0 and arr[0].x` — sequence two calls instead: step_until the node exists (`tree.get_nodes_in_group("boss").size() >= 1`), then step_until reading it (`tree.get_nodes_in_group("boss")[0].state == 4`). |
+| `max_ms` | integer | No | Safety cap on game time to advance while waiting (max 50000, default 20000). If the predicate never holds within this budget (or the wall-clock budget), the call returns with predicate_met: false instead of hanging. |
+| `report` | string[] | No | Optional GDScript expressions (same scope as `until`) evaluated when stepping stops and returned as a { expression: value } map — e.g. ["G.wave", "tree.get_nodes_in_group(\"enemies\").size()"]. Use this to read the state you care about in the same call instead of a separate observation round-trip. Each must parse and evaluate without error up front. |
+| `inputs` | array | No | Optional input timeline driven inside the window, exactly like step (same vocabulary: actions, joypad buttons, axes, stick vectors, raw keys, relative mouse-look look:[dx,dy] — e.g. hold a stick deflection while waiting for an enemy to appear). Holds are released by window end. |
+
+#### `thaw`
+
+Resume real-time play, restoring the game's own pause state (an open pause menu stays open).
+
+*No parameters.*
+
+#### `status`
+
+Report the freeze state: `frozen` is authoritative for the current state; `frozen_wall_ms` is real wall-clock held (not game time); `launched_frozen` is a historical flag (this run booted frozen) and stays true after thaw. Also reports the game's own pause intent, time scale, and whether game code is contesting the freeze.
+
+*No parameters.*
+
+### Examples
+
+```json
+// freeze
+{
+  "action": "freeze"
+}
+```
+
+```json
+// step
+{
+  "action": "step",
+  "duration_ms": 1
+}
+```
+
+```json
+// step_until
+{
+  "action": "step_until",
+  "until": "example"
+}
+```
+
+*2 more actions available: `thaw`, `status`*
+
+---
+

--- a/docs/tools/input.md
+++ b/docs/tools/input.md
@@ -12,26 +12,34 @@ Input injection for testing running games: named actions, joypad buttons, analog
 
 Inject input into a running Godot game for testing: named actions (with analog strength), joypad buttons, analog axes, stick vectors, raw keyboard keys (with modifier combos), and relative mouse-look. Use get_map to discover available input actions and their bindings, sequence to execute inputs with precise timing (optionally with an effect probe that proves the inputs changed game state), or type_text to type into UI elements. Note: relative mouse-look is supported (look: [dx, dy], for FPS-camera _input handlers); absolute cursor positioning is not (see docs/design/mouse-input-spike.md).
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_map`, `sequence`, `type_text` | Yes |  |
-| `inputs` | array | No | Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), a STICK vector (stick + x/y), a raw KEY (key, e.g. "ctrl+s"), or relative mouse LOOK (look: [dx, dy]) — mix freely on one timeline. Joypad events drive bound actions (with real deadzone math), raw _input handlers, and the polled Input singletons (get_joy_axis / is_joy_button_pressed); key events likewise drive bound actions, _input/_unhandled_input, and Input.is_key_pressed; look events deliver InputEventMouseMotion.relative to _input/_unhandled_input for FPS-camera code (duration_ms >= 16 distributes the delta as a smooth sweep). No physical pad, keyboard, or mouse is needed. Limitation: Input.get_connected_joypads() never reports a virtual pad, so games that gate controller mode on pad DETECTION cannot be switched into it. |
-| `report` | string[] | No | Optional effect probe: GDScript expressions evaluated once before the first input and again after the last, to prove the inputs actually changed something (vs. falling into the void — player dead, UI focus elsewhere, wrong action). Reference autoloads by name (e.g. "G.shots", "G.wave") plus `tree`/`root` (e.g. "tree.get_nodes_in_group('enemies').size()"), same context as godot_game_time step_until. Each expression returns {before, after, changed}; the result also carries any_changed. Expressions do NOT short-circuit and a parse/eval error rejects the call. The after-reading is sampled a couple frames past the final input, so only near-immediate effects register — for slower effects use godot_game_time or runtime_state watch. |
-| `screenshot_at_ms` | integer[] | No | Optional: millisecond offsets (from sequence start) at which to capture a lossless PNG frame DURING the real-time run. The bridge owns the sequence clock, so it grabs each frame at the right moment and returns them with the result — letting you catch transient visuals (muzzle flashes, explosions, kill banners) that fade long before a separate screenshot call could land. Up to 8 frames, each returned as an image labeled with its actual offset; an offset (like the whole sequence) must fall within the 40000ms single-call window. COST: each frame costs vision tokens by RESOLUTION (~width*height/750), independent of format, and persists in context on every following turn — so prefer a few frames at a modest screenshot_max_width over many large ones. For frozen/precise inspection prefer godot_game_time step + screenshot_game instead. |
-| `screenshot_max_width` | integer | No | Max width in px for captured frames (default 640). Resolution is the real vision-token lever (cost ~width*height/750 per frame); lower it to spend less context, raise it only when fine detail matters. |
-| `text` | string | No | Text to type |
-| `delay_ms` | integer | No | Delay between keystrokes in milliseconds (default 50) |
-| `submit` | boolean | No | Press Enter after typing to submit (for LineEdit text_submitted) |
-
 ### Actions
 
 #### `get_map`
 
+List available input actions from the project Input Map
+
+*No parameters.*
+
 #### `sequence`
 
+Execute an input timeline
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `inputs` | array | Yes | Array of inputs to execute. Each entry is one of: a named ACTION (action_name, optional analog strength), a joypad BUTTON (joy_button), an analog AXIS hold (axis + value), a STICK vector (stick + x/y), a raw KEY (key, e.g. "ctrl+s"), or relative mouse LOOK (look: [dx, dy]) — mix freely on one timeline. Joypad events drive bound actions (with real deadzone math), raw _input handlers, and the polled Input singletons (get_joy_axis / is_joy_button_pressed); key events likewise drive bound actions, _input/_unhandled_input, and Input.is_key_pressed; look events deliver InputEventMouseMotion.relative to _input/_unhandled_input for FPS-camera code (duration_ms >= 16 distributes the delta as a smooth sweep). No physical pad, keyboard, or mouse is needed. Limitation: Input.get_connected_joypads() never reports a virtual pad, so games that gate controller mode on pad DETECTION cannot be switched into it. |
+| `report` | string[] | No | Optional effect probe: GDScript expressions evaluated once before the first input and again after the last, to prove the inputs actually changed something (vs. falling into the void — player dead, UI focus elsewhere, wrong action). Reference autoloads by name (e.g. "G.shots", "G.wave") plus `tree`/`root` (e.g. "tree.get_nodes_in_group('enemies').size()"), same context as godot_game_time step_until. Each expression returns {before, after, changed}; the result also carries any_changed. Expressions do NOT short-circuit and a parse/eval error rejects the call. The after-reading is sampled a couple frames past the final input, so only near-immediate effects register — for slower effects use godot_game_time or runtime_state watch. |
+| `screenshot_at_ms` | integer[] | No | Optional: millisecond offsets (from sequence start) at which to capture a lossless PNG frame DURING the real-time run. The bridge owns the sequence clock, so it grabs each frame at the right moment and returns them with the result — letting you catch transient visuals (muzzle flashes, explosions, kill banners) that fade long before a separate screenshot call could land. Up to 8 frames, each returned as an image labeled with its actual offset; an offset (like the whole sequence) must fall within the 40000ms single-call window. COST: each frame costs vision tokens by RESOLUTION (~width*height/750), independent of format, and persists in context on every following turn — so prefer a few frames at a modest screenshot_max_width over many large ones. For frozen/precise inspection prefer godot_game_time step + screenshot_game instead. |
+| `screenshot_max_width` | integer | No | Max width in px for captured frames (default 640). Resolution is the real vision-token lever (cost ~width*height/750 per frame); lower it to spend less context, raise it only when fine detail matters. |
+
 #### `type_text`
+
+Type text into the focused UI element
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | Text to type |
+| `delay_ms` | integer | Yes | Delay between keystrokes in milliseconds (default 50) |
+| `submit` | boolean | Yes | Press Enter after typing to submit (for LineEdit text_submitted) |
 
 ### Examples
 
@@ -45,14 +53,24 @@ Inject input into a running Godot game for testing: named actions (with analog s
 ```json
 // sequence
 {
-  "action": "sequence"
+  "action": "sequence",
+  "inputs": [
+    {
+      "action_name": "example",
+      "start_ms": 0,
+      "duration_ms": 0
+    }
+  ]
 }
 ```
 
 ```json
 // type_text
 {
-  "action": "type_text"
+  "action": "type_text",
+  "text": "example",
+  "delay_ms": 0,
+  "submit": false
 }
 ```
 

--- a/docs/tools/node.md
+++ b/docs/tools/node.md
@@ -12,66 +12,117 @@ Node manipulation and script attachment tools
 
 Manage scene nodes: get properties, find, create, update, delete, reparent, attach/detach scripts, connect signals
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_properties`, `find`, `create`, `update`, `delete`, `reparent`, `attach_script`, `detach_script`, `connect_signal` | Yes |  |
-| `node_path` | string | No | Path to the node emitting the signal |
-| `name_pattern` | string | No | Glob pattern to match node names, e.g. "*Spawner*", "Turret?" |
-| `type` | string | No | Filter by node type, e.g. "CharacterBody2D", "Area2D" |
-| `root_path` | string | No | Path to start search from (defaults to scene root) |
-| `parent_path` | string | No | Path to the parent node |
-| `node_name` | string | No | Name for the new node |
-| `node_type` | string | No | Type of node to create, e.g. "Sprite2D" (use this OR scene_path) |
-| `scene_path` | string | No | Path to scene to instantiate, e.g. "res://enemies/goblin.tscn" (use this OR node_type) |
-| `properties` | Record<string, unknown> | No | Properties to set on the node |
-| `new_parent_path` | string | No | Path to the new parent node |
-| `script_path` | string | No | Path to the script file |
-| `signal_name` | string | No | Name of the signal, e.g. "pressed", "body_entered" |
-| `target_path` | string | No | Path to the target node that will receive the signal |
-| `method_name` | string | No | Name of the method to call on the target node |
-
 ### Actions
 
 #### `get_properties`
 
+Get a node's properties
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+
 #### `find`
+
+Find nodes by name and/or type
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name_pattern` | string | No | Glob pattern to match node names, e.g. "*Spawner*", "Turret?" |
+| `type` | string | No | Filter by node type, e.g. "CharacterBody2D", "Area2D" |
+| `root_path` | string | No | Path to start search from (defaults to scene root) |
 
 #### `create`
 
+Create a node, or instantiate a scene as a node
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `parent_path` | string | Yes | Path to the parent node |
+| `node_name` | string | Yes | Name for the new node |
+| `node_type` | string | No | Type of node to create, e.g. "Sprite2D" (use this OR scene_path) |
+| `scene_path` | string | No | Path to scene to instantiate, e.g. "res://enemies/goblin.tscn" (use this OR node_type) |
+| `properties` | Record<string, unknown> | No | Properties to set on the node |
+
 #### `update`
+
+Update a node's properties
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `properties` | Record<string, unknown> | No | Properties to set on the node |
 
 #### `delete`
 
+Delete a node
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+
 #### `reparent`
+
+Move a node to a new parent
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `new_parent_path` | string | Yes | Path to the new parent node |
 
 #### `attach_script`
 
+Attach a script to a node
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+| `script_path` | string | Yes | Path to the script file |
+
 #### `detach_script`
 
+Detach a node's script
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node |
+
 #### `connect_signal`
+
+Connect a signal to a target method
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the node emitting the signal |
+| `signal_name` | string | Yes | Name of the signal, e.g. "pressed", "body_entered" |
+| `target_path` | string | Yes | Path to the target node that will receive the signal |
+| `method_name` | string | Yes | Name of the method to call on the target node |
 
 ### Examples
 
 ```json
 // get_properties
 {
-  "action": "get_properties"
+  "action": "get_properties",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // find
 {
-  "action": "find"
+  "action": "find",
+  "name_pattern": "*Enemy*"
 }
 ```
 
 ```json
 // create
 {
-  "action": "create"
+  "action": "create",
+  "parent_path": "/root/Main",
+  "node_name": "NewNode",
+  "node_type": "Sprite2D"
 }
 ```
 

--- a/docs/tools/profiler.md
+++ b/docs/tools/profiler.md
@@ -12,26 +12,45 @@ Performance profiling: snapshots, per-frame time series with spike detection, ac
 
 Performance profiling and analysis: snapshot all engine metrics, collect per-frame time series data with spike detection, list active _process/_physics_process scripts, inspect signal connections
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `snapshot`, `start`, `stop`, `get_data`, `get_active_processes`, `get_signal_connections` | Yes |  |
-| `node_path` | string | No | Node path (defaults to scene root) |
-
 ### Actions
 
 #### `snapshot`
 
+Full performance snapshot (all engine metrics)
+
+*No parameters.*
+
 #### `start`
+
+Start per-frame time-series profiling
+
+*No parameters.*
 
 #### `stop`
 
+Stop time-series profiling
+
+*No parameters.*
+
 #### `get_data`
+
+Get collected time-series data with spike detection
+
+*No parameters.*
 
 #### `get_active_processes`
 
+List active _process/_physics_process scripts
+
+*No parameters.*
+
 #### `get_signal_connections`
+
+Inspect signal connections
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | No | Node path (defaults to scene root) |
 
 ### Examples
 

--- a/docs/tools/project.md
+++ b/docs/tools/project.md
@@ -12,23 +12,34 @@ Project information tools
 
 Get project information and settings
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_info`, `get_settings`, `addon_status`, `check_stale` | Yes |  |
-| `category` | string | No | Settings category to filter by (use "input" for input mappings) |
-| `include_builtin` | boolean | No | Include built-in ui_* actions (with category="input") |
-
 ### Actions
 
 #### `get_info`
 
+Get project name, path, version, and main scene
+
+*No parameters.*
+
 #### `get_settings`
+
+Get project settings
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `category` | string | No | Settings category to filter by (use "input" for input mappings) |
+| `include_builtin` | boolean | No | Include built-in ui_* actions (with category="input") |
 
 #### `addon_status`
 
+Check addon/server version compatibility
+
+*No parameters.*
+
 #### `check_stale`
+
+Check whether project.godot was edited on disk after the editor loaded it, leaving the editor with stale autoloads / input map (and phantom "Identifier not found" errors in its log that do not exist at runtime). Returns the disk-vs-editor divergence; run godot_editor restart to reload. Useful right after editing project.godot as a file.
+
+*No parameters.*
 
 ### Examples
 

--- a/docs/tools/resource.md
+++ b/docs/tools/resource.md
@@ -12,18 +12,17 @@ Resource inspection tools for SpriteFrames, TileSet, Materials, etc.
 
 Manage Godot resources: inspect Resource files by path. Returns type-specific structured data for SpriteFrames, TileSet, Material, Texture2D, etc.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_info` | Yes |  |
-| `resource_path` | string | Yes | Resource path (e.g., "res://player/sprites.tres") |
-| `max_depth` | number | No | Detail level: 0 = summary only, 1 = full detail (default), 2+ = expand sub-resources |
-| `include_internal` | boolean | No | Include internal properties starting with underscore (default: false) |
-
 ### Actions
 
 #### `get_info`
+
+Inspect a Resource file by path
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `resource_path` | string | Yes | Resource path (e.g., "res://player/sprites.tres") |
+| `max_depth` | number | No | Detail level: 0 = summary only, 1 = full detail (default), 2+ = expand sub-resources |
+| `include_internal` | boolean | No | Include internal properties starting with underscore (default: false) |
 
 ### Examples
 

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -12,11 +12,14 @@ Observe live game entity state as structured JSON — positions, velocities, ani
 
 Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
 
-### Parameters
+### Actions
+
+#### `digest`
+
+Snapshot current game entity state as structured JSON — exact positions, velocities, animation state, and custom game data. Much cheaper than screenshot_game (no vision tokens). Works on any game with no setup; add nodes to the "mcp_watch" group or implement `func _mcp_state() -> Dictionary` on key nodes for richer, targeted data. WHAT TO PUT IN _mcp_state(): include BOTH (1) live runtime values that change during play (cursor position, health, score, fill counts) AND (2) static definition context an agent needs to interpret them — e.g. a puzzle node should expose its clue data, a level node its objective list, a shop its item catalog. Without definition context, an agent can observe state changes but cannot verify correctness. Also include layout geometry for renderable nodes (bounds, sizes, offsets) to enable programmatic layout checks without a screenshot.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | `digest`, `watch_start`, `watch_collect`, `watch_stop` | Yes |  |
 | `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → a visibility fallback that surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), "none" = no automatic selection; return only the nodes named in paths |
 | `group` | string | No | Group name to use when select="group" or "auto" (default: "mcp_watch") |
 | `paths` | string[] | No | Explicit absolute node paths to include in addition to tier selection, e.g. ["/root/GameState"]. The digest walks the current scene only, so autoload singletons — where global game state often lives (cash, score, settings) — are otherwise unreachable. Each path returns _mcp_state() if present, else a snapshot of the node's script variables (scalars/arrays, ~1 KB cap). Paths that do not resolve are returned in unresolved_paths. |
@@ -24,20 +27,29 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 | `type` | string | No | Class filter (e.g. "CharacterBody2D") |
 | `max_nodes` | integer | No | Maximum nodes in result (default: 40) |
 | `include` | string[] | No | Subset of fields to include (default: all available) |
+
+#### `watch_start`
+
+Start an in-engine sampler that records specified node fields over a time window. Returns immediately; call watch_collect after duration_ms to get the summarized digest. Field keys: "pos.x", "pos.y", "vel.x", "vel.y" for built-in properties; any key from _mcp_state() for custom game state (e.g. "health", "ammo"). TIMING: watch_start and the action that drives state change (godot_input sequence, player input, etc.) must overlap within the watch window. Send both in the same parallel tool call batch, or use a duration_ms large enough (3000–4000ms) to cover the round-trip latency before the driving action is approved and sent. NODE PATHS: if a path in specs cannot be resolved, that spec is silently skipped; check resolved_fields in the response — 0 means all paths were invalid.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
 | `specs` | object[] | No | Which nodes and fields to watch. Optional when signals is provided. |
 | `signals` | object[] | No | Signals to record as discrete timeline events during the window. Each emission is buffered as {t_ms, source, signal, args} (200 events/window shared FAIRLY — each signal gets an equal sub-budget so a chatty signal cannot starve a rare one; keep-first within each, with events_dropped + events_dropped_by_signal reporting any loss; args stringified to ~100 chars). watch_collect merges these with string-field transitions into a time-sorted `timeline`. Signals with more than 5 parameters are skipped and reported in unresolved_signals, as are bad paths/names. Connections stay live until duration_ms elapses or watch_stop. Signals must be emitted on the main thread (worker-thread emissions are unsupported). At least one of specs/signals is required. |
 | `hz` | integer | No | Sample rate in Hz (default: 20) |
 | `duration_ms` | integer | No | Auto-stop after this many milliseconds (default: 1000) |
 
-### Actions
-
-#### `digest`
-
-#### `watch_start`
-
 #### `watch_collect`
 
+Collect the current sampler buffer and return a per-field summary (start/end/min/max/mean/slope for numeric fields; transition events for string fields) plus a time-sorted `timeline` merging watched signal emissions with string-field transitions (kinds: signal, anim_transition, field_change). TIMESTAMPS: signal t_ms is emission time (ms resolution); anim/field t_ms is DETECTION time at the sample rate — the change happened up to one sample interval earlier, so do not infer cross-kind ordering from nearby timestamps. Safe to call before auto-stop — returns whatever has been recorded so far; signal connections stay live until the window ends.
+
+*No parameters.*
+
 #### `watch_stop`
+
+Stop the sampler early (disconnecting watched signals) and return the final per-field summary and merged `timeline`. Equivalent to watch_collect + stopping the sampler.
+
+*No parameters.*
 
 ### Examples
 
@@ -51,7 +63,15 @@ Observe live game state as structured data. Use digest for a one-shot entity sna
 ```json
 // watch_start
 {
-  "action": "watch_start"
+  "action": "watch_start",
+  "specs": [
+    {
+      "path": "/root/Main/Player",
+      "fields": [
+        "example"
+      ]
+    }
+  ]
 }
 ```
 

--- a/docs/tools/scene.md
+++ b/docs/tools/scene.md
@@ -12,29 +12,41 @@ Scene management tools
 
 Manage scenes: open, save, or create scenes
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `open`, `save`, `create` | Yes |  |
-| `scene_path` | string | No | Path for the new scene file |
-| `root_type` | string | No | Type of root node, e.g. "Node2D" |
-| `root_name` | string | No | Name of root node (defaults to root_type) |
-
 ### Actions
 
 #### `open`
 
+Open a scene file
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | Yes | Path to scene file to open |
+
 #### `save`
 
+Save the current scene
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | No | Path to save to (defaults to the current scene path) |
+
 #### `create`
+
+Create a new scene
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | Yes | Path for the new scene file |
+| `root_type` | string | Yes | Type of root node, e.g. "Node2D" |
+| `root_name` | string | No | Name of root node (defaults to root_type) |
 
 ### Examples
 
 ```json
 // open
 {
-  "action": "open"
+  "action": "open",
+  "scene_path": "res://scenes/enemy.tscn"
 }
 ```
 
@@ -48,7 +60,9 @@ Manage scenes: open, save, or create scenes
 ```json
 // create
 {
-  "action": "create"
+  "action": "create",
+  "scene_path": "res://scenes/enemy.tscn",
+  "root_type": "example"
 }
 ```
 

--- a/docs/tools/scene3d.md
+++ b/docs/tools/scene3d.md
@@ -12,30 +12,36 @@
 
 Get spatial information for 3D nodes: global transforms, bounding boxes, visibility. Use get_spatial_info for node details, get_bounds for combined AABB of a subtree.
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `get_spatial_info`, `get_bounds` | Yes |  |
-| `node_path` | string | No | Path to the Node3D |
-| `include_children` | boolean | No | Include child nodes |
-| `type_filter` | string | No | Filter by node type, e.g. "MeshInstance3D" |
-| `max_results` | integer | No | Limit number of results. Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed. |
-| `within_aabb` | object {position, size} | No | Only include nodes whose global position is within this AABB |
-| `root_path` | string | No | Path to search root (defaults to scene root) |
-
 ### Actions
 
 #### `get_spatial_info`
 
+Get spatial data for a Node3D and optionally its children
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the Node3D |
+| `include_children` | boolean | Yes | Include child nodes |
+| `type_filter` | string | No | Filter by node type, e.g. "MeshInstance3D" |
+| `max_results` | integer | No | Limit number of results. Defaults to 50 when include_children=true. Set higher (e.g., 500) if needed. |
+| `within_aabb` | object {position, size} | No | Only include nodes whose global position is within this AABB |
+
 #### `get_bounds`
+
+Get the combined AABB of a subtree
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Path to search root (defaults to scene root) |
 
 ### Examples
 
 ```json
 // get_spatial_info
 {
-  "action": "get_spatial_info"
+  "action": "get_spatial_info",
+  "node_path": "/root/Main/Player",
+  "include_children": false
 }
 ```
 

--- a/docs/tools/tilemap.md
+++ b/docs/tools/tilemap.md
@@ -13,46 +13,106 @@ TileMapLayer and GridMap editing tools (uses Godot 4.3+ TileMapLayer, not deprec
 
 Query and edit TileMapLayer data: list layers, get info, get/set cells, convert coordinates
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `list_layers`, `get_info`, `get_tileset_info`, `get_used_cells`, `get_cell`, `get_cells_in_region`, `convert_coords`, `set_cell`, `erase_cell`, `clear_layer`, `set_cells_batch` | Yes |  |
-| `root_path` | string | No | Starting node path (defaults to scene root) |
-| `node_path` | string | No | Path to the TileMapLayer |
-| `coords` | object {x, y} | No | Cell coordinates |
-| `min_coords` | object {x, y} | No | Minimum corner of region |
-| `max_coords` | object {x, y} | No | Maximum corner of region |
-| `local_position` | object {x, y} | No | Local position to convert to map coords |
-| `map_coords` | object {x, y} | No | Map coordinates to convert to local position |
-| `source_id` | integer | No | TileSet source ID, default 0 |
-| `atlas_coords` | object {x, y} | No | Atlas coordinates, default 0,0 |
-| `alternative_tile` | integer | No | Alternative tile ID, default 0 |
-| `cells` | object[] | No | Array of cells to set |
-
 ### Actions
 
 #### `list_layers`
 
+List TileMapLayer nodes in the scene
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Starting node path (defaults to scene root) |
+
 #### `get_info`
+
+Get TileMapLayer info
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
 
 #### `get_tileset_info`
 
+Get the layer's TileSet info
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+
 #### `get_used_cells`
+
+Get all used cells
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
 
 #### `get_cell`
 
+Get a single cell
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `coords` | object {x, y} | Yes | Cell coordinates |
+
 #### `get_cells_in_region`
+
+Get cells within a rectangular region
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `min_coords` | object {x, y} | Yes | Minimum corner of region |
+| `max_coords` | object {x, y} | Yes | Maximum corner of region |
 
 #### `convert_coords`
 
+Convert between local position and map coordinates
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `local_position` | object {x, y} | No | Local position to convert to map coords |
+| `map_coords` | object {x, y} | No | Map coordinates to convert to local position |
+
 #### `set_cell`
+
+Set a single cell
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `coords` | object {x, y} | Yes | Cell coordinates |
+| `source_id` | integer | No | TileSet source ID, default 0 |
+| `atlas_coords` | object {x, y} | No | Atlas coordinates, default 0,0 |
+| `alternative_tile` | integer | No | Alternative tile ID, default 0 |
 
 #### `erase_cell`
 
+Erase a single cell
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `coords` | object {x, y} | Yes | Cell coordinates |
+
 #### `clear_layer`
 
+Clear all cells in the layer
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+
 #### `set_cells_batch`
+
+Set many cells at once
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the TileMapLayer |
+| `cells` | object[] | Yes | Array of cells to set |
 
 ### Examples
 
@@ -66,14 +126,16 @@ Query and edit TileMapLayer data: list layers, get info, get/set cells, convert 
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // get_tileset_info
 {
-  "action": "get_tileset_info"
+  "action": "get_tileset_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
@@ -85,39 +147,94 @@ Query and edit TileMapLayer data: list layers, get info, get/set cells, convert 
 
 Query and edit GridMap data: list gridmaps, get info, get/set cells
 
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `action` | `list`, `get_info`, `get_meshlib_info`, `get_used_cells`, `get_cell`, `get_cells_by_item`, `set_cell`, `clear_cell`, `clear`, `set_cells_batch` | Yes |  |
-| `root_path` | string | No | Starting node path (defaults to scene root) |
-| `node_path` | string | No | Path to the GridMap |
-| `coords` | object {x, y, z} | No | Cell coordinates |
-| `item` | integer | No | MeshLibrary item index |
-| `orientation` | integer | No | Orientation 0-23, default 0 |
-| `cells` | object[] | No | Array of cells to set |
-
 ### Actions
 
 #### `list`
 
+List GridMap nodes in the scene
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `root_path` | string | No | Starting node path (defaults to scene root) |
+
 #### `get_info`
+
+Get GridMap info
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
 
 #### `get_meshlib_info`
 
+Get the GridMap's MeshLibrary info
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+
 #### `get_used_cells`
+
+Get all used cells
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
 
 #### `get_cell`
 
+Get a single cell
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `coords` | object {x, y, z} | Yes | Cell coordinates |
+
 #### `get_cells_by_item`
+
+Get all cells using a given MeshLibrary item
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `item` | integer | Yes | MeshLibrary item index |
 
 #### `set_cell`
 
+Set a single cell
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `coords` | object {x, y, z} | Yes | Cell coordinates |
+| `item` | integer | Yes | MeshLibrary item index |
+| `orientation` | integer | No | Orientation 0-23, default 0 |
+
 #### `clear_cell`
+
+Clear a single cell
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `coords` | object {x, y, z} | Yes | Cell coordinates |
 
 #### `clear`
 
+Clear all cells
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+
 #### `set_cells_batch`
+
+Set many cells at once
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the GridMap |
+| `cells` | object[] | Yes | Array of cells to set |
 
 ### Examples
 
@@ -131,14 +248,16 @@ Query and edit GridMap data: list gridmaps, get info, get/set cells
 ```json
 // get_info
 {
-  "action": "get_info"
+  "action": "get_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 
 ```json
 // get_meshlib_info
 {
-  "action": "get_meshlib_info"
+  "action": "get_meshlib_info",
+  "node_path": "/root/Main/Player"
 }
 ```
 

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -1,6 +1,8 @@
 import { writeFileSync, readFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+import { z } from 'zod';
 
 import { sceneTools } from '../src/tools/scene.js';
 import { nodeTools } from '../src/tools/node.js';
@@ -14,10 +16,17 @@ import { docsTools } from '../src/tools/docs.js';
 import { inputTools } from '../src/tools/input.js';
 import { profilerTools } from '../src/tools/profiler.js';
 import { runtimeStateTools } from '../src/tools/runtime-state.js';
+import { gameTimeTools } from '../src/tools/game-time.js';
 import { execTools } from '../src/tools/exec.js';
 import { sceneResources } from '../src/resources/scene.js';
 import { scriptResources } from '../src/resources/script.js';
 import { toInputSchema } from '../src/core/schema.js';
+import {
+  getActionVariants,
+  buildVariantExample,
+  rawJsonSchema,
+  type ActionVariant,
+} from '../src/core/doc-examples.js';
 import type { AnyToolDefinition, ResourceDefinition } from '../src/core/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -46,6 +55,7 @@ const categories: ToolCategory[] = [
   { name: 'Input', filename: 'input', description: 'Input injection for testing running games: named actions, joypad buttons, analog axes and stick vectors, raw keyboard keys with modifier combos, relative mouse-look, and text typing (no absolute cursor positioning)', tools: inputTools },
   { name: 'Profiler', filename: 'profiler', description: 'Performance profiling: snapshots, per-frame time series with spike detection, active process inspection, signal connections', tools: profilerTools },
   { name: 'Runtime State', filename: 'runtime-state', description: 'Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots.', tools: runtimeStateTools },
+  { name: 'Game Time Control', filename: 'game-time', description: 'Deterministic game-clock control: freeze the running game, step a bounded slice of game time (or step until a condition holds) with inputs riding inside the window, then thaw — so observation is not racing ahead between tool calls.', tools: gameTimeTools },
   { name: 'Game Script Execution', filename: 'exec', description: 'Run GDScript inside the running game for test scenario setup: one-shot state mutations plus persistent holder-managed nodes, behind a denylist accident guard.', tools: execTools },
 ];
 
@@ -342,36 +352,17 @@ function getExampleValue(name: string, prop: Record<string, unknown>): unknown {
   }
 }
 
-interface ActionVariant {
-  action: string;
-  properties: Record<string, Record<string, unknown>>;
-  required: string[];
-}
-
-// Discriminated-union schemas serialize to oneOf (one object variant per
-// action). Pull each variant's action literal, properties, and required list.
-function getActionVariants(schema: Record<string, unknown>): ActionVariant[] | null {
-  const branches = (schema.oneOf || schema.anyOf) as Array<Record<string, unknown>> | undefined;
-  if (!Array.isArray(branches)) return null;
-
-  const variants: ActionVariant[] = [];
-  for (const branch of branches) {
-    const properties = (branch.properties as Record<string, Record<string, unknown>>) || {};
-    const actionProp = properties.action;
-    const action =
-      (actionProp?.const as string | undefined) ??
-      (Array.isArray(actionProp?.enum) ? (actionProp!.enum as string[])[0] : undefined);
-    if (action === undefined) continue;
-    variants.push({ action, properties, required: (branch.required as string[]) || [] });
-  }
-  return variants.length > 0 ? variants : null;
-}
-
 function generateUnionActionDocs(variants: ActionVariant[]): string {
   let md = '### Actions\n\n';
 
   for (const variant of variants) {
     md += `#### \`${variant.action}\`\n\n`;
+
+    // The richest per-action copy lives on the action literal's `.describe()`;
+    // surface it under the heading instead of leaving the section bare (#287).
+    const actionDesc = String(variant.properties.action?.description ?? '').trim();
+    if (actionDesc) md += `${actionDesc}\n\n`;
+
     const paramNames = Object.keys(variant.properties).filter((n) => n !== 'action');
 
     if (paramNames.length === 0) {
@@ -394,15 +385,11 @@ function generateUnionActionDocs(variants: ActionVariant[]): string {
   return md;
 }
 
-function generateUnionExamples(variants: ActionVariant[]): string {
+function generateUnionExamples(variants: ActionVariant[], toolSchema: z.ZodType): string {
   let md = '### Examples\n\n';
 
   for (const variant of variants.slice(0, 3)) {
-    const example: Record<string, unknown> = { action: variant.action };
-    for (const name of variant.required) {
-      if (name === 'action') continue;
-      example[name] = getExampleValue(name, variant.properties[name]);
-    }
+    const example = buildVariantExample(variant, toolSchema);
     md += `\`\`\`json\n// ${variant.action}\n${JSON.stringify(example, null, 2)}\n\`\`\`\n\n`;
   }
 
@@ -414,17 +401,19 @@ function generateUnionExamples(variants: ActionVariant[]): string {
 }
 
 function generateToolMarkdown(tool: AnyToolDefinition): string {
-  const schema = toInputSchema(tool.schema);
   let md = `## ${tool.name}\n\n`;
   md += `${tool.description}\n\n`;
 
-  const variants = getActionVariants(schema);
+  // Detect action unions from the raw (un-flattened) schema; toInputSchema would
+  // have collapsed the oneOf, hiding per-action required fields + descriptions.
+  const variants = getActionVariants(rawJsonSchema(tool));
   if (variants) {
     md += generateUnionActionDocs(variants);
-    md += generateUnionExamples(variants);
+    md += generateUnionExamples(variants, tool.schema);
     return md;
   }
 
+  const schema = toInputSchema(tool.schema);
   md += `### Parameters\n\n`;
   md += generateParamsTable(schema);
   md += '\n';
@@ -571,4 +560,8 @@ function main(): void {
   console.log(`\nGenerated documentation for ${categories.reduce((sum, c) => sum + c.tools.length, 0)} tools and ${allResources.length} resources.`);
 }
 
-main();
+// Only write files when run as a script (tsx scripts/generate-docs.ts); stay
+// inert when imported by tests so the doc-generation helpers can be unit-tested.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/server/src/__tests__/core/doc-examples.test.ts
+++ b/server/src/__tests__/core/doc-examples.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getActionVariants,
+  buildVariantExample,
+  rawJsonSchema,
+  exampleForProp,
+} from '../../core/doc-examples.js';
+import {
+  sceneTools,
+  nodeTools,
+  editorTools,
+  projectTools,
+  animationTools,
+  tilemapTools,
+  resourceTools,
+  scene3dTools,
+  docsTools,
+  inputTools,
+  profilerTools,
+  runtimeStateTools,
+  gameTimeTools,
+  execTools,
+} from '../../tools/index.js';
+import type { AnyToolDefinition } from '../../core/types.js';
+
+const ALL_TOOLS: AnyToolDefinition[] = [
+  ...sceneTools,
+  ...nodeTools,
+  ...editorTools,
+  ...projectTools,
+  ...animationTools,
+  ...tilemapTools,
+  ...resourceTools,
+  ...scene3dTools,
+  ...docsTools,
+  ...inputTools,
+  ...profilerTools,
+  ...runtimeStateTools,
+  ...gameTimeTools,
+  ...execTools,
+];
+
+// Tool + each of its action variants, as the doc generator sees them.
+const ACTION_CASES = ALL_TOOLS.flatMap((tool) => {
+  const variants = getActionVariants(rawJsonSchema(tool));
+  return variants ? variants.map((variant) => ({ tool, variant })) : [];
+});
+
+function variantOf(toolName: string, action: string) {
+  const tool = ALL_TOOLS.find((t) => t.name === toolName)!;
+  const variant = getActionVariants(rawJsonSchema(tool))!.find((v) => v.action === action)!;
+  return { tool, variant };
+}
+
+describe('generated doc examples (#287)', () => {
+  it('discovers action variants across the tool surface', () => {
+    // Guards the whole premise: if union detection regresses, every per-action
+    // doc would silently fall back to the flat path again.
+    const toolsWithActions = new Set(ACTION_CASES.map((c) => c.tool.name));
+    expect(toolsWithActions.size).toBeGreaterThanOrEqual(14);
+    expect(ACTION_CASES.length).toBeGreaterThan(50);
+  });
+
+  // Defect 1: every generated example must satisfy the REAL Zod schema —
+  // including discriminator-only actions, schema-required fields, and refines.
+  it.each(ACTION_CASES.map((c) => [`${c.tool.name}:${c.variant.action}`, c] as const))(
+    'emits a schema-valid example for %s',
+    (_label, { tool, variant }) => {
+      const example = buildVariantExample(variant, tool.schema);
+      const result = tool.schema.safeParse(example);
+      expect(result.success, JSON.stringify(example)).toBe(true);
+    }
+  );
+
+  // Defect 2: each action literal's .describe() must be available to render
+  // under the action heading (no more empty Actions sections).
+  it.each(ACTION_CASES.map((c) => [`${c.tool.name}:${c.variant.action}`, c] as const))(
+    'carries an action description for %s',
+    (_label, { variant }) => {
+      const desc = String(variant.properties.action?.description ?? '').trim();
+      expect(desc.length).toBeGreaterThan(0);
+    }
+  );
+
+  it('includes schema-required fields beyond the discriminator (exec run -> source, remove -> name)', () => {
+    const run = variantOf('godot_exec', 'run');
+    expect(buildVariantExample(run.variant, run.tool.schema)).toMatchObject({
+      action: 'run',
+      source: expect.any(String),
+    });
+
+    const remove = variantOf('godot_exec', 'remove');
+    expect(buildVariantExample(remove.variant, remove.tool.schema)).toMatchObject({
+      action: 'remove',
+      name: expect.any(String),
+    });
+  });
+
+  it('satisfies a refine that JSON Schema cannot express (watch_start needs specs or signals)', () => {
+    const { tool, variant } = variantOf('godot_runtime_state', 'watch_start');
+    const example = buildVariantExample(variant, tool.schema);
+    // Required-only would be {action} and fail the refine; augmentation must add one.
+    const hasSpecs = Array.isArray((example as Record<string, unknown>).specs) && (example.specs as unknown[]).length > 0;
+    const hasSignals = Array.isArray((example as Record<string, unknown>).signals) && (example.signals as unknown[]).length > 0;
+    expect(hasSpecs || hasSignals).toBe(true);
+  });
+
+  it('does not over-specify actions that need only the discriminator (watch_collect)', () => {
+    const { tool, variant } = variantOf('godot_runtime_state', 'watch_collect');
+    const example = buildVariantExample(variant, tool.schema);
+    expect(example).toEqual({ action: 'watch_collect' });
+  });
+
+  describe('exampleForProp', () => {
+    it('builds a non-empty array from its items schema', () => {
+      const val = exampleForProp('paths', { type: 'array', items: { type: 'string' } });
+      expect(val).toEqual(['example']);
+    });
+
+    it('builds a union-typed array entry from the first branch (input sequence entries)', () => {
+      const { tool } = variantOf('godot_input', 'sequence');
+      const example = buildVariantExample(
+        getActionVariants(rawJsonSchema(tool))!.find((v) => v.action === 'sequence')!,
+        tool.schema
+      );
+      const inputs = (example as Record<string, unknown>).inputs as unknown[];
+      expect(Array.isArray(inputs)).toBe(true);
+      expect(inputs.length).toBeGreaterThan(0);
+      expect(inputs[0]).not.toBeNull();
+    });
+
+    it('respects a numeric lower bound', () => {
+      expect(exampleForProp('hz', { type: 'integer', minimum: 1 })).toBe(1);
+    });
+
+    it('only populates required object fields', () => {
+      const val = exampleForProp('spec', {
+        type: 'object',
+        properties: { path: { type: 'string' }, fields: { type: 'array', items: { type: 'string' } } },
+        required: ['path'],
+      }) as Record<string, unknown>;
+      expect(val).toEqual({ path: '/root/Main/Player' });
+    });
+  });
+});

--- a/server/src/core/doc-examples.ts
+++ b/server/src/core/doc-examples.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import type { AnyToolDefinition } from './types.js';
+
+// Deriving per-action documentation (variant tables + copy-pasteable examples)
+// from a tool's schema. Kept separate from the doc-generation SCRIPT so it can
+// be unit-tested without the script's file I/O. The script (scripts/generate-docs.ts)
+// imports these to render markdown.
+
+export interface ActionVariant {
+  action: string;
+  properties: Record<string, Record<string, unknown>>;
+  required: string[];
+}
+
+// The Anthropic-shaped input schema flattens discriminated unions into a single
+// object (see core/schema.ts), which discards per-action structure. For docs we
+// want that structure back, so read the raw (un-flattened) JSON Schema, where a
+// discriminatedUnion serializes to a top-level `oneOf` of per-action branches —
+// each carrying its own `required` list and the action literal's `.describe()`.
+export function rawJsonSchema(tool: AnyToolDefinition): Record<string, unknown> {
+  const { $schema, ...rest } = z.toJSONSchema(tool.schema, { target: 'draft-07' }) as Record<string, unknown>;
+  return rest;
+}
+
+// Discriminated-union schemas serialize to oneOf (one object variant per
+// action). Pull each variant's action literal, properties, and required list.
+export function getActionVariants(schema: Record<string, unknown>): ActionVariant[] | null {
+  const branches = (schema.oneOf || schema.anyOf) as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(branches)) return null;
+
+  const variants: ActionVariant[] = [];
+  for (const branch of branches) {
+    const properties = (branch.properties as Record<string, Record<string, unknown>>) || {};
+    const actionProp = properties.action;
+    const action =
+      (actionProp?.const as string | undefined) ??
+      (Array.isArray(actionProp?.enum) ? (actionProp!.enum as string[])[0] : undefined);
+    if (action === undefined) continue;
+    variants.push({ action, properties, required: (branch.required as string[]) || [] });
+  }
+  return variants.length > 0 ? variants : null;
+}
+
+// Representative values for well-known parameter names, so generated examples
+// read like real calls rather than `"example"` placeholders.
+const NAMED_EXAMPLES: Record<string, unknown> = {
+  node_path: '/root/Main/Player',
+  parent_path: '/root/Main',
+  new_parent_path: '/root/UI',
+  scene_path: 'res://scenes/enemy.tscn',
+  script_path: 'res://scripts/player.gd',
+  resource_path: 'res://resources/spriteframes.tres',
+  animation_name: 'idle',
+  node_name: 'NewNode',
+  node_type: 'Sprite2D',
+  name_pattern: '*Enemy*',
+  type: 'CharacterBody2D',
+  root_path: '/root/Main',
+  path: '/root/Main/Player',
+  signal: 'body_entered',
+};
+
+// Build a representative, schema-VALID value for one JSON-Schema property.
+// Recurses through arrays/objects/unions and produces NON-EMPTY arrays +
+// populated required object fields, so min-length / nested-required constraints hold.
+export function exampleForProp(name: string, prop: Record<string, unknown>): unknown {
+  if (prop.const !== undefined) return prop.const;
+  if (Array.isArray(prop.enum)) return (prop.enum as unknown[])[0];
+  if (name in NAMED_EXAMPLES) return NAMED_EXAMPLES[name];
+
+  // A prop that is itself a union (z.union / z.discriminatedUnion serialize to
+  // anyOf / oneOf — e.g. the input `sequence` entry shapes): build the first branch.
+  const branches = (prop.oneOf ?? prop.anyOf ?? prop.allOf) as Record<string, unknown>[] | undefined;
+  if (Array.isArray(branches) && branches.length > 0) {
+    return exampleForProp(name, branches[0]);
+  }
+
+  switch (prop.type) {
+    case 'string':
+      return 'example';
+    case 'integer':
+    case 'number':
+      // Respect a lower bound so .min(n) constraints aren't violated.
+      return typeof prop.minimum === 'number' ? prop.minimum : 0;
+    case 'boolean':
+      return false;
+    case 'array': {
+      const items = prop.items as Record<string, unknown> | undefined;
+      // One representative element: keeps arrays non-empty so a length-based
+      // refine (e.g. watch_start's specs/signals) is satisfied.
+      return items ? [exampleForProp(name, items)] : [];
+    }
+    case 'object': {
+      const props = (prop.properties as Record<string, Record<string, unknown>>) || {};
+      const req = (prop.required as string[]) || [];
+      const obj: Record<string, unknown> = {};
+      for (const key of Object.keys(props)) {
+        if (req.includes(key)) obj[key] = exampleForProp(key, props[key]);
+      }
+      return obj;
+    }
+    default:
+      return null;
+  }
+}
+
+// A copy-pasteable example for one action: the discriminator plus every
+// schema-required field. JSON Schema can't express cross-field refinements
+// (e.g. watch_start requires specs OR signals), so if the required-only example
+// fails the REAL Zod schema, add optional fields one at a time until it
+// validates — keeping the minimal field that unblocks it (#287).
+export function buildVariantExample(
+  variant: ActionVariant,
+  toolSchema: z.ZodType
+): Record<string, unknown> {
+  const example: Record<string, unknown> = { action: variant.action };
+  for (const name of variant.required) {
+    if (name === 'action') continue;
+    example[name] = exampleForProp(name, variant.properties[name]);
+  }
+
+  if (!toolSchema.safeParse(example).success) {
+    for (const [name, prop] of Object.entries(variant.properties)) {
+      if (name === 'action' || name in example) continue;
+      example[name] = exampleForProp(name, prop);
+      if (toolSchema.safeParse(example).success) break;
+      delete example[name]; // this field didn't unblock it — don't over-specify
+    }
+  }
+
+  return example;
+}


### PR DESCRIPTION
Closes #287.

## The defects

The doc generator (`server/scripts/generate-docs.ts`) ran every tool schema through `toInputSchema`, which **flattens** a `discriminatedUnion` into a single object — collapsing each action's `.literal().describe()` into a bare `enum` and merging all per-action fields as optional. That flattening happened *before* union detection, so the union-aware renderers (`generateUnionActionDocs`/`generateUnionExamples`) were **dead code**, and all 14 action tools fell through to the flat path:

1. **Invalid examples** — per-action example blocks rendered the bare `{"action": "<name>"}`, which is schema-invalid whenever an action needs more: `exec run` (→ `source`), `exec remove` (→ `name`), and `runtime_state watch_start` (a zod `refine` requires `specs` | `signals`).
2. **Empty Actions sections** — every action rendered as a bare heading with no description, even though each action literal carries rich `.describe()` copy.

## The fix

- Detect action unions from the **raw (un-flattened)** JSON Schema, so the union path is actually reached (per-action `required` lists + descriptions are visible).
- Render each action literal's `.describe()` under its heading.
- Build examples from the real per-variant `required` list. For cross-field refinements JSON Schema cannot express (`watch_start`), validate the candidate against the **actual zod schema** via `safeParse` and add the minimal optional field that makes it valid (also added union-typed array support for the `input sequence` entry shapes).
- Extracted the pure schema→example logic into `src/core/doc-examples.ts` so it is type-checked and unit-tested (the build compiles `src/__tests__/`, so the test couldn't live next to the script).
- Also documents `godot_game_time`, which was missing from the generator's category list entirely.

## Verification

- `tsc` clean; full suite **558/558** (28 files).
- New `doc-examples.test.ts` (188 assertions): every action example across all 15 tools is asserted schema-valid against its real zod schema, and every action carries a non-empty description — plus the motivating cases (`exec run`→`source`, `exec remove`→`name`, `watch_start` refine, `watch_collect` stays minimal).
- Docs regenerated; only content-changed files committed.