### PR TITLE
feat: tag usage log entries with the server version

### DIFF
--- a/server/src/utils/usage-logger.ts
+++ b/server/src/utils/usage-logger.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { getServerVersion } from '../version.js';
 
 const DEFAULT_MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 const LOG_DIR = path.join(os.homedir(), '.godot-mcp');
@@ -8,6 +9,7 @@ const LOG_FILE = path.join(LOG_DIR, 'usage.log');
 
 interface UsageEntry {
   ts: string;
+  mcp_version: string;
   tool: string;
   action?: string;
   success: boolean;
@@ -69,6 +71,7 @@ export function logToolUsage(
 
   const entry: UsageEntry = {
     ts: new Date().toISOString(),
+    mcp_version: getServerVersion(),
     tool,
     success,
     duration_ms: Math.round(durationMs),


### PR DESCRIPTION
## Summary

Adds an `mcp_version` field (from `getServerVersion()`) to every usage-log entry written to `~/.godot-mcp/usage.log`.

The usage log exists to answer "which tools and actions are earning their keep" (CONTRIBUTING.md). With several releases shipping per day, that analysis is much weaker without knowing which version produced each entry — error rates and usage patterns shift release to release (e.g. input injection and game-time behavior changed substantially across 3.10 → 3.21). This stamps each line so the data can be sliced by version.

No behavior change otherwise: logging stays local-only, on-by-default with `GODOT_MCP_USAGE_LOG=0` opt-out, silent-failure, 10MB rotation.

## Test plan

- [x] `npm test` — 562 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)