### PR TITLE
fix: make npm README links absolute and overhaul the GitHub-facing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,10 @@ If you're unsure, open an issue first. We can figure out the right home for the 
 ## Updating Documentation
 
 This repo has two READMEs:
-- `README.md` (repo root) - What GitHub visitors see
-- `server/README.md` - What npm package users see
+- `README.md` (repo root) - what GitHub visitors see. This is the one you edit.
+- `server/README.md` - what npm package users see. Generated from the root README by `npm run generate-docs`, which rewrites relative links to absolute GitHub URLs so they work on npmjs.com. Never edit it by hand.
 
-If your change affects how users install or configure godot-mcp, update both. Keep them in sync.
+If your change touches the root README, run `npm run generate-docs` to refresh the npm copy.
 
 ## Releases
 
@@ -94,6 +94,8 @@ The MCP server and Godot addon share version numbers and are released together.
 - `server/src/connection/` - WebSocket client to Godot
 - `godot/addons/godot_mcp/commands/` - GDScript command handlers
 - `godot/addons/godot_mcp/core/` - Addon utilities (logger, debugger plugin)
+
+For the full picture — connection lifecycle, the game bridge, release mechanics — see the [Architecture Guide](docs/architecture.md).
 
 ## Questions?
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-How to connect godot-mcp to your MCP client.
+How to connect godot-mcp to your MCP client. If something refuses to connect after setup, see the [Troubleshooting Guide](docs/troubleshooting.md).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 
 Enable it in Godot: **Project > Project Settings > Plugins > Godot MCP**
 
-### 3. Go
+### 3. Start building
 
 Open your Godot project, restart your AI assistant, and start building. If anything refuses to connect, the [Troubleshooting Guide](docs/troubleshooting.md) has you covered.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,55 @@
 # godot-mcp
 
