### PR TITLE
test: pin the watch lifecycle wire contract across the GDScript/TS boundary

### DIFF
--- a/godot/addons/godot_mcp/test/watch_contract.json
+++ b/godot/addons/godot_mcp/test/watch_contract.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Single source of truth for the godot_runtime_state watch wire contract (#286). The GDScript headless suite (watch_contract_headless_test.gd) and the server vitest suite (server/src/__tests__/tools/watch-contract.test.ts) both assert their literals against THIS file, so a rename of any key on either side breaks its own suite instead of silently drifting. Each shape lists its key names; 'optional' keys may be absent. 'watch_start_request_positional' is the editor->game EngineDebugger argument ORDER (GDScript-internal). KNOWN BOUNDARY: the editor command layer's request-key consume (runtime_state_commands.gd) and the positional decode are GDScript<->GDScript and not exercised at runtime by either suite; the high-value cross-language surface (response/event/sample keys, GDScript producer <-> TS consumer) is pinned from both directions.",
+  "watch_start_request": { "required": ["specs", "hz", "duration_ms", "signals"], "optional": [] },
+  "watch_start_request_positional": ["specs", "hz", "duration_ms", "signals"],
+  "watch_start_response": { "required": ["started", "resolved_fields", "connected_signals", "unresolved_signals"], "optional": [] },
+  "unresolved_signal": { "required": ["path", "signal", "reason"], "optional": [] },
+  "watch_collect_response": { "required": ["window_ms", "sample_count", "fields", "events", "events_truncated", "events_dropped", "events_dropped_by_signal", "fields_truncated"], "optional": [] },
+  "field_sample": { "required": ["t_ms", "value"], "optional": [] },
+  "event": { "required": ["t_ms", "source", "signal"], "optional": ["args"] }
+}

