### PR TITLE
test: raise live docs test timeout above the tool's per-fetch budget

### DIFF
--- a/server/src/__tests__/tools/docs.test.ts
+++ b/server/src/__tests__/tools/docs.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createMockGodot, createToolContext } from '../helpers/mock-godot.js';
 import { docs } from '../../tools/docs.js';
+
+// These suites hit the LIVE Godot docs site (docs.ts does a real fetch). The tool
+// aborts each request at FETCH_TIMEOUT_MS (15s); the heaviest test makes two
+// sequential fetches, so on a slow CI network the total can exceed vitest's 5s
+// default — the observed flake (a spurious red on otherwise-unrelated PRs). Raise
+// the per-file timeout to comfortably cover ~2 live fetches plus margin. A truly
+// unreachable docs site will still fail (by design — that is a real signal), but
+// merely-slow responses no longer trip the clock.
+vi.setConfig({ testTimeout: 40_000 });
 
 describe('godot_docs tool', () => {
   describe('schema validation', () => {


### PR DESCRIPTION
## Problem

The `godot_docs` live-integration suites in `docs.test.ts` fetch the **real** docs site (`docs.ts` does a real `fetch`). The tool aborts each request at `FETCH_TIMEOUT_MS` (15s), and the heaviest test (`fetches class reference with section filtering`) issues **two sequential fetches**. On a slow CI network the total can exceed vitest's **5s default** per-test timeout → a spurious `Test timed out in 5000ms` that reds otherwise-unrelated PRs (observed on #303, cleared only by a re-run).

## Fix

Raise the per-file test timeout to **40s** via `vi.setConfig({ testTimeout: 40_000 })` — comfortably above the ~2×15s worst case the tool itself bounds. Merely-slow responses no longer trip the clock; a genuinely unreachable docs site still fails, which is the real signal these live tests exist to provide.

- One-file change, no production code touched.
- The tool's own 15s/fetch abort still bounds how long any test can run, so the higher ceiling can't mask a true hang.

## Verification

`npm run build` + `npx vitest run src/__tests__/tools/docs.test.ts` → 9/9 pass, tsc clean.

## Note

This keeps the docs tests **live** (per maintainer preference) rather than mocking them. The residual: a real docs.godotengine.org outage will still fail the build — acceptable, since that is a genuine signal, not flake.