-MCP server that connects Claude to your Godot editor. Less copy-paste, more creating.
+[![npm version](https://img.shields.io/npm/v/%40satelliteoflove%2Fgodot-mcp?logo=npm&color=cb3837)](https://www.npmjs.com/package/@satelliteoflove/godot-mcp)
+[![CI](https://github.com/satelliteoflove/godot-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/satelliteoflove/godot-mcp/actions/workflows/ci.yml)
+[![Godot 4.5+](https://img.shields.io/badge/Godot-4.5%2B-478cbf?logo=godotengine&logoColor=white)](https://godotengine.org)
+[![Node 20+](https://img.shields.io/badge/Node-20%2B-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/satelliteoflove/godot-mcp/blob/main/LICENSE)
 
-## Why This Exists
+Give your AI assistant eyes and hands in the Godot editor — and a running game it can actually playtest.
 
-Using AI assistants for game dev means a lot of back-and-forth: copying error messages, describing what's on screen, pasting debug output, manually applying suggested changes. It works, but it's tedious.
+<!-- HERO PLACEHOLDER: short demo GIF goes here (agent running the game, stepping time, reading state). Use an absolute raw.githubusercontent.com URL so it also renders on npm. -->
 
-This MCP gives Claude direct access to your Godot editor. It can see your scene tree, capture screenshots, read errors, and make changes directly. You stay focused on the creative work while the mechanical relay disappears. Faster iterations, less busywork, more time building the game you actually want to make.
+## Why this one?
+
+There are a few Godot MCP servers out there, and most can open a scene and poke at nodes. This one is built around a harder problem: **letting an agent verify its own work.** Run the game, drive it like a player, observe what actually happened, and prove the change did what it claimed — without you ferrying screenshots and error logs back and forth.
+
+The pieces that make that possible, and that you won't find elsewhere:
+
+- **Deterministic playtesting.** Freeze the game clock, step exact slices of game time (or step *until a condition holds*), with inputs riding inside the window. Observation never races the game.
+- **Cheap observation.** Live entity state — positions, velocities, animation state, your own custom data — as structured JSON. Most "what's happening on screen?" questions get answered without spending vision tokens on a screenshot.
+- **Real input.** Named actions with analog strength, joypad buttons and stick vectors, raw keys with modifier combos, relative mouse-look, text typing. Sequences run with precise timing and can prove they changed game state.
+- **Scenario setup.** Run GDScript inside the running game: grant the weapon, skip to wave 3, spawn a test bot — no debug hooks baked into your game code.
+
+Here's what that looks like when an agent tests a boss fight:
+
+```text
+godot_editor        run frozen=true           # boot with game time frozen at frame 0
+godot_exec          GameState.wave = 3        # set up the scenario worth testing
+godot_game_time     step_until "tree.get_nodes_in_group('boss').size() >= 1"
+godot_runtime_state digest                    # exact positions and state — no pixels, no guessing
+godot_game_time     step 500ms + dodge input  # play the moment that matters
+godot_editor        screenshot_game           # and a screenshot when it's actually worth the tokens
+```
+
+Less copy-paste, more creating.
 
 ## Quick Start
 
 ### 1. Configure your AI assistant
 
-Add godot-mcp to your MCP client. See the [Installation Guide](INSTALL.md) for config examples (Claude Desktop, Claude Code, VSCode/Copilot, and more).
+Add godot-mcp to your MCP client. See the [Installation Guide](INSTALL.md) for config examples (Claude Desktop, Claude Code, VSCode/Copilot, and more). The short version:
 
-While you're at it, add [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) too — it's a complementary server that covers static GDScript diagnostics and the running game's console output. See [Works Well With](#works-well-with).
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
 
 ### 2. Install the Godot addon
 
@@ -22,76 +57,84 @@ While you're at it, add [minimal-godot-mcp](https://github.com/ryanmazzolini/min
 npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 ```
 
-Enable in Godot: **Project Settings > Plugins > Godot MCP**
+Enable it in Godot: **Project > Project Settings > Plugins > Godot MCP**
 
 ### 3. Go
 
-Open your Godot project, restart your AI assistant, and start building.
+Open your Godot project, restart your AI assistant, and start building. If anything refuses to connect, the [Troubleshooting Guide](docs/troubleshooting.md) has you covered.
 
-## What Claude Can Do
+## What's in the box
 
-- **See** your editor, scenes, running game, editor errors, and performance
-- **Inspect** nodes, resources, animations, tilemaps, 3D spatial data
-- **Modify** scenes, nodes, scripts, animations, tilemaps directly
-- **Test** by running the game and injecting input
-- **Learn** by fetching Godot docs on demand
+15 tools, ~90 actions, 3 MCP resources. Full API docs in the [Tools Reference](docs/tools/README.md).
 
-## Works Well With
+| Tool | What it does |
+|------|--------------|
+| `godot_scene` | Open, save, and create scenes |
+| `godot_node` | Create, update, delete, and reparent nodes; attach scripts; connect signals |
+| `godot_editor` | Editor state, selection, run/stop/restart, screenshots, editor error log, 2D viewport control |
+| `godot_project` | Project info and settings |
+| `godot_animation` | Query, play, and edit animations down to individual tracks and keyframes |
+| `godot_tilemap` / `godot_gridmap` | Read and edit TileMapLayer and GridMap cells |
+| `godot_resource` | Inspect resources with type-aware output: SpriteFrames, TileSet, Materials, Textures |
+| `godot_scene3d` | 3D transforms, bounding boxes, and visibility for spatial reasoning |
+| `godot_docs` | Fetch Godot documentation as clean markdown, version-matched to your editor |
+| `godot_input` | Inject input into the running game: actions, joypad, raw keys, mouse-look, text |
+| `godot_profiler` | Metric snapshots and per-frame time series with spike detection |
+| `godot_runtime_state` | Live game state as JSON: one-shot digests, watch windows, signal timelines |
+| `godot_game_time` | Freeze, step, and step-until on the game clock — deterministic observation |
+| `godot_exec` | Run GDScript inside the running game for test scenario setup |
 
-[minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) by [@ryanmazzolini](https://github.com/ryanmazzolini) is another MCP server for Godot, and it's worth running alongside this one. This server drives the editor through an addon — scene and node manipulation, running the game, input injection, runtime state, screenshots, and editor-side errors (`@tool`, import, and addon failures). minimal-godot-mcp needs no addon and provides exactly the functionality this server does not implement: LSP diagnostics for fast static `.gd` checking, and the running game's console output and stderr over DAP.
+A note on shape: this kit deliberately stays at 15 tools rather than 90. Related operations live as actions inside one tool, so your agent's context isn't flooded with tool definitions it won't use.
 
-Neither duplicates the other, and they don't conflict. Install both and you get static analysis and the live game console alongside full editor and runtime control.
+## Things to ask for
 
-**One godot-mcp client at a time, though.** A Godot editor bridge serves a single godot-mcp connection. If a second godot-mcp client connects - for example, a subagent that inherited the same MCP config - it is rejected while the first is active rather than displacing it, so the original session keeps working. The second client retries and connects automatically once the first disconnects. A client that crashes without closing its socket is taken over after a short idle timeout, so a dead session never permanently blocks new connections.
+A feel for what an agent can do with this, in plain prompts:
+
+- *"Run the game and screenshot the title screen. Does the layout survive 1280x720?"*
+- *"The player can clip through the east wall. Reproduce it, then check the collision shapes and tell me why."*
+- *"Step the game until the second wave spawns and give me every enemy's position and velocity."*
+- *"Hold the left stick at half deflection for two seconds — does the walk animation blend correctly?"*
+- *"Profile ten seconds of gameplay and find what's causing the frame spikes."*
+- *"Add a hit-flash animation to the Player: modulate to red and back over 0.2 seconds."*
+
+For richer runtime observation, add key nodes to the `mcp_watch` group or give them a `_mcp_state()` method — see the [Runtime State Guide](docs/runtime-state-guide.md).
+
+## How it works
+
+```text
+┌─────────────────┐   stdio    ┌─────────────────┐  WebSocket   ┌──────────────────┐  debugger   ┌──────────────┐
+│   MCP client    │ ◄────────► │  godot-mcp      │ ◄──────────► │  Bridge addon    │ ◄─────────► │ Running game │
+│ (Claude, etc.)  │            │  server (Node)  │   :6550      │  (Godot editor)  │    wire     │  (autoload)  │
+└─────────────────┘            └─────────────────┘              └──────────────────┘             └──────────────┘
+```
+
+The server talks to an editor addon over a local WebSocket; the addon reaches into the running game over Godot's own debugger protocol, so the game process needs no extra ports or setup. The addon binds to `127.0.0.1` by default. WSL2 is fully supported (auto-detection, host IP discovery, configurable bind modes) — see the [Installation Guide](INSTALL.md#wsl-support).
+
+Curious about connection lifecycles, the single-client policy, or how frozen-time stepping works under the hood? The [Architecture Guide](docs/architecture.md) goes deep.
+
+## Works well with minimal-godot-mcp
+
+[minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) by [@ryanmazzolini](https://github.com/ryanmazzolini) covers exactly what this server doesn't: LSP diagnostics for fast static GDScript checking, and the running game's console output over DAP. This server covers everything that needs an editor bridge. No overlap, no conflict — run both, and your agent gets static analysis and the game console alongside full editor and runtime control.
+
+One caveat: a Godot editor serves a single godot-mcp client at a time. Extra clients (a subagent inheriting your MCP config, say) wait their turn rather than hijacking your session — details in [Troubleshooting](docs/troubleshooting.md#one-client-at-a-time).
 
 ## Documentation
 
-- [Installation Guide](INSTALL.md) - MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more
-- [Claude Code Setup Guide](docs/claude-code-setup.md) - CLAUDE.md template for Godot projects
-- [Runtime State Guide](docs/runtime-state-guide.md) - Expose game state to agents via the `mcp_watch` group and `_mcp_state()`
-- [Tools Reference](docs/tools/README.md) - All 12 tools with full API docs
-- [Resources Reference](docs/resources.md) - MCP resources for reading project data
-- [Contributing](CONTRIBUTING.md) - Dev setup, adding tools, release process
-- [Changelog](server/CHANGELOG.md) - Release history
+- [Installation Guide](INSTALL.md) — MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more
+- [Troubleshooting](docs/troubleshooting.md) — connection checklist, CLI smoke test, common fixes
+- [Claude Code Setup Guide](docs/claude-code-setup.md) — CLAUDE.md template for Godot projects
+- [Runtime State Guide](docs/runtime-state-guide.md) — expose game state to agents via `mcp_watch` and `_mcp_state()`
+- [Tools Reference](docs/tools/README.md) — all 15 tools with full API docs
+- [Resources Reference](docs/resources.md) — MCP resources for reading project data
+- [Architecture Guide](docs/architecture.md) — how the server, addon, and game bridge fit together
+- [Contributing](CONTRIBUTING.md) — dev setup, adding tools, release process
+- [Changelog](server/CHANGELOG.md) — release history
 
-## Architecture
+## Requirements
 
-```
-[Claude/AI Assistant/MCP Client] <--stdio--> [MCP Server] <--WebSocket:6550--> [Godot MCP Bridge Addon]
-```
-
-WSL2 is supported (auto-detection, host IP discovery, configurable bind modes). See the [Installation Guide](INSTALL.md#wsl-support) for setup details.
-
-## CLI smoke test (paste-ready JSON-RPC)
-
-If you run the server manually via CLI (for example: `npx -y @satelliteoflove/godot-mcp`), you can paste these **stdio JSON-RPC frames** to verify it responds and can reach Godot:
-
-1) Write in CLI
-
-```json
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cli-test","version":"0"}}}
-```
-
-2) Response
-
-```json
-{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{},"resources":{},"logging":{}},"serverInfo":{"name":"godot-mcp","version":"2.11.0"}},"jsonrpc":"2.0","id":1}
-```
-
-3) Call a tool
-
-```json
-{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"godot_editor","arguments":{"action":"get_state"}}}
-```
-
-4) Response
-
-```json
-{"result":{"content":[{"type":"text","text":"{\n  \"current_scene\": null,\n  \"godot_version\": \"4.5.1-stable (official)\",\n  \"is_playing\": false,\n  \"main_screen\": \"unknown\",\n  \"open_scenes\": []\n}"}]},"jsonrpc":"2.0","id":2}
-```
-
-Tip: If you enabled **Port override** in the Godot MCP panel, start the server with matching env vars (or export as environment variable):
-`GODOT_HOST=... GODOT_PORT=... npm run start` or `GODOT_HOST=... GODOT_PORT=... npx -y @satelliteoflove/godot-mcp`
+- **Godot 4.5+** (the addon uses the Logger class introduced in 4.5)
+- **Node.js 20+**
+- Any MCP client that speaks stdio
 
 ## Development
 
@@ -102,11 +145,8 @@ npm test
 npm run generate-docs
 ```
 
-## Requirements
-
-- Node.js 20+
-- Godot 4.5+
+Contributions welcome — this project favors tools that solve real, time-wasting problems. Read [CONTRIBUTING.md](CONTRIBUTING.md) before building something big, or open an issue and we'll figure out the right shape together.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ This server provides **15 tools** and **3 resources** for AI-assisted Godot deve
 - [Claude Code Setup Guide](claude-code-setup.md) - Configure your project for AI-assisted development
 - [Tools Reference](tools/README.md) - All available MCP tools
 - [Resources Reference](resources.md) - MCP resources for reading project data
+- [Architecture Guide](architecture.md) - How the server, addon, and game bridge fit together
+- [Troubleshooting](troubleshooting.md) - Connection checklist, CLI smoke test, common fixes
 
 ## Tool Categories
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+How godot-mcp's three processes fit together, and the design decisions behind them.
+
+## The big picture
+
+```mermaid
+flowchart LR
+    Client["MCP client<br/>(Claude Code, Claude Desktop,<br/>Copilot, ...)"]
+    Server["godot-mcp server<br/>(Node.js)"]
+    Addon["Bridge addon<br/>(Godot editor)"]
+    Game["MCPGameBridge autoload<br/>(running game)"]
+
+    Client <-->|"stdio (JSON-RPC)"| Server
+    Server <-->|"WebSocket :6550"| Addon
+    Addon <-->|"EngineDebugger wire"| Game
+```
+
+Three processes, three links:
+
+1. **MCP client ↔ server.** Standard MCP over stdio. The server (`server/src/`) defines the 15 tools, validates arguments with Zod schemas, and translates tool calls into bridge commands.
+2. **Server ↔ editor addon.** A WebSocket on `127.0.0.1:6550` by default. The *addon* is the listener; the *server* is the client that connects to it. The addon (`godot/addons/godot_mcp/`) routes each command through `command_router.gd` to a handler module per domain (scene, node, animation, input, ...).
+3. **Editor addon ↔ running game.** No second socket. The addon registers `MCPGameBridge` as an autoload in your project and talks to it over Godot's own debugger protocol — the editor side sends `godot_mcp:`-prefixed debugger messages via an `EditorDebuggerPlugin` (`core/mcp_debugger_plugin.gd`), and the game-side bridge (`game_bridge/mcp_game_bridge.gd`) picks them up with `EngineDebugger.register_message_capture()`. Because it rides the debug wire, the running game needs no extra ports, no network permissions, and no per-project setup.
+
+## Connection lifecycle
+
+The server connects eagerly and assumes the editor may not be there yet:
+
+- **Reconnection** uses exponential backoff: 1s, 2s, 4s, 8s, 16s, then every 30s. You can start the server and the editor in either order.
+- **Heartbeats** go out every 30 seconds so the addon can tell a quiet-but-alive client from a dead one.
+
+### One client at a time
+
+The editor bridge serves a single client. When a second client connects while one is active:
+
+- The newcomer is rejected with WebSocket close code `4001` ("another client is already connected") instead of displacing the incumbent — a subagent that inherited your MCP config can't hijack your session mid-edit.
+- Rejected clients retry with backoff and connect automatically once the slot frees up.
+- If the incumbent goes silent for **45 seconds** (no messages, no heartbeats) or its TCP connection drops, it's considered stale and the next client takes over. A crashed session never permanently wedges the bridge.
+
+This logic lives in `godot/addons/godot_mcp/websocket_server.gd`.
+
+## Deterministic game time
+
+`godot_editor run frozen=true` boots the game with the clock frozen from frame 0, and `godot_game_time` owns the clock from there:
+
+- **freeze / thaw** pause and resume under agent control, layered correctly over the game's *own* pause state — freezing over an open pause menu and thawing back to it preserves the game's intent.
+- **step** advances a bounded slice of game time (or an exact frame count), then re-freezes.
+- **step_until** re-evaluates a GDScript predicate every frame and stops the frame it holds, with a safety cap so it can't hang.
+- Input timelines ride *inside* the step window, so `is_action_just_pressed` edges land on real frames.
+
+The point: between any two tool calls, the game is exactly where the agent left it. Screenshots, state digests, and node queries all work while frozen, so observation never races gameplay.
+
+## WSL support
+
+The standard cross-boundary setup is Godot on Windows with the MCP server inside WSL2:
+
+- **Detection** (`server/src/utils/wsl-detection.ts`): the server checks `WSL_DISTRO_NAME` / `WSL_INTEROP` and falls back to scanning `/proc/version`.
+- **Host discovery** (`server/src/utils/host-ip-resolver.ts`): on WSL2 the Windows host IP comes from the nameserver in `/etc/resolv.conf`; on WSL1 it's the default gateway from `/proc/net/route`. `GODOT_HOST` overrides everything.
+- **Bind modes** (MCP panel in the editor): the addon defaults to `127.0.0.1`, which WSL traffic can't reach — switch to **WSL** mode to listen on the `vEthernet (WSL)` interface, or **Custom** for any specific IP. Panel settings persist to `project.godot`.
+
+## Security posture
+
+- The addon binds to **localhost by default**; the WebSocket is unencrypted (`ws://`). The other bind modes exist for WSL and trusted-LAN setups — don't point them at interfaces you don't trust.
+- `godot_exec` runs GDScript inside the running game behind a static denylist (process spawning, file writes, settings persistence). That denylist is an **accident guard, not a security boundary** — it keeps an agent from absent-mindedly writing to disk, not a sandboxed adversary from escaping.
+
+## Versioning and releases
+
+The server and addon are released together and share one version number:
+
+- [release-please](https://github.com/googleapis/release-please) drives versioning from conventional commits; the release workflow syncs the version into the addon's `plugin.cfg` and regenerates docs.
+- The npm package bundles the addon, which is what `npx @satelliteoflove/godot-mcp --install-addon <path>` copies into your project. Each GitHub release also attaches the addon as a zip.
+- The MCP panel shows both versions and warns on mismatch.
+
+## Repo layout
+
+```text
+server/src/tools/         MCP tool definitions (one file per domain)
+server/src/resources/     MCP resource handlers
+server/src/connection/    WebSocket client to the editor addon
+server/src/installer/     --install-addon implementation
+godot/addons/godot_mcp/
+  plugin.gd               EditorPlugin entry point; registers the autoload
+  websocket_server.gd     WebSocket listener + single-client policy
+  command_router.gd       Routes commands to handlers
+  commands/               GDScript command handlers (one file per domain)
+  core/                   Debugger plugin, logger, shared utilities
+  game_bridge/            Runs inside the game: bridge, state sampler, profiler, exec guard
+  ui/                     The MCP bottom panel
+```
+
+Docs under `docs/tools/`, `docs/resources.md`, and `docs/README.md` are generated from the tool definitions by `npm run generate-docs` — edit the tool schemas, not those files.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,104 @@
+# Troubleshooting
+
+Connection problems, common fixes, and how to verify each link in the chain.
+
+## The 60-second checklist
+
+Most "it doesn't work" reports come down to one of these:
+
+1. **Is the Godot editor open?** The server connects to an addon running *inside the editor*. No editor, no connection.
+2. **Is the addon enabled?** Check **Project > Project Settings > Plugins > Godot MCP**. Installing the addon doesn't enable it.
+3. **What does the MCP panel say?** The **MCP** tab in the editor's bottom panel shows connection status: green means a client is connected, orange means the addon is listening but no client has connected yet.
+4. **Did you restart your AI assistant after installing?** MCP clients typically launch servers at startup. A client started before the config change won't see the server.
+5. **Do the ports match?** The addon listens on `6550` by default. If you enabled **Port override** in the MCP panel, the server needs a matching `GODOT_PORT` (see [Environment Variables](../INSTALL.md#environment-variables)).
+
+## One client at a time
+
+A Godot editor bridge serves a **single** godot-mcp connection. This matters once subagents or multiple terminals inherit the same MCP config.
+
+- If a second godot-mcp client connects while the first is active, it is **rejected** (WebSocket close code `4001`) rather than displacing the original — your session keeps working.
+- The rejected client retries automatically with backoff and connects as soon as the first client disconnects.
+- A client that crashes without closing its socket doesn't block anyone for long: the addon considers a connection stale after **45 seconds** of silence (live clients heartbeat every 30 seconds) and lets the next client take over.
+
+So if a tool call reports that another client holds the connection: close the other session, or just wait — the takeover is automatic.
+
+## Port conflicts and overrides
+
+If port `6550` is taken on your machine (or you run multiple Godot projects side by side):
+
+1. In the editor's **MCP** bottom panel, enable **Port override**, pick a port, and click **Apply**.
+2. Set `GODOT_PORT` to the same value in your MCP client config (an `env` block alongside `command`/`args`, or however your client passes environment variables).
+
+The panel persists its settings to `project.godot`, so the override sticks per-project.
+
+## WSL
+
+Running the MCP server inside WSL2 while Godot runs on Windows works, but localhost won't cross that boundary by itself:
+
+- In the MCP panel, set **Bind mode: WSL** so the addon listens on the Windows `vEthernet (WSL)` interface instead of `127.0.0.1`.
+- The server auto-detects WSL and discovers the Windows host IP on its own; set `GODOT_HOST` only if discovery fails.
+
+Full details in the [Installation Guide](../INSTALL.md#wsl-support).
+
+## Server and addon versions disagree
+
+The MCP panel shows both the addon version and (when connected) the server version, and warns when they differ. The two are released together and expected to match. To update the addon in your project:
+
+```bash
+npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
+```
+
+Add `--force` if you intentionally need to downgrade. Restart the Godot editor afterwards.
+
+## Where errors show up
+
+Two different processes produce errors, and they surface in two different places:
+
+- **Editor-side errors** — `@tool` script failures, import errors, addon errors, failures from scene/resource edits — come from `godot_editor` with the `get_log_messages` action. This is the "did my change break the editor?" channel.
+- **Running game console output** (including `print()` and stderr) is intentionally not duplicated here — [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) provides it over DAP. Runtime *state* (positions, velocities, custom data) is `godot_runtime_state` territory.
+
+## CLI smoke test (paste-ready JSON-RPC)
+
+To verify the server starts and can reach Godot without involving an MCP client, run it manually:
+
+```bash
+npx -y @satelliteoflove/godot-mcp
+```
+
+Then paste these stdio JSON-RPC frames, one per line:
+
+**1) Initialize:**
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cli-test","version":"0"}}}
+```
+
+You should get a response naming the server and its version:
+
+```json
+{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{},"resources":{},"logging":{}},"serverInfo":{"name":"godot-mcp","version":"<your installed version>"}},"jsonrpc":"2.0","id":1}
+```
+
+**2) Call a tool** (requires the Godot editor open with the addon enabled):
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"godot_editor","arguments":{"action":"get_state"}}}
+```
+
+A healthy response carries the editor state:
+
+```json
+{"result":{"content":[{"type":"text","text":"{\n  \"current_scene\": null,\n  \"godot_version\": \"4.5.1-stable (official)\",\n  \"is_playing\": false,\n  \"main_screen\": \"unknown\",\n  \"open_scenes\": []\n}"}]},"jsonrpc":"2.0","id":2}
+```
+
+If step 1 works but step 2 times out, the server is fine and the problem is the WebSocket hop — work through the [checklist](#the-60-second-checklist) above. If you're using a port override, remember to start the server with matching env vars:
+
+```bash
+GODOT_HOST=... GODOT_PORT=... npx -y @satelliteoflove/godot-mcp
+```
+
+Other useful CLI flags: `--version`, `--help`.
+
+## Still stuck?
+
+Open a [GitHub issue](https://github.com/satelliteoflove/godot-mcp/issues) with your OS, Godot version, server version (`npx @satelliteoflove/godot-mcp --version`), and what the MCP panel shows. The more of the chain you've tested with the smoke test above, the faster we can pin it down.

--- a/server/README.md
+++ b/server/README.md
@@ -59,7 +59,7 @@ npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 
 Enable it in Godot: **Project > Project Settings > Plugins > Godot MCP**
 
-### 3. Go
+### 3. Start building
 
 Open your Godot project, restart your AI assistant, and start building. If anything refuses to connect, the [Troubleshooting Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/troubleshooting.md) has you covered.
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,20 +1,55 @@
 # godot-mcp
 
-MCP server that connects Claude to your Godot editor. Less copy-paste, more creating.
+[![npm version](https://img.shields.io/npm/v/%40satelliteoflove%2Fgodot-mcp?logo=npm&color=cb3837)](https://www.npmjs.com/package/@satelliteoflove/godot-mcp)
+[![CI](https://github.com/satelliteoflove/godot-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/satelliteoflove/godot-mcp/actions/workflows/ci.yml)
+[![Godot 4.5+](https://img.shields.io/badge/Godot-4.5%2B-478cbf?logo=godotengine&logoColor=white)](https://godotengine.org)
+[![Node 20+](https://img.shields.io/badge/Node-20%2B-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/satelliteoflove/godot-mcp/blob/main/LICENSE)
 
-## Why This Exists
+Give your AI assistant eyes and hands in the Godot editor — and a running game it can actually playtest.
 
-Using AI assistants for game dev means a lot of back-and-forth: copying error messages, describing what's on screen, pasting debug output, manually applying suggested changes. It works, but it's tedious.
+<!-- HERO PLACEHOLDER: short demo GIF goes here (agent running the game, stepping time, reading state). Use an absolute raw.githubusercontent.com URL so it also renders on npm. -->
 
-This MCP gives Claude direct access to your Godot editor. It can see your scene tree, capture screenshots, read errors, and make changes directly. You stay focused on the creative work while the mechanical relay disappears. Faster iterations, less busywork, more time building the game you actually want to make.
+## Why this one?
+
+There are a few Godot MCP servers out there, and most can open a scene and poke at nodes. This one is built around a harder problem: **letting an agent verify its own work.** Run the game, drive it like a player, observe what actually happened, and prove the change did what it claimed — without you ferrying screenshots and error logs back and forth.
+
+The pieces that make that possible, and that you won't find elsewhere:
+
+- **Deterministic playtesting.** Freeze the game clock, step exact slices of game time (or step *until a condition holds*), with inputs riding inside the window. Observation never races the game.
+- **Cheap observation.** Live entity state — positions, velocities, animation state, your own custom data — as structured JSON. Most "what's happening on screen?" questions get answered without spending vision tokens on a screenshot.
+- **Real input.** Named actions with analog strength, joypad buttons and stick vectors, raw keys with modifier combos, relative mouse-look, text typing. Sequences run with precise timing and can prove they changed game state.
+- **Scenario setup.** Run GDScript inside the running game: grant the weapon, skip to wave 3, spawn a test bot — no debug hooks baked into your game code.
+
+Here's what that looks like when an agent tests a boss fight:
+
+```text
+godot_editor        run frozen=true           # boot with game time frozen at frame 0
+godot_exec          GameState.wave = 3        # set up the scenario worth testing
+godot_game_time     step_until "tree.get_nodes_in_group('boss').size() >= 1"
+godot_runtime_state digest                    # exact positions and state — no pixels, no guessing
+godot_game_time     step 500ms + dodge input  # play the moment that matters
+godot_editor        screenshot_game           # and a screenshot when it's actually worth the tokens
+```
+
+Less copy-paste, more creating.
 
 ## Quick Start
 
 ### 1. Configure your AI assistant
 
-Add godot-mcp to your MCP client. See the [Installation Guide](INSTALL.md) for config examples (Claude Desktop, Claude Code, VSCode/Copilot, and more).
+Add godot-mcp to your MCP client. See the [Installation Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/INSTALL.md) for config examples (Claude Desktop, Claude Code, VSCode/Copilot, and more). The short version:
 
-While you're at it, add [minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) too — it's a complementary server that covers static GDScript diagnostics and the running game's console output. See [Works Well With](#works-well-with).
+```json
+{
+  "mcpServers": {
+    "godot-mcp": {
+      "command": "npx",
+      "args": ["-y", "@satelliteoflove/godot-mcp"]
+    }
+  }
+}
+```
 
 ### 2. Install the Godot addon
 
@@ -22,76 +57,84 @@ While you're at it, add [minimal-godot-mcp](https://github.com/ryanmazzolini/min
 npx @satelliteoflove/godot-mcp --install-addon /path/to/your/godot/project
 ```
 
-Enable in Godot: **Project Settings > Plugins > Godot MCP**
+Enable it in Godot: **Project > Project Settings > Plugins > Godot MCP**
 
 ### 3. Go
 
-Open your Godot project, restart your AI assistant, and start building.
+Open your Godot project, restart your AI assistant, and start building. If anything refuses to connect, the [Troubleshooting Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/troubleshooting.md) has you covered.
 
-## What Claude Can Do
+## What's in the box
 
-- **See** your editor, scenes, running game, editor errors, and performance
-- **Inspect** nodes, resources, animations, tilemaps, 3D spatial data
-- **Modify** scenes, nodes, scripts, animations, tilemaps directly
-- **Test** by running the game and injecting input
-- **Learn** by fetching Godot docs on demand
+15 tools, ~90 actions, 3 MCP resources. Full API docs in the [Tools Reference](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/tools/README.md).
 
-## Works Well With
+| Tool | What it does |
+|------|--------------|
+| `godot_scene` | Open, save, and create scenes |
+| `godot_node` | Create, update, delete, and reparent nodes; attach scripts; connect signals |
+| `godot_editor` | Editor state, selection, run/stop/restart, screenshots, editor error log, 2D viewport control |
+| `godot_project` | Project info and settings |
+| `godot_animation` | Query, play, and edit animations down to individual tracks and keyframes |
+| `godot_tilemap` / `godot_gridmap` | Read and edit TileMapLayer and GridMap cells |
+| `godot_resource` | Inspect resources with type-aware output: SpriteFrames, TileSet, Materials, Textures |
+| `godot_scene3d` | 3D transforms, bounding boxes, and visibility for spatial reasoning |
+| `godot_docs` | Fetch Godot documentation as clean markdown, version-matched to your editor |
+| `godot_input` | Inject input into the running game: actions, joypad, raw keys, mouse-look, text |
+| `godot_profiler` | Metric snapshots and per-frame time series with spike detection |
+| `godot_runtime_state` | Live game state as JSON: one-shot digests, watch windows, signal timelines |
+| `godot_game_time` | Freeze, step, and step-until on the game clock — deterministic observation |
+| `godot_exec` | Run GDScript inside the running game for test scenario setup |
 
-[minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) by [@ryanmazzolini](https://github.com/ryanmazzolini) is another MCP server for Godot, and it's worth running alongside this one. This server drives the editor through an addon — scene and node manipulation, running the game, input injection, runtime state, screenshots, and editor-side errors (`@tool`, import, and addon failures). minimal-godot-mcp needs no addon and provides exactly the functionality this server does not implement: LSP diagnostics for fast static `.gd` checking, and the running game's console output and stderr over DAP.
+A note on shape: this kit deliberately stays at 15 tools rather than 90. Related operations live as actions inside one tool, so your agent's context isn't flooded with tool definitions it won't use.
 
-Neither duplicates the other, and they don't conflict. Install both and you get static analysis and the live game console alongside full editor and runtime control.
+## Things to ask for
 
-**One godot-mcp client at a time, though.** A Godot editor bridge serves a single godot-mcp connection. If a second godot-mcp client connects - for example, a subagent that inherited the same MCP config - it is rejected while the first is active rather than displacing it, so the original session keeps working. The second client retries and connects automatically once the first disconnects. A client that crashes without closing its socket is taken over after a short idle timeout, so a dead session never permanently blocks new connections.
+A feel for what an agent can do with this, in plain prompts:
+
+- *"Run the game and screenshot the title screen. Does the layout survive 1280x720?"*
+- *"The player can clip through the east wall. Reproduce it, then check the collision shapes and tell me why."*
+- *"Step the game until the second wave spawns and give me every enemy's position and velocity."*
+- *"Hold the left stick at half deflection for two seconds — does the walk animation blend correctly?"*
+- *"Profile ten seconds of gameplay and find what's causing the frame spikes."*
+- *"Add a hit-flash animation to the Player: modulate to red and back over 0.2 seconds."*
+
+For richer runtime observation, add key nodes to the `mcp_watch` group or give them a `_mcp_state()` method — see the [Runtime State Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/runtime-state-guide.md).
+
+## How it works
+
+```text
+┌─────────────────┐   stdio    ┌─────────────────┐  WebSocket   ┌──────────────────┐  debugger   ┌──────────────┐
+│   MCP client    │ ◄────────► │  godot-mcp      │ ◄──────────► │  Bridge addon    │ ◄─────────► │ Running game │
+│ (Claude, etc.)  │            │  server (Node)  │   :6550      │  (Godot editor)  │    wire     │  (autoload)  │
+└─────────────────┘            └─────────────────┘              └──────────────────┘             └──────────────┘
+```
+
+The server talks to an editor addon over a local WebSocket; the addon reaches into the running game over Godot's own debugger protocol, so the game process needs no extra ports or setup. The addon binds to `127.0.0.1` by default. WSL2 is fully supported (auto-detection, host IP discovery, configurable bind modes) — see the [Installation Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/INSTALL.md#wsl-support).
+
+Curious about connection lifecycles, the single-client policy, or how frozen-time stepping works under the hood? The [Architecture Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/architecture.md) goes deep.
+
+## Works well with minimal-godot-mcp
+
+[minimal-godot-mcp](https://github.com/ryanmazzolini/minimal-godot-mcp) by [@ryanmazzolini](https://github.com/ryanmazzolini) covers exactly what this server doesn't: LSP diagnostics for fast static GDScript checking, and the running game's console output over DAP. This server covers everything that needs an editor bridge. No overlap, no conflict — run both, and your agent gets static analysis and the game console alongside full editor and runtime control.
+
+One caveat: a Godot editor serves a single godot-mcp client at a time. Extra clients (a subagent inheriting your MCP config, say) wait their turn rather than hijacking your session — details in [Troubleshooting](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/troubleshooting.md#one-client-at-a-time).
 
 ## Documentation
 
-- [Installation Guide](INSTALL.md) - MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more
-- [Claude Code Setup Guide](../docs/claude-code-setup.md) - CLAUDE.md template for Godot projects
-- [Runtime State Guide](../docs/runtime-state-guide.md) - Expose game state to agents via the `mcp_watch` group and `_mcp_state()`
-- [Tools Reference](../docs/tools/README.md) - All 12 tools with full API docs
-- [Resources Reference](../docs/resources.md) - MCP resources for reading project data
-- [Contributing](../CONTRIBUTING.md) - Dev setup, adding tools, release process
-- [Changelog](CHANGELOG.md) - Release history
+- [Installation Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/INSTALL.md) — MCP client configs for Claude Desktop, Claude Code, VSCode/Copilot, and more
+- [Troubleshooting](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/troubleshooting.md) — connection checklist, CLI smoke test, common fixes
+- [Claude Code Setup Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/claude-code-setup.md) — CLAUDE.md template for Godot projects
+- [Runtime State Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/runtime-state-guide.md) — expose game state to agents via `mcp_watch` and `_mcp_state()`
+- [Tools Reference](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/tools/README.md) — all 15 tools with full API docs
+- [Resources Reference](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/resources.md) — MCP resources for reading project data
+- [Architecture Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/architecture.md) — how the server, addon, and game bridge fit together
+- [Contributing](https://github.com/satelliteoflove/godot-mcp/blob/main/CONTRIBUTING.md) — dev setup, adding tools, release process
+- [Changelog](https://github.com/satelliteoflove/godot-mcp/blob/main/server/CHANGELOG.md) — release history
 
-## Architecture
+## Requirements
 
-```
-[Claude/AI Assistant/MCP Client] <--stdio--> [MCP Server] <--WebSocket:6550--> [Godot MCP Bridge Addon]
-```
-
-WSL2 is supported (auto-detection, host IP discovery, configurable bind modes). See the [Installation Guide](INSTALL.md#wsl-support) for setup details.
-
-## CLI smoke test (paste-ready JSON-RPC)
-
-If you run the server manually via CLI (for example: `npx -y @satelliteoflove/godot-mcp`), you can paste these **stdio JSON-RPC frames** to verify it responds and can reach Godot:
-
-1) Write in CLI
-
-```json
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cli-test","version":"0"}}}
-```
-
-2) Response
-
-```json
-{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{},"resources":{},"logging":{}},"serverInfo":{"name":"godot-mcp","version":"2.11.0"}},"jsonrpc":"2.0","id":1}
-```
-
-3) Call a tool
-
-```json
-{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"godot_editor","arguments":{"action":"get_state"}}}
-```
-
-4) Response
-
-```json
-{"result":{"content":[{"type":"text","text":"{\n  \"current_scene\": null,\n  \"godot_version\": \"4.5.1-stable (official)\",\n  \"is_playing\": false,\n  \"main_screen\": \"unknown\",\n  \"open_scenes\": []\n}"}]},"jsonrpc":"2.0","id":2}
-```
-
-Tip: If you enabled **Port override** in the Godot MCP panel, start the server with matching env vars (or export as environment variable):
-`GODOT_HOST=... GODOT_PORT=... npm run start` or `GODOT_HOST=... GODOT_PORT=... npx -y @satelliteoflove/godot-mcp`
+- **Godot 4.5+** (the addon uses the Logger class introduced in 4.5)
+- **Node.js 20+**
+- Any MCP client that speaks stdio
 
 ## Development
 
@@ -102,11 +145,8 @@ npm test
 npm run generate-docs
 ```
 
-## Requirements
-
-- Node.js 20+
-- Godot 4.5+
+Contributions welcome — this project favors tools that solve real, time-wasting problems. Read [CONTRIBUTING.md](https://github.com/satelliteoflove/godot-mcp/blob/main/CONTRIBUTING.md) before building something big, or open an issue and we'll figure out the right shape together.
 
 ## License
 
-MIT
+[MIT](https://github.com/satelliteoflove/godot-mcp/blob/main/LICENSE)

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@satelliteoflove/godot-mcp",
   "version": "3.21.1",
-  "description": "MCP server for Godot Engine integration",
+  "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -33,12 +33,18 @@
   },
   "keywords": [
     "godot",
+    "godot4",
     "mcp",
+    "mcp-server",
     "model-context-protocol",
     "ai",
-    "game-development"
+    "ai-agents",
+    "claude",
+    "game-development",
+    "game-testing",
+    "gdscript"
   ],
-  "author": "",
+  "author": "Christopher Childress",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -488,6 +488,8 @@ This server provides **${totalTools} tools** and **${allResources.length} resour
 - [Claude Code Setup Guide](claude-code-setup.md) - Configure your project for AI-assisted development
 - [Tools Reference](tools/README.md) - All available MCP tools
 - [Resources Reference](resources.md) - MCP resources for reading project data
+- [Architecture Guide](architecture.md) - How the server, addon, and game bridge fit together
+- [Troubleshooting](troubleshooting.md) - Connection checklist, CLI smoke test, common fixes
 
 ## Tool Categories
 
@@ -523,11 +525,19 @@ Add to your MCP configuration:
 
 function generateNpmReadme(): string {
   const rootReadme = readFileSync(ROOT_README, 'utf-8');
+  const blobBase = 'https://github.com/satelliteoflove/godot-mcp/blob/main/';
+  const rawBase = 'https://raw.githubusercontent.com/satelliteoflove/godot-mcp/main/';
 
-  return rootReadme
-    .replace(/\]\(docs\//g, '](../docs/')
-    .replace(/\]\(CONTRIBUTING\.md\)/g, '](../CONTRIBUTING.md)')
-    .replace(/\]\(server\/CHANGELOG\.md\)/g, '](CHANGELOG.md)');
+  // npmjs.com resolves relative links against the repo root, not server/, so
+  // every relative link must become an absolute GitHub URL. Images need raw
+  // URLs (a blob URL is an HTML page and will not render as an image).
+  return rootReadme.replace(
+    /(!?)\[([^\]]*)\]\((?!https?:\/\/|#)([^)\s]+)\)/g,
+    (_match, bang: string, text: string, path: string) => {
+      const isImage = bang === '!' || /\.(png|jpe?g|gif|svg|webp)(#|$)/i.test(path);
+      return `${bang}[${text}](${isImage ? rawBase : blobBase}${path})`;
+    },
+  );
 }
 
 


### PR DESCRIPTION
## Summary

A full pass over the project's public face, anchored by one real bug fix: the npm package README's links were broken on npmjs.com.

### The fix

`server/README.md` is generated from the root README with relative links (`../docs/...`), which 404 on npmjs.com because npm resolves them against the repo root. `generate-docs.ts` now rewrites every relative link to an absolute GitHub URL — raw URLs for images so a future hero GIF renders on npm too. Typed as `fix:` so the patch release republishes the corrected README to npm.

### The overhaul

- **README.md rewritten** around the "agents that verify their own work" pitch: differentiators named up front (game-time control, runtime-state digests, input injection breadth, `godot_exec`), a worked boss-fight testing example, example prompts, badges, and corrected facts — 15 tools / ~90 actions, not 12; the smoke test's rotted `2.11.0` version is gone.
- **`docs/troubleshooting.md` (new)**: 60-second connection checklist, one-client-at-a-time semantics (moved out of the README, with the real numbers: 4001 rejection, 45s stale takeover), port overrides, WSL, version mismatch, and the CLI smoke test — now version-agnostic.
- **`docs/architecture.md` (new)**: three-process design with a Mermaid diagram, connection lifecycle and backoff values, how the game bridge rides Godot's debugger wire, frozen-time stepping, WSL host discovery, security posture, and release mechanics.
- **Metadata**: `package.json` gains a real author, a descriptive description, and 11 keywords. CONTRIBUTING.md documents that `server/README.md` is generated (don't hand-edit); INSTALL.md links the troubleshooting guide.
- `docs/README.md` regenerated — Quick Links now include the two new guides.

A hero GIF slot is marked with an HTML comment at the top of the README for when there's a recording to drop in.

## Test plan

- [x] `npm test` — 562 tests pass
- [x] `npm run generate-docs` — regenerates cleanly; npm README link rewriting verified (all relative links now absolute, badge images untouched)
- [x] All relative links in the new/edited docs resolve to real files and anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)