--- a/godot/addons/godot_mcp/test/watch_contract_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_contract_headless_test.gd
@@ -1,0 +1,199 @@
+extends SceneTree
+
+## Cross-language wire-contract check for the watch lifecycle (#286).
+##
+## The watch contract (request/response/event/sample key names) lives as literals
+## on BOTH sides of the bridge: the GDScript sampler PRODUCES the response keys,
+## the TypeScript server CONSUMES them. Before this test, each side asserted only
+## its own literals, so a rename on either side passed both suites green. This
+## suite pins the PRODUCER side against a shared artifact
+## (res://addons/godot_mcp/test/watch_contract.json); the server vitest
+## (watch-contract.test.ts) pins the CONSUMER side against the SAME file. A rename
+## now breaks its own suite.
+##
+## KNOWN BOUNDARY: the editor command layer's request-key consume
+## (runtime_state_commands.gd) and the editor->game positional decode are
+## GDScript<->GDScript and not on this suite's runtime path — the request-key
+## NAMES are pinned on the TS send side instead. This suite pins the high-value
+## cross-language surface: the watch_collect response keys, the per-event/sample
+## dict keys, and the watch_start response keys the sampler owns.
+##
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/watch_contract_headless_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+var _count := 0
+var _failures := 0
+
+const CONTRACT_PATH := "res://addons/godot_mcp/test/watch_contract.json"
+
+
+class _Emitter extends Node:
+	signal fired
+	signal hit(amount)
+	var score := 7
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n===================== WATCH CONTRACT TEST =====================\n")
+
+	var contract := _load_contract()
+	if contract.is_empty():
+		_check("contract artifact loads and parses to a Dictionary", false, true)
+		_finish()
+		return
+	_check("contract artifact loads and parses to a Dictionary", true, true)
+
+	# Within-artifact consistency: the editor->game positional order must list the
+	# same names as the named request (the editor re-encodes one as the other).
+	_check("positional arg order matches the named request keys",
+		contract["watch_start_request_positional"],
+		(contract["watch_start_request"] as Dictionary)["required"])
+
+	var sampler := MCPRuntimeStateSampler.new()
+	root.add_child(sampler)
+	var emitter := _Emitter.new()
+	emitter.name = "FakeAutoload"
+	root.add_child(emitter)
+	await process_frame
+
+	# One field + two resolvable signals (0-arg `fired`, 1-arg `hit`) + one
+	# unresolvable spec, so every contract shape gets exercised in one window.
+	var start_res: Dictionary = sampler.start(
+		[{"path": "/root/FakeAutoload", "fields": ["score"]}],
+		60, 5000,
+		[
+			{"path": "/root/FakeAutoload", "signal": "fired"},
+			{"path": "/root/FakeAutoload", "signal": "hit"},
+			{"path": "/root/NoSuchNode", "signal": "fired"},
+		])
+
+	# watch_start response: the sampler owns every key EXCEPT `started`, which the
+	# bridge adds when it wraps this dict (mcp_game_bridge.gd). So assert the
+	# sampler returns the contract keys minus that one, and that `started` is
+	# genuinely a contract key.
+	var wsr: Array = (contract["watch_start_response"] as Dictionary)["required"]
+	_check("'started' is a watch_start_response contract key (added by the bridge)", wsr.has("started"), true)
+	var sampler_start_keys: Array = wsr.duplicate()
+	sampler_start_keys.erase("started")
+	_check_exact_keys("watch_start: sampler returns the response keys minus 'started'",
+		start_res.keys(), sampler_start_keys)
+
+	# unresolved_signal entry shape (the one bogus spec).
+	var unresolved: Array = start_res.get("unresolved_signals", [])
+	_check("watch_start: exactly one unresolved signal", unresolved.size(), 1)
+	if unresolved.size() == 1:
+		_check_exact_keys("unresolved_signal: entry keys",
+			(unresolved[0] as Dictionary).keys(),
+			(contract["unresolved_signal"] as Dictionary)["required"])
+
+	# Records one arg-less event (fired) and one event with args (hit) — exercises
+	# both the required-only and the optional-`args` event shapes.
+	emitter.fired.emit()
+	emitter.hit.emit(3)
+
+	# Drive a few field samples deterministically (interval forced to 1, as in the
+	# timeline test) so `fields` is non-empty and field_sample keys can be checked.
+	sampler._sample_interval = 1
+	for i in 3:
+		sampler._process(0.0)
+
+	var result: Dictionary = sampler.collect()
+
+	# watch_collect response: EXACT key set (catches a renamed/added/dropped key on
+	# the producer side — the headline of #286).
+	_check_exact_keys("watch_collect: response key set",
+		result.keys(),
+		(contract["watch_collect_response"] as Dictionary)["required"])
+
+	# field_sample shape: every sample of every field.
+	var field_contract: Array = (contract["field_sample"] as Dictionary)["required"]
+	var fields: Dictionary = result.get("fields", {})
+	_check("watch_collect: the score field was sampled", fields.has("/root/FakeAutoload:score"), true)
+	var sample_violations := 0
+	for full_key in fields:
+		for sample in (fields[full_key] as Array):
+			if not _keys_match_exact((sample as Dictionary).keys(), field_contract):
+				sample_violations += 1
+	_check("field_sample: every sample dict matches the contract keys", sample_violations, 0)
+
+	# event shape: required keys present, only `args` allowed beyond them.
+	var ev_required: Array = (contract["event"] as Dictionary)["required"]
+	var ev_optional: Array = (contract["event"] as Dictionary)["optional"]
+	var events: Array = result.get("events", [])
+	_check("watch_collect: both signal emissions recorded", events.size(), 2)
+	for ev in events:
+		_check_event_keys("event: keys for %s" % str((ev as Dictionary).get("signal")),
+			(ev as Dictionary).keys(), ev_required, ev_optional)
+	# And confirm the optional `args` key is actually exercised (the hit event).
+	var with_args := events.filter(func(e): return (e as Dictionary).has("args"))
+	_check("event: the optional 'args' key is exercised (hit emission)", with_args.size(), 1)
+
+	sampler.stop()
+	_finish()
+
+
+func _load_contract() -> Dictionary:
+	var f := FileAccess.open(CONTRACT_PATH, FileAccess.READ)
+	if f == null:
+		printerr("could not open contract artifact: %s" % CONTRACT_PATH)
+		return {}
+	var txt := f.get_as_text()
+	f.close()
+	var parsed = JSON.parse_string(txt)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		printerr("contract artifact did not parse to a Dictionary")
+		return {}
+	return parsed
+
+
+func _keys_match_exact(actual: Array, required: Array) -> bool:
+	if actual.size() != required.size():
+		return false
+	for k in required:
+		if not actual.has(k):
+			return false
+	return true
+
+
+func _check_exact_keys(label: String, actual: Array, required: Array) -> void:
+	_check_event_keys(label, actual, required, [])
+
+
+func _check_event_keys(label: String, actual: Array, required: Array, optional: Array) -> void:
+	var missing := []
+	for k in required:
+		if not actual.has(k):
+			missing.append(k)
+	var allowed: Array = required + optional
+	var extra := []
+	for k in actual:
+		if not allowed.has(k):
+			extra.append(k)
+	_check(label + " — required keys present", missing, [])
+	_check(label + " — no keys outside the contract", extra, [])
+
+
+func _finish() -> void:
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS - %d checks" % _count)
+	else:
+		printerr("FAILED - %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/watch_contract_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/watch_contract_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://c8cqlbhd7c87

--- a/server/src/__tests__/tools/watch-contract.test.ts
+++ b/server/src/__tests__/tools/watch-contract.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  createMockGodot,
+  createToolContext,
+  structuredOf,
+  MockGodotConnection,
+} from '../helpers/mock-godot.js';
+import { runtimeState } from '../../tools/runtime-state.js';
+
+// Cross-language wire-contract check for the watch lifecycle (#286).
+//
+// This pins the CONSUMER side: the TypeScript server's watch encode/decode must
+// use exactly the key names in the shared artifact. The GDScript headless suite
+// (godot/addons/godot_mcp/test/watch_contract_headless_test.gd) pins the PRODUCER
+// side against the SAME file. A rename on either side now breaks its own suite
+// instead of silently drifting (the TS `?? default` back-compat would otherwise
+// swallow a vanished response key).
+//
+// The artifact is read at RUNTIME (not a static JSON import) so tsc's rootDir
+// (src/) does not choke on a file outside it — the #287 lesson.
+//
+// KNOWN BOUNDARY: the request-key NAMES are pinned here on the SEND side; the
+// editor command layer's consume of those names (runtime_state_commands.gd) and
+// the editor->game positional decode are GDScript<->GDScript, off both suites'
+// runtime paths. The high-value cross-language surface (response/event/sample
+// keys) is pinned from both directions.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CONTRACT_PATH = resolve(HERE, '../../../../godot/addons/godot_mcp/test/watch_contract.json');
+
+interface Shape {
+  required: string[];
+  optional: string[];
+}
+interface Contract {
+  watch_start_request: Shape;
+  watch_start_request_positional: string[];
+  watch_start_response: Shape;
+  unresolved_signal: Shape;
+  watch_collect_response: Shape;
+  field_sample: Shape;
+  event: Shape;
+}
+
+function loadContract(): Contract {
+  try {
+    return JSON.parse(readFileSync(CONTRACT_PATH, 'utf8')) as Contract;
+  } catch (e) {
+    throw new Error(
+      `Could not read the watch contract artifact at ${CONTRACT_PATH}. ` +
+        `It is the single source of truth shared with the GDScript headless suite; ` +
+        `if it moved, update CONTRACT_PATH here and the res:// path in the headless test. (${String(e)})`
+    );
+  }
+}
+
+const contract = loadContract();
+
+// Build an object whose keys are EXACTLY the contract shape's required keys,
+// pulling each value from `values`. Throws if the test fails to supply a value
+// for a contract key — that forces the test fixtures to track the artifact, so a
+// rename in the artifact surfaces here (not as a silently stale literal).
+function objFromContract(shape: keyof Contract, values: Record<string, unknown>): Record<string, unknown> {
+  const def = contract[shape] as Shape;
+  const out: Record<string, unknown> = {};
+  for (const key of def.required) {
+    if (!(key in values)) {
+      throw new Error(
+        `test fixture for "${String(shape)}" is missing a value for contract key "${key}" — ` +
+          `update the fixture to match watch_contract.json`
+      );
+    }
+    out[key] = values[key];
+  }
+  // Optional keys (e.g. event.args) ride along only when the test supplies them.
+  for (const key of def.optional ?? []) {
+    if (key in values) out[key] = values[key];
+  }
+  return out;
+}
+
+describe('watch wire contract (#286)', () => {
+  let mock: MockGodotConnection;
+
+  beforeEach(() => {
+    mock = createMockGodot();
+  });
+
+  it('the contract artifact is well-formed', () => {
+    const shapes: (keyof Contract)[] = [
+      'watch_start_request',
+      'watch_start_response',
+      'unresolved_signal',
+      'watch_collect_response',
+      'field_sample',
+      'event',
+    ];
+    for (const shape of shapes) {
+      const s = contract[shape] as Shape;
+      expect(Array.isArray(s.required), shape).toBe(true);
+      expect(s.required.length, shape).toBeGreaterThan(0);
+      expect(Array.isArray(s.optional), shape).toBe(true);
+    }
+    // The editor->game positional order must name the same keys as the request.
+    expect([...contract.watch_start_request_positional].sort()).toEqual(
+      [...contract.watch_start_request.required].sort()
+    );
+  });
+
+  // ── Request: what the server SENDS ─────────────────────────────────────────
+
+  it('watch_start sends exactly the watch_start_request keys', async () => {
+    mock.mockResponse(
+      objFromContract('watch_start_response', {
+        started: true,
+        resolved_fields: 0,
+        connected_signals: 0,
+        unresolved_signals: [],
+      })
+    );
+    const ctx = createToolContext(mock);
+
+    await runtimeState.execute(
+      { action: 'watch_start', specs: [], hz: 20, duration_ms: 1000, signals: [] },
+      ctx
+    );
+
+    const call = mock.calls.find((c) => c.command === 'watch_start');
+    expect(call, 'watch_start command was sent').toBeDefined();
+    expect(Object.keys(call!.params).sort()).toEqual([...contract.watch_start_request.required].sort());
+  });
+
+  // ── watch_start response: what the server READS ────────────────────────────
+
+  it('watch_start reads the watch_start_response / unresolved_signal keys', async () => {
+    const startResp = objFromContract('watch_start_response', {
+      started: true,
+      resolved_fields: 2,
+      connected_signals: 1,
+      unresolved_signals: [
+        objFromContract('unresolved_signal', {
+          path: '/root/Missing',
+          signal: 'fired',
+          reason: 'node_not_found',
+        }),
+      ],
+    });
+    mock.mockResponse(startResp);
+    const ctx = createToolContext(mock);
+
+    const data = structuredOf(
+      await runtimeState.execute(
+        { action: 'watch_start', signals: [{ path: '/root/Missing', signal: 'fired' }] },
+        ctx
+      )
+    );
+
+    // Each assertion proves the TS decode read a specific contract key.
+    expect(data.resolved_fields).toBe(2); // resolved_fields
+    expect(data.connected_signals).toBe(1); // connected_signals
+    expect(data.unresolved_signals).toHaveLength(1); // unresolved_signals
+    expect(data.unresolved_signals[0]).toMatchObject({
+      path: '/root/Missing', // unresolved_signal.path
+      signal: 'fired', // unresolved_signal.signal
+      reason: 'node_not_found', // unresolved_signal.reason
+    });
+  });
+
+  // ── watch_collect response: what the server READS ──────────────────────────
+
+  it('watch_collect decodes exactly the watch_collect_response / event / field_sample keys', async () => {
+    const raw = objFromContract('watch_collect_response', {
+      window_ms: 1000,
+      sample_count: 2,
+      fields: {
+        '/root/Player:hp': [
+          objFromContract('field_sample', { t_ms: 0, value: 100 }),
+          objFromContract('field_sample', { t_ms: 500, value: 80 }),
+        ],
+      },
+      events: [objFromContract('event', { t_ms: 120, source: '/root/G', signal: 'hit', args: '[2]' })],
+      events_truncated: true,
+      events_dropped: 7,
+      events_dropped_by_signal: { '/root/G:hit': 7 },
+      fields_truncated: { '/root/Player:hp': true },
+    });
+    mock.mockResponse(raw);
+    const ctx = createToolContext(mock);
+
+    const data = structuredOf(await runtimeState.execute({ action: 'watch_collect' }, ctx));
+
+    // Top-level collect keys (each assertion = the TS decode read that key):
+    expect(data.window_ms).toBe(1000); // window_ms
+    expect(data.sample_count).toBe(2); // sample_count
+    expect(data.events_dropped).toBe(7); // events_dropped
+    expect(data.events_dropped_by_signal).toEqual({ '/root/G:hit': 7 }); // events_dropped_by_signal
+    expect(data.timeline_truncated).toBe(true); // events_truncated -> timeline_truncated
+
+    // events + event-dict keys: the signal landed in the timeline with its args.
+    const signalEntry = data.timeline.find((e: { kind: string }) => e.kind === 'signal');
+    expect(signalEntry).toMatchObject({
+      t_ms: 120, // event.t_ms
+      source: '/root/G', // event.source
+      name: 'hit', // event.signal (renamed to `name` in the timeline entry)
+      args: '[2]', // event.args (optional)
+    });
+
+    // fields + field_sample keys: the field summary reflects the sampled values,
+    // and fields_truncated surfaced as samples_truncated.
+    const hp = data.fields['/root/Player:hp'];
+    expect(hp).toBeDefined(); // fields
+    expect(hp.start).toBe(100); // field_sample.t_ms/value drove the summary
+    expect(hp.end).toBe(80);
+    expect(hp.samples_truncated).toBe(true); // fields_truncated
+  });
+});


### PR DESCRIPTION
## What

The `godot_runtime_state` watch wire contract (request / response / event / sample key names spanning the GDScript sampler and the TypeScript server) was pinned only by convention — each test suite asserted its own literals, so a rename on either side passed both suites green, and the server's `?? default` back-compat silently swallowed a vanished response key. This adds a single source-of-truth artifact both suites assert against, so drift breaks its own suite.

## How

- **`godot/addons/godot_mcp/test/watch_contract.json`** — canonical key sets for every shape (request, watch_start/watch_collect responses, event, field_sample, unresolved_signal). Lives under `test/`, which `copy-addon.ts` excludes from the shipped addon.
- **`watch_contract_headless_test.gd`** — pins the PRODUCER side: asserts the real sampler's `collect()` / `start()` output key sets match the artifact exactly (18 checks).
- **`watch-contract.test.ts`** — pins the CONSUMER side: drives `runtimeState.execute` with a mock bridge, building fixtures FROM the artifact keys (a guard throws if a fixture omits a contract key) and asserting the TS encode/decode reads them. Reads the artifact at runtime (not a static import) to stay clear of tsc's `rootDir`.

A rename on either side now breaks its own suite.

## Verification

- `npm run build` + `npm test`: 562 passed (4 new), tsc clean.
- Headless suite via a junctioned project: 18/18.
- **Drift smoke test, both directions:** renaming a response key in the sampler only → the GDScript suite fails; renaming it in the artifact only → the vitest fails. Reverted.

## Scope / notes

- Cross-language surface that matters (response/event/sample keys, GDScript producer ↔ TS consumer) is pinned from both directions. The editor command layer's request-key consume and the editor→game positional decode are GDScript-internal and off both suites' runtime paths (documented in the test headers); request-key names are pinned on the TS send side.
- Test-only change — no tool schema or runtime behavior change.
- Leaves documented as-is the exotic re-entrancy limitation noted in #286 (calling `watch_start` from inside a watched signal's handler mid-emission can leak one stale event): low-frequency and orthogonal to the contract.

Closes #286