### PR TITLE
docs: preserve mouse-injection spike evidence in-repo, retire the archive branch

### DIFF
--- a/docs/design/mouse-injection-spike.md
+++ b/docs/design/mouse-injection-spike.md
@@ -1,0 +1,303 @@
+# Mouse Injection Spike: In-Process Sequencing, Lifecycle Safety, Confirm-by-Delta
+
+Status: design spike (investigation + proven probes + one shipped bug fix). The
+injection *primitive* is settled; this doc covers the layers ON TOP that a real
+`godot_input` mouse tool needs, what is now proven, and what remains. Companion
+to the regimes work in `godot/addons/godot_mcp/test/README.md` (the mouse suite).
+
+> **Archival note.** This spike fed the decision recorded in
+> [`mouse-input-spike.md`](mouse-input-spike.md): **godot-mcp will not add
+> comprehensive mouse input.** This document is preserved as the build-oriented
+> evidence behind that call. It references the spike's full set of 13 probe
+> scripts by their findings, but only a **keystone subset** is retained in-repo
+> under `godot/addons/godot_mcp/test/` — the polled-position keystone
+> (`mouse_polled_position_test.gd`), its focus-independence
+> (`mouse_unfocused_poll_test.gd`), transform completeness
+> (`mouse_transform_completeness_test.gd`), and the queue engine
+> (`mouse_queue_engine_test.gd`). The other probes named below are recorded here
+> as findings, not kept as files. The reference engine `mcp_input_queue.gd` was
+> moved into `test/` (dev-only, stripped from the shipped addon) since it was
+> never wired into the bridge.
+
+## Problem statement
+
+"Comprehensive mouse support" is not the injection call — it is a small stack on
+top of it:
+
+```
+tool surface  /  gesture vocab  /  targeting  /  SEQUENCING ENGINE  /
+LIFECYCLE SAFETY  /  observability  /  [injection primitive ✓]
+```
+
+The injection primitive and its input regimes are proven (pointer, look,
+SubViewport, content-scale/DPI, screen_relative, the polled-position keystone —
+six committed probes, see the test README). Those probes all ran as
+`extends SceneTree --script`, where the probe script **is** the main loop and can
+`await SceneTree.process_frame`. A real bridge is the opposite: a **Node inside a
+running game** that cannot await frames. Two whole layers never appeared in the
+probe harness and are the ones most likely to sink the feature:
+
+1. **The per-frame sequencing engine** — how a node drains queued input without
+   awaiting frames.
+2. **Lifecycle safety** — guaranteeing a press is never left latched.
+
+Plus a correctness rule that spans both: **confirm by state delta**, never by
+"the event was sent."
+
+This spike built and proved all three (Tier 1 of the risk register), wrote a
+committed reference engine, and fixed a real stuck-held bug already shipped in
+the action-sequence path.
+
+## What is already true (verified against code)
+
+- Editor ↔ game runs over `EngineDebugger`. The game side registers a capture
+  (`MCPGameBridge._ready` → `EngineDebugger.register_message_capture("godot_mcp", _on_debugger_message)`)
+  and replies with `EngineDebugger.send_message("godot_mcp:<name>", [...])`.
+- **The bridge is already a per-frame queue drainer.** `MCPGameBridge` has a
+  `_process` loop that drains a timestamped event queue for `execute_input_sequence`
+  (`_handle_execute_input_sequence` builds `_sequence_events`; `_process` pops the
+  due ones each frame). So the "in-process engine" is not hypothetical — it
+  exists, and studying it surfaced the exact Tier-1 failure modes below.
+- The existing engine uses `InputEventAction` only (no mouse buttons/motion at
+  coordinates), drains **all** due events in one frame, has **no**
+  `process_mode = ALWAYS`, and (until this spike) dropped unfired releases when a
+  new sequence cleared the queue.
+
+## Foundational harness fact (proven)
+
+A child `Node` added to `root` in an `extends SceneTree --script` harness receives
+real per-frame `_process()` callbacks even though the script is itself the main
+loop, and `process_mode = ALWAYS` keeps it ticking while `SceneTree.paused` is
+true (a default-mode node stalls). This is what makes the queue engine testable
+off the live game loop. Verified before building anything else; it underpins
+`mouse_queue_engine_test.gd` and `mouse_lifecycle_safety_test.gd`.
+
+---
+
+## Tier 1, resolved
+
+### 1. The per-frame sequencing engine
+
+A bridge node must drain a queue **one event per frame** from `_process`. Draining
+all due events in a frame collapses press+release onto one frame; blocking the
+loop with a synchronous wait is the other failure mode. The engine must also keep
+running while the game is paused so a pending **release** never gets stuck behind
+a pause.
+
+Proven by `mouse_queue_engine_test.gd` against the reference module
+`test/mcp_input_queue.gd`:
+
+- Q1 — never drains more than one step per frame; fully drains (`pending_count`
+  sequence `4→3→2→1→0`).
+- Q2 — a decomposed click puts move/press/release on different, ordered frames.
+- Q3 — `process_mode = ALWAYS` keeps draining while `paused = true`.
+- Q4/Q5 — the empirical surprise: a plain `Button` fires `pressed` once for BOTH
+  same-frame and frame-stepped press+release (so a discrete click is *not* why
+  one-per-frame matters). The real reason is **duration**: a hold/duration
+  consumer that polls `Input.is_mouse_button_pressed` (hold-to-paint) observes the
+  button as held for ≥1 frame only when press and release are on different frames;
+  a same-frame pair is a zero-duration hold it never sees (`frame-stepped=3
+  down-frames` vs `same-frame=0`). Frame separation is therefore mandatory for
+  hold-to-paint, drags, and hover-before-press.
+
+### 2. Lifecycle safety
+
+A press injected without its paired release **latches**:
+`Input.is_mouse_button_pressed()` / `is_action_pressed()` stay true and a
+hold-to-paint game paints with no end. The remedy is a held-state registry plus a
+release that is a `finally`, not a step.
+
+Proven by `mouse_lifecycle_safety_test.gd` against the reference module:
+
+- The registry tracks press↔release exactly; a press with no release latches (the
+  bug reproduced).
+- `release_all()` synthesizes the paired release for everything held AND drops the
+  pending queue (the panic button) — three latched inputs (LEFT, RIGHT, an action)
+  all cleared.
+- A watchdog force-releases any input held longer than `hold_timeout_ms`.
+- `on_disconnect()` (MCP/debugger session end) and `_exit_tree` (game shutdown /
+  scene change) both flush paired releases.
+
+### 3. Silent no-op reported as success
+
+An injected click that lands on empty space, off-screen, or on an occluder changes
+nothing, yet "the event was sent" reads as success. Confirm by an observable
+**state delta**: sample state before and after, and only call it success if
+something changed; an empty delta is "no observable effect."
+
+Proven by `mouse_confirm_delta_test.gd`:
+
+- D1/D2 (headless-safe, event-path world target): a hit produces a delta
+  (success); a miss produces none (no observable effect).
+- C1–C3 (windowed, GUI occlusion): hitting a `Button` yields a delta with a
+  positive `gui_get_hovered_control` preflight; empty space hovers null with no
+  delta; an opaque overlay (`mouse_filter = STOP`) over the button is caught by
+  the preflight (`gui_get_hovered_control` returns the overlay) and the occluded
+  click produces no button delta.
+
+---
+
+## Shipped bug fixed in this spike
+
+`MCPGameBridge._handle_execute_input_sequence` began every call with
+`_sequence_events.clear()`. If a prior sequence was still mid-flight (the editor
+side hit its 30s `INPUT_TIMEOUT` and the agent retried, or two calls overlapped),
+any already-fired press whose paired release was still queued had that release
+**dropped** by the clear — latching the action "pressed" in the Input singleton
+with nothing left to release it. The same latent defect gets worse once mouse
+buttons ride this engine (a latched mouse button paints forever).
+
+Fix (small, self-contained): track actions whose press has fired in
+`_held_actions`, and release them — flushed immediately — before clearing the
+queue and on `_exit_tree`. A release is now a guaranteed cleanup, never a queued
+step a clear can drop. Guarded by `input_sequence_stuck_held_test.gd`, which
+drives the real bridge node: it fails on the pre-fix code (action stays latched
+after an overlapping start, and after the node leaves the tree) and passes after.
+
+---
+
+## The reference module
+
+`godot/addons/godot_mcp/test/mcp_input_queue.gd` (`class_name MCPInputQueue`) — a
+standalone `Node`, never wired into the command router and preserved as an
+archived prototype (the mouse feature was decided no-go). It implements the three
+Tier-1 layers in one place:
+
+- One-step-per-frame drain from `_process`, `process_mode = ALWAYS`.
+- Gesture decomposition: `enqueue_move/button/click/drag/action`, each step its
+  own frame; clicks optionally lead with a hover move so a Control registers
+  `mouse_entered` before the press.
+- Held-state registry; `release_all(reason)`; per-input watchdog
+  (`hold_timeout_ms`); `on_disconnect()`; `_exit_tree` release.
+- Signals for observability: `queue_drained`, `released_all_done`,
+  `watchdog_released`, `step_injected`.
+- Bakes in the proven regime rules: both `position` and `global_position` on every
+  event; both `relative` and `screen_relative` on motion; never `warp_mouse`.
+
+When wired in, the bridge would `add_child` one queue, route `godot_input` mouse
+commands to its enqueue API, sample state on `queue_drained` for confirm-by-delta,
+and call `on_disconnect()`/`release_all()` from the debugger session-stopped path
+(mirror `MCPDebuggerPlugin`'s existing cleanup).
+
+---
+
+## Tier 2 — correctness boundary (in progress)
+
+### Resolved: the polled-cursor ceiling is permanent, not a focus artifact
+
+The proven keystone is that on a focused real window injection cannot drive
+`Viewport.get_mouse_position()` (it reflects the physical OS cursor). The open
+hope was that this only held *while the game had focus* — that in the real MCP
+topology (editor focused, game backgrounded) an unfocused game would stop
+receiving physical-cursor updates and let injected motion drive the poll. That
+would have shrunk the ceiling to a hover-only edge case.
+
+`mouse_unfocused_poll_test.gd` settles it: **no.** Dropping the main window's
+focus with a second native window (which flips `window_is_focused(MAIN)` to
+`false` while the main loop keeps ticking), the poll *still* does not follow
+injection — even though an `_input` spy confirms the injected event reached
+root's viewport (ruling out a same-process routing-steal). Deterministic across
+runs; the poll stays pinned to the physical cursor in both focus states. The only
+thing that moves it is `warp_mouse` (banned). So the boundary is firm and
+taxonomic:
+
+- **VISIBLE mode, event path** (`event.position`) → drivable: clicks, world
+  placement, GUI buttons.
+- **VISIBLE mode, polled absolute position** (`get_mouse_position()` in
+  `_process`) → NOT drivable: cursor-follow ghosts, hover previews, poll-based
+  hold-to-paint. `PlacementController.gd:77` is exactly this case — so in our own
+  dogfood game, click-to-place works but the ghost won't follow and drag-paint
+  picks the physical cursor's cell, not ours.
+- **CAPTURED mode, relative** (`.relative`) → drivable (FPS look,
+  `mouse_look_test`); polled absolute position is moot there.
+
+Product consequence: `godot_input` must drive only the event-path/relative
+regimes, confirm by game-state delta (never the cursor), and document the limit.
+A poll-based interaction is reachable only if the game cooperates by reading an
+injectable virtual position — not a general solution, and out of scope for an
+unmodified-game tool.
+
+### Resolved: transform completeness — one rule covers every stretch config
+
+`mouse_transform_completeness_test.gd` proves the recipe generalises beyond the
+`aspect=IGNORE` pure-scale case `mouse_dpi_scale_test` covered. The round-trip
+invariant — to hit canvas pixel `C`, inject `get_final_transform() * C` and the
+event lands on `C` — holds (two points per config, deterministic) under: identity,
+`CANVAS_ITEMS` 2×, `aspect=KEEP` (where `get_final_transform()` carries the
+**letterbox translation offset** — origin `(0,40)` — so the recipe absorbs it for
+free), `content_scale_factor=1.5` (composes into the transform), and
+`mode=VIEWPORT`. So the bridge needs no per-config branching, only
+`get_final_transform()`. Injected `position` is WINDOW-CLIENT space, so OS display
+scaling (window px → physical px) never enters the position calculation; physical
+DPI bites only if a target is read off a raw screenshot (a targeting-input
+concern). The cold-start settle wrinkle `mouse_dpi_scale_test` showed is handled
+by polling `get_final_transform()` until it stabilises before resolving a target —
+the same wait-for-stable pattern the moving-target work needs.
+
+`mouse_multiwindow_routing_test.gd` settles routing: `Input.parse_input_event()`
+drives the MAIN window viewport regardless of OS focus; a secondary `Window` is
+reachable only via *its own* `push_input` (which leaves the global Input
+button/action singletons stale, per `mouse_subviewport_test`). The tool targets
+the main window by default; a secondary window is a distinct, lower-fidelity path.
+
+### Resolved: moving/unstable targets — resolve at fire time, wait-for-stable with a timeout
+
+`mouse_moving_target_test.gd` reproduces CityCamera's rig and lerp speeds
+(`PAN_LERP_SPEED=12`, zoom 8, orbit 10) and uses ray/plane ground-picking as
+ground truth (no physics, runs headless). The decision-relevant numbers:
+
+- A world target's pre-resolved pixel goes stale fast. A 10-unit pan with the click
+  firing 4 frames later lands the resolve-once click **~6 cells** (5.90 world
+  units) off — not a sub-pixel nicety, a wrong-cell bug. Recomputing
+  `unproject_position` at fire time is exact (0.000 off) at every frame of a
+  combined pan+zoom+orbit.
+- `wait-for-stable` (poll the target's projected position until it stops moving by
+  < eps for N consecutive frames) settles promptly when motion stops (~0.3s) AND
+  must carry a timeout: a continuously orbiting camera never settles, so the poll
+  must return "unstable" at a bounded frame count and the tool falls back to
+  resolve-at-fire-time rather than hanging.
+
+So targeting rules for the bridge: resolve `unproject_position` in the frame the
+press fires (never at enqueue); optionally `wait-for-stable` first, always with a
+timeout + unstable fallback. The transform-settle poll from the transform probe is
+the same mechanism.
+
+### Still open
+
+The polled-position keystone must be baked into targeting (decompose drags into
+event-path clicks; never confirm by cursor pos) — now reinforced by the
+focus-independence finding above. This is an implementation discipline for the v1
+feature, not an open research question. **Tier 2 research is complete.**
+
+**Tier 3 — breadth.** Modifiers + `button_mask` on drag-motion events; full button
+set (right/middle/extra/wheel/double-click); cross-platform (all proofs are
+Windows — macOS + Wayland unverified; in-process injection should be the most
+portable path but is unproven off Windows).
+
+**Tier 4 — shipping.** Godot-in-CI for the headless-capable subset; flattened
+(discriminated-union) MCP `inputSchema`; end-to-end dogfood on the real game;
+server+addon stay version-coupled (release-please) so the TS tool never ships
+ahead of the GDScript bridge.
+
+## Sequencing
+
+1. (done) Tier-1 prerequisites: per-frame queue + lifecycle safety + confirm-by-
+   delta, proven with probes; reference module + shipped-bug fix committed.
+2. v1 feature: wire `MCPInputQueue` into the bridge, add the `godot_input` mouse
+   command + thin TS tool, targeting (reuse `onscreen.gd`), confirm-by-delta, a
+   frozen gesture set with click-decomposition baked in.
+3. v2: observe/clickable query, wait-for-stable, remaining transforms,
+   modifiers/wheel/double-click.
+4. v3: cross-platform proofs, CI, determinism (time_scale pin, record/replay).
+
+## Proposed follow-up issues
+
+- feat: wire MCPInputQueue into MCPGameBridge + `godot_input` mouse command (v1).
+- feat: confirm-by-delta on the bridge — sample runtime_state around a gesture,
+  report "no observable effect" on empty delta.
+- feat: pointer targeting via onscreen.gd — world/screen target → event-path
+  clicks, never polled cursor position.
+- test: Tier-2 transform matrix (content_scale_factor, aspect=keep letterbox,
+  stretch=viewport, multi-window).
+- test: cross-platform injection (macOS, Wayland) for the in-process path.
+- ci: Godot-in-CI job running the headless-capable mouse + Tier-1 subset.

--- a/docs/design/mouse-input-spike.md
+++ b/docs/design/mouse-input-spike.md
@@ -12,9 +12,9 @@
 > investigation uncovered.
 
 This document records the research, the findings, and the rationale so the
-question is settled and need not be re-litigated. The detailed probe code and a
-build-oriented design doc live on the archived `test/mouse-injection-fixtures`
-branch (see [Evidence trail](#evidence-trail)).
+question is settled and need not be re-litigated. The build-oriented design doc
+and a keystone subset of the probe scripts are kept in-repo (see
+[Evidence trail](#evidence-trail)).
 
 ---
 
@@ -199,17 +199,26 @@ revisiting if **any** of these appears:
 
 ## Evidence trail
 
-The probes (Godot `SceneTree` scripts, TAP-style) and the build-oriented design doc
-live on the archived `test/mouse-injection-fixtures` branch under
-`godot/addons/godot_mcp/test/` and `docs/design/mouse-injection-spike.md`:
+The build-oriented design doc is at
+[`docs/design/mouse-injection-spike.md`](mouse-injection-spike.md). The spike
+produced 13 Godot `SceneTree` probe scripts (TAP-style); a **keystone subset is
+retained in-repo** under `godot/addons/godot_mcp/test/`, and the rest are recorded
+as findings in this doc and the design writeup rather than kept as files.
 
-- `mouse_pointer_recipe_test`, `mouse_polled_position_test` — the injection recipe
-  and the polled-position keystone.
-- `mouse_unfocused_poll_test` — the keystone is focus-independent.
-- `mouse_dpi_scale_test`, `mouse_transform_completeness_test`,
-  `mouse_multiwindow_routing_test` — targeting transform completeness and routing.
-- `mouse_gui_dispatch_test`, `mouse_subviewport_test`, `mouse_look_test` — GUI
-  dispatch, SubViewport routing, relative mouselook.
-- `mouse_queue_engine_test`, `mouse_lifecycle_safety_test`,
-  `mouse_confirm_delta_test`, `input_sequence_stuck_held_test` — the in-process
-  per-frame queue, lifecycle safety, confirm-by-delta, and the shipped-bug guard.
+Retained as runnable probes:
+
+- `mouse_polled_position_test.gd` — the polled-position keystone, the fact the
+  decision rests on.
+- `mouse_unfocused_poll_test.gd` — that keystone is focus-independent.
+- `mouse_transform_completeness_test.gd` — the targeting transform round-trips
+  under every stretch config.
+- `mouse_queue_engine_test.gd` (with the archived `mcp_input_queue.gd` prototype)
+  — the in-process per-frame sequencing/lifecycle engine.
+- `input_sequence_stuck_held_test.gd` — guard for the stuck-held bug fix
+  (PR [#231](https://github.com/satelliteoflove/godot-mcp/pull/231)), kept
+  regardless of the mouse decision.
+
+Recorded as findings only (scripts not retained): `mouse_pointer_recipe_test`,
+`mouse_dpi_scale_test`, `mouse_multiwindow_routing_test`, `mouse_gui_dispatch_test`,
+`mouse_subviewport_test`, `mouse_look_test`, `mouse_lifecycle_safety_test`,
+`mouse_confirm_delta_test`, `mouse_moving_target_test`.

--- a/godot/addons/godot_mcp/test/README.md
+++ b/godot/addons/godot_mcp/test/README.md
@@ -1,0 +1,51 @@
+# godot_mcp addon — on-demand GDScript tests
+
+These are `SceneTree` scripts (TAP-ish output, exit 0 = pass) that validate engine
+behaviour the addon relies on. **They are not wired into CI** (CI has no Godot).
+Run them on demand against any project that has the addon copied in:
+
+```pwsh
+& "<godot.exe>" [--headless] --path "<project-with-addon>" `
+    --script "res://addons/godot_mcp/test/<file>.gd"
+```
+
+`ObjectDB instances leaked / resources still in use at exit` warnings appear only
+when the host project has autoloads — they come from the host, not the tests, and
+don't affect the pass/fail result. Run against a minimal project for clean output.
+
+Everything in this directory is stripped from the shipped npm addon
+(`server/scripts/copy-addon.ts` drops `test/`), so these are dev-only.
+
+## Mouse-injection spike — retained evidence (godot-mcp #228)
+
+A 2026 research spike asked whether `godot_input` could add comprehensive
+mouse/coordinate input. **It was decided no-go** — injection cannot drive the
+*polled* mouse cursor on a real window without `warp_mouse` (which hijacks the
+developer's physical pointer). The full reasoning, genre support matrix, and
+rationale are in **[`docs/design/mouse-input-spike.md`](../../../../docs/design/mouse-input-spike.md)**
+(the decision) and **[`docs/design/mouse-injection-spike.md`](../../../../docs/design/mouse-injection-spike.md)**
+(the build-oriented writeup).
+
+The spike produced 13 probe scripts. A **keystone subset is retained here** as
+runnable evidence for the load-bearing findings; the rest are recorded as findings
+in the two docs above rather than kept as files. What remains:
+
+| File | What it proves | Run mode |
+|---|---|---|
+| `mouse_polled_position_test.gd` | **The keystone.** Headless, injection drives polled `get_mouse_position()`; on a real window it does **not** (the poll reflects the physical OS cursor). The single fact the no-go decision rests on. | both |
+| `mouse_unfocused_poll_test.gd` | That keystone is **focus-independent**: even with the game window unfocused (the real MCP topology), injected motion that provably reaches the event path still doesn't move the polled cursor. Rules out "it only bites while focused." | windowed |
+| `mouse_transform_completeness_test.gd` | Targeting was never the blocker: `get_final_transform() * C` round-trips to canvas pixel `C` under every stretch config (scale, `content_scale_factor`, `aspect=KEEP` letterbox, `mode=VIEWPORT`). | windowed (headless runs the scale-only subset) |
+| `mouse_queue_engine_test.gd` | The per-frame sequencing/lifecycle engine a real bridge needs: exactly one step drains per frame, press and release land on different ordered frames, `process_mode = ALWAYS` keeps draining while paused. Exercises the archived `mcp_input_queue.gd` prototype. | both (one Button check reported windowed only) |
+
+`mcp_input_queue.gd` in this directory is the archived reference engine that
+`mouse_queue_engine_test.gd` exercises — a prototype that was never wired into the
+bridge (see its header).
+
+### The shipped bug this spike found
+
+One real fix shipped from the investigation (PR #231) and is guarded by a test
+that lives here permanently, independent of the mouse decision:
+
+| File | What it guards | Run mode |
+|---|---|---|
+| `input_sequence_stuck_held_test.gd` | A stuck-held bug in the shipped `MCPGameBridge.execute_input_sequence`: clearing the queue mid-flight dropped already-pressed actions' releases, latching them. Drives the real bridge node; fails pre-fix, passes post-fix. | both |

--- a/godot/addons/godot_mcp/test/mcp_input_queue.gd
+++ b/godot/addons/godot_mcp/test/mcp_input_queue.gd
@@ -1,0 +1,279 @@
+extends Node
+class_name MCPInputQueue
+
+## In-process input sequencing + lifecycle-safety engine for injected mouse/action
+## input (godot-mcp #228, Tier-1 spike). ARCHIVED PROTOTYPE — the reference engine
+## from the mouse-injection spike, exercised by mouse_queue_engine_test.gd in this
+## same directory. It was never wired into MCPGameBridge: the spike concluded
+## against shipping comprehensive mouse input (see
+## docs/design/mouse-input-spike.md), so this is preserved as evidence of the
+## explored design, not live code. Lives under test/ (stripped from the shipped
+## addon) rather than game_bridge/ for that reason.
+##
+## WHY THIS EXISTS — the two Tier-1 risks the injection probes never touched:
+##
+##   1. Per-frame sequencing. The injection probes drove input with
+##      `await SceneTree.process_frame` because the probe script WAS the main
+##      loop. A real bridge is a NODE inside the running game; it cannot await
+##      frames. It must drain a queue ONE event per frame from `_process`.
+##      Draining all due events in a single frame collapses press+release onto
+##      one frame, which corrupts Control hover/press state and any game that
+##      reads a press and its release across frames. So: exactly one step per
+##      frame (`_process` pops one). `process_mode = ALWAYS` so injection — and,
+##      crucially, RELEASES — still flow while the game tree is paused.
+##
+##   2. Lifecycle safety. A press injected without its paired release latches:
+##      `Input.is_mouse_button_pressed()` / `is_action_pressed()` stay true and a
+##      hold-to-paint game paints forever. So every press is tracked in a held
+##      registry, and a release is a `finally`, not a step: `release_all()`
+##      synthesizes the paired release for everything still held and is invoked on
+##      completion, abort, watchdog timeout, MCP/debugger disconnect, and tree
+##      exit.
+##
+## Pointer note (the polled-position keystone, proven separately in
+## mouse_polled_position_test.gd): on a real window `Viewport.get_mouse_position()`
+## reflects the PHYSICAL cursor, not injected events. Pointer gestures must be
+## decomposed into discrete event-path clicks (this engine's one-step-per-frame
+## button/motion events) and confirmed by game-state delta, never by cursor pos.
+
+const DEFAULT_HOLD_TIMEOUT_MS := 10000
+
+## Force-release any single held input still down after this many ms. The
+## last-ditch backstop for a gesture that errored or was abandoned mid-flight
+## without anyone calling release_all(). <= 0 disables the watchdog.
+var hold_timeout_ms := DEFAULT_HOLD_TIMEOUT_MS
+
+# FIFO of pending steps. Each step is { "event": InputEvent }.
+var _queue: Array[Dictionary] = []
+# Held registry: key -> record used to synthesize the paired release.
+#   "mb:<button_index>" -> { kind, button_index, pos, pressed_msec }
+#   "act:<action>"      -> { kind, action, pressed_msec }
+var _held: Dictionary = {}
+
+## Emitted when the queue empties after having had at least one step (the natural
+## end of a gesture — the point at which confirm-by-delta should sample state).
+signal queue_drained
+## Emitted by release_all(): how many held inputs were force-released, and why.
+signal released_all_done(count: int, reason: String)
+## Emitted when the watchdog force-releases a single timed-out held input.
+signal watchdog_released(key: String)
+## Emitted on every injected step (introspection for tests/observability).
+signal step_injected(kind: String, key: String)
+
+
+func _init() -> void:
+	# ALWAYS: keep draining (and releasing) even while get_tree().paused is true.
+	process_mode = Node.PROCESS_MODE_ALWAYS
+
+
+func _exit_tree() -> void:
+	# The "finally": never leave the game with a latched button when the bridge
+	# node leaves the tree (game shutdown / scene change that frees us).
+	release_all("exit_tree")
+
+
+# --- per-frame drain: exactly ONE step per frame ----------------------------
+
+func _process(_delta: float) -> void:
+	_tick_watchdog()
+	if _queue.is_empty():
+		return
+	var step: Dictionary = _queue.pop_front()
+	_inject(step["event"])
+	if _queue.is_empty():
+		queue_drained.emit()
+
+
+# --- enqueue API (gestures decompose into one-event-per-frame steps) ---------
+
+func enqueue_event(ev: InputEvent) -> void:
+	_queue.push_back({"event": ev})
+
+
+func enqueue_move(pos: Vector2, relative := Vector2.ZERO) -> void:
+	var mm := InputEventMouseMotion.new()
+	mm.position = pos
+	mm.global_position = pos
+	# Set both relative and screen_relative (window-space delta) — screen_relative
+	# is never backfilled from relative (proven in mouse_dpi_scale_test.gd).
+	mm.relative = relative
+	mm.screen_relative = relative
+	mm.button_mask = _current_button_mask()
+	_queue.push_back({"event": mm})
+
+
+func enqueue_button(pos: Vector2, button_index: int, pressed: bool) -> void:
+	var mb := InputEventMouseButton.new()
+	mb.button_index = button_index
+	mb.pressed = pressed
+	mb.position = pos
+	mb.global_position = pos
+	# button_mask reflects buttons down AFTER this event resolves.
+	var mask := _current_button_mask()
+	var bit := _mask_bit(button_index)
+	mb.button_mask = (mask | bit) if pressed else (mask & ~bit)
+	_queue.push_back({"event": mb})
+
+
+## A click decomposed into press + release on SEPARATE frames (one-per-frame
+## drain guarantees the gap). Optionally precede with a hover-move so a Control
+## registers mouse_entered before the press.
+func enqueue_click(pos: Vector2, button_index := MOUSE_BUTTON_LEFT, with_hover := true) -> void:
+	if with_hover:
+		enqueue_move(pos)
+	enqueue_button(pos, button_index, true)
+	enqueue_button(pos, button_index, false)
+
+
+## A drag: press at the first point, a move per subsequent point, release at the
+## last. Each is its own frame. `path` must have >= 2 points.
+func enqueue_drag(path: Array, button_index := MOUSE_BUTTON_LEFT) -> void:
+	if path.size() < 2:
+		return
+	enqueue_move(path[0])
+	enqueue_button(path[0], button_index, true)
+	var prev: Vector2 = path[0]
+	for i in range(1, path.size()):
+		var p: Vector2 = path[i]
+		enqueue_move(p, p - prev)
+		prev = p
+	enqueue_button(path[path.size() - 1], button_index, false)
+
+
+func enqueue_action(action: StringName, pressed: bool) -> void:
+	var a := InputEventAction.new()
+	a.action = action
+	a.pressed = pressed
+	a.strength = 1.0 if pressed else 0.0
+	_queue.push_back({"event": a})
+
+
+# --- lifecycle safety -------------------------------------------------------
+
+## Synthesize and inject a release for every input still held, and drop any
+## pending queue. Returns how many inputs were released. Idempotent (0 if none
+## held). This is the panic button and the completion `finally`.
+func release_all(reason := "manual") -> int:
+	_queue.clear()
+	var released := 0
+	for key in _held.keys():
+		var rel := _make_release(_held[key])
+		if rel != null:
+			Input.parse_input_event(rel)
+			released += 1
+	if released > 0:
+		Input.flush_buffered_events()
+	_held.clear()
+	if released > 0:
+		released_all_done.emit(released, reason)
+	return released
+
+
+## Call when the MCP/debugger session ends. Lifecycle `finally` for disconnect.
+func on_disconnect() -> void:
+	release_all("disconnect")
+
+
+func held_count() -> int:
+	return _held.size()
+
+
+func held_keys() -> Array:
+	return _held.keys()
+
+
+func pending_count() -> int:
+	return _queue.size()
+
+
+func is_idle() -> bool:
+	return _queue.is_empty() and _held.is_empty()
+
+
+# --- internals --------------------------------------------------------------
+
+func _inject(ev: InputEvent) -> void:
+	Input.parse_input_event(ev)
+	Input.flush_buffered_events()
+	if ev is InputEventMouseButton:
+		var mb := ev as InputEventMouseButton
+		var key := "mb:%d" % mb.button_index
+		if mb.pressed:
+			_held[key] = {
+				"kind": "mouse_button",
+				"button_index": mb.button_index,
+				"pos": mb.position,
+				"pressed_msec": Time.get_ticks_msec(),
+			}
+		else:
+			_held.erase(key)
+		step_injected.emit("mouse_button", key)
+	elif ev is InputEventAction:
+		var a := ev as InputEventAction
+		var key := "act:%s" % a.action
+		if a.pressed:
+			_held[key] = {
+				"kind": "action",
+				"action": a.action,
+				"pressed_msec": Time.get_ticks_msec(),
+			}
+		else:
+			_held.erase(key)
+		step_injected.emit("action", key)
+	else:
+		step_injected.emit("other", "")
+
+
+func _tick_watchdog() -> void:
+	if hold_timeout_ms <= 0 or _held.is_empty():
+		return
+	var now := Time.get_ticks_msec()
+	var expired: Array = []
+	for key in _held.keys():
+		if now - int(_held[key]["pressed_msec"]) >= hold_timeout_ms:
+			expired.append(key)
+	for key in expired:
+		var rel := _make_release(_held[key])
+		if rel != null:
+			Input.parse_input_event(rel)
+			Input.flush_buffered_events()
+		_held.erase(key)
+		watchdog_released.emit(key)
+
+
+func _make_release(h: Dictionary) -> InputEvent:
+	match h["kind"]:
+		"mouse_button":
+			var mb := InputEventMouseButton.new()
+			mb.button_index = h["button_index"]
+			mb.pressed = false
+			mb.button_mask = 0
+			mb.position = h.get("pos", Vector2.ZERO)
+			mb.global_position = mb.position
+			return mb
+		"action":
+			var a := InputEventAction.new()
+			a.action = h["action"]
+			a.pressed = false
+			a.strength = 0.0
+			return a
+	return null
+
+
+func _current_button_mask() -> int:
+	var mask := 0
+	for key in _held:
+		if _held[key]["kind"] == "mouse_button":
+			mask |= _mask_bit(_held[key]["button_index"])
+	return mask
+
+
+func _mask_bit(button_index: int) -> int:
+	match button_index:
+		MOUSE_BUTTON_LEFT:
+			return MOUSE_BUTTON_MASK_LEFT
+		MOUSE_BUTTON_RIGHT:
+			return MOUSE_BUTTON_MASK_RIGHT
+		MOUSE_BUTTON_MIDDLE:
+			return MOUSE_BUTTON_MASK_MIDDLE
+	return 0

--- a/godot/addons/godot_mcp/test/mcp_input_queue.gd.uid
+++ b/godot/addons/godot_mcp/test/mcp_input_queue.gd.uid
@@ -1,0 +1,1 @@
+uid://dceugy6c528fa

--- a/godot/addons/godot_mcp/test/mouse_polled_position_test.gd
+++ b/godot/addons/godot_mcp/test/mouse_polled_position_test.gd
@@ -1,0 +1,119 @@
+extends SceneTree
+
+## Polled-position regression guard for injected mouse input (godot-mcp #228).
+##
+## THE KEYSTONE FACT, and the one most likely to be mis-assumed: whether
+## Input.parse_input_event() drives the POLLED Viewport.get_mouse_position()
+## depends on the DisplayServer, and the two answers are OPPOSITE:
+##
+##   - headless: injection updates the polled value (no OS cursor exists, so the
+##     event-updated cache is all there is). This is why the original pointer
+##     probe passed 10/10 headless.
+##   - real window (Windows/X11/etc.): the ROOT window viewport's
+##     get_mouse_position() live-reflects the PHYSICAL OS cursor; injection does
+##     NOT move it. The EVENT PATH (event.position in _input/_unhandled_input) is
+##     still faithful. So games that POLL get_mouse_position() (hover previews,
+##     poll-based hold-to-paint) follow the real mouse and are NOT drivable by
+##     injection — drive them through discrete event-path clicks instead, and
+##     never assume the visual cursor reflects the injection. (warp_mouse would
+##     move the polled value but hijacks the developer's real cursor — refused.)
+##
+## This test asserts BOTH halves so either one regressing fails loudly. The
+## windowed half assumes the physical mouse is HELD STILL during the run (an
+## automated invocation): it asserts injection leaves the polled value unchanged.
+##
+## Not wired into CI (CI has no Godot). Run on demand, BOTH ways:
+##   & "<godot.exe>"            --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/mouse_polled_position_test.gd"   # windowed half
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/mouse_polled_position_test.gd"   # headless half
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+var _count := 0
+var _failures := 0
+var _evt_pos := Vector2(-1, -1)   # last position seen on the EVENT path
+
+
+class EvtSpy extends Node:
+	var owner_test
+	func _unhandled_input(event: InputEvent) -> void:
+		if event is InputEventMouseMotion:
+			owner_test._evt_pos = (event as InputEventMouseMotion).position
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _approx(a: Vector2, b: Vector2) -> bool:
+	return a.distance_to(b) < 2.0
+
+
+func _inject(p: Vector2) -> void:
+	var mm := InputEventMouseMotion.new()
+	mm.position = p
+	mm.global_position = p
+	Input.parse_input_event(mm)
+	Input.flush_buffered_events()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n===================== MOUSE POLLED-POSITION TEST =====================\n")
+	var dsname := DisplayServer.get_name()
+	print("DisplayServer name: %s" % dsname)
+	print("NOTE: windowed run assumes the physical mouse is NOT moved during it.")
+
+	var spy := EvtSpy.new()
+	spy.owner_test = self
+	root.add_child(spy)
+	for i in 3:
+		await process_frame
+
+	var r_before := root.get_mouse_position()
+	_data("get_mouse_position() before any injection", str(r_before))
+
+	# Inject, then read the polled value with ZERO awaits (no frame boundary for an
+	# OS event to intervene) — the tightest possible test of the cache.
+	var target := Vector2(320, 180)
+	_inject(target)
+	var r_immediate := root.get_mouse_position()
+	_data("injected position", str(target))
+	_data("event-path position (authoritative)", str(_evt_pos))
+	_data("get_mouse_position() immediately after flush", str(r_immediate))
+
+	# The event path is faithful on EVERY platform — this is the proven invariant.
+	_check("event path carries the injected position", _approx(_evt_pos, target), true)
+
+	if dsname == "headless":
+		_check("headless: injected motion DRIVES polled get_mouse_position()",
+			_approx(r_immediate, target), true)
+	else:
+		# Real DisplayServer: polled value reflects the physical cursor, unchanged
+		# by injection, and is NOT the injected target.
+		_check("windowed: injection does NOT change polled get_mouse_position()",
+			_approx(r_immediate, r_before), true)
+		_check("windowed: polled get_mouse_position() is NOT the injected target",
+			_approx(r_immediate, target), false)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+func _data(label: String, value: Variant) -> void:
+	print("   . %s = %s" % [label, str(value)])

--- a/godot/addons/godot_mcp/test/mouse_polled_position_test.gd.uid
+++ b/godot/addons/godot_mcp/test/mouse_polled_position_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bb7dwr8spikrx

--- a/godot/addons/godot_mcp/test/mouse_queue_engine_test.gd
+++ b/godot/addons/godot_mcp/test/mouse_queue_engine_test.gd
@@ -1,0 +1,262 @@
+extends SceneTree
+
+## Per-frame queue-engine guard for injected input (godot-mcp #228, Tier-1).
+##
+## Validates MCPInputQueue — the in-process sequencing engine a real bridge needs
+## because, unlike the injection probes, a bridge NODE cannot `await` frames; it
+## must drain a queue ONE event per frame from `_process`. This test adds the
+## queue as a child of `root` and lets the SceneTree tick it for real (a child
+## Node DOES get per-frame _process even though this script is the main loop —
+## that foundational fact is what makes the whole approach work).
+##
+## Guards:
+##   Q1  exactly one step drains per frame (never two collapsed onto one frame)
+##   Q2  a click's press and release land on DIFFERENT, ordered frames
+##   Q3  process_mode = ALWAYS keeps the queue draining while the tree is paused
+##   Q4  (windowed, REPORTED) frame-stepped vs same-frame on a plain Button —
+##       it turns out BOTH fire pressed once, so a discrete Button click is NOT
+##       why frame separation matters
+##   Q5  the real reason: a hold/duration consumer (poll of
+##       Input.is_mouse_button_pressed, i.e. hold-to-paint) only ever observes a
+##       button as held if press and release are on different frames; a same-frame
+##       press+release is a zero-duration hold it never sees
+##
+## Not wired into CI (CI has no Godot). Run on demand:
+##   & "<godot.exe>" [--headless] --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/mouse_queue_engine_test.gd"
+## Q1-Q3 pass headless and windowed; Q4 only reports under a real DisplayServer.
+## Exit code 0 = all asserted checks passed, 1 = at least one failed.
+
+const InputQueue := preload("res://addons/godot_mcp/test/mcp_input_queue.gd")
+
+var _count := 0
+var _failures := 0
+
+
+class MouseSpy extends Node:
+	var press_frame := -1
+	var release_frame := -1
+	var move_frames: Array = []
+	func _unhandled_input(e: InputEvent) -> void:
+		if e is InputEventMouseButton:
+			if (e as InputEventMouseButton).pressed:
+				press_frame = Engine.get_process_frames()
+			else:
+				release_frame = Engine.get_process_frames()
+		elif e is InputEventMouseMotion:
+			move_frames.append(Engine.get_process_frames())
+
+
+class HoldPoller extends Node:
+	# Mimics a hold-to-paint loop: counts frames the LEFT button is polled as down.
+	var down_frames := 0
+	func _process(_d: float) -> void:
+		if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
+			down_frames += 1
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n===================== MOUSE QUEUE-ENGINE TEST =====================\n")
+	print("DisplayServer name: %s" % DisplayServer.get_name())
+
+	var q = InputQueue.new()
+	q.hold_timeout_ms = 0  # disable watchdog for these timing tests
+	root.add_child(q)
+	var spy := MouseSpy.new()
+	root.add_child(spy)
+	for i in 3:
+		await process_frame
+
+	await _q1_one_per_frame(q)
+	await _q2_press_release_separate_frames(q, spy)
+	await _q3_drains_while_paused(q)
+	await _q4_button_state_machine(q)
+	await _q5_hold_requires_frame_separation(q)
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+# Q1 — enqueue several events, sample pending_count() once per frame, assert the
+# count never drops by more than 1 in a single frame (i.e. one step per frame)
+# and reaches zero.
+func _q1_one_per_frame(q) -> void:
+	for p in [Vector2(10, 10), Vector2(20, 20), Vector2(30, 30), Vector2(40, 40)]:
+		q.enqueue_move(p)
+	var seq: Array = [q.pending_count()]
+	for i in 7:
+		await process_frame
+		seq.append(q.pending_count())
+	_data("pending_count per frame", str(seq))
+
+	var max_drop := 0
+	for i in range(1, seq.size()):
+		max_drop = max(max_drop, int(seq[i - 1]) - int(seq[i]))
+	_check("Q1 never drains more than ONE step per frame", max_drop <= 1, true)
+	_check("Q1 queue fully drains to zero", int(seq[seq.size() - 1]) == 0, true)
+
+
+# Q2 — a decomposed click (hover move, press, release) must put press and release
+# on different, ordered frames. This is the property that keeps a press and its
+# release from colliding on one frame.
+func _q2_press_release_separate_frames(q, spy) -> void:
+	spy.press_frame = -1
+	spy.release_frame = -1
+	spy.move_frames = []
+	q.enqueue_click(Vector2(100, 100), MOUSE_BUTTON_LEFT, true)
+	# Drain: hover + press + release = 3 steps; give margin.
+	for i in 6:
+		await process_frame
+	_data("move/press/release frames", "moves=%s press=%d release=%d"
+		% [str(spy.move_frames), spy.press_frame, spy.release_frame])
+	_check("Q2 press was delivered", spy.press_frame >= 0, true)
+	_check("Q2 release was delivered", spy.release_frame >= 0, true)
+	_check("Q2 press and release on DIFFERENT frames",
+		spy.press_frame != spy.release_frame, true)
+	_check("Q2 release strictly after press",
+		spy.release_frame > spy.press_frame, true)
+	_check("Q2 left button not left held after click", q.held_count() == 0, true)
+
+
+# Q3 — pause the tree; the ALWAYS-mode queue must keep draining (so a pending
+# release never gets stuck behind a pause).
+func _q3_drains_while_paused(q) -> void:
+	paused = true
+	for p in [Vector2(5, 5), Vector2(6, 6), Vector2(7, 7)]:
+		q.enqueue_move(p)
+	for i in 6:
+		await process_frame
+	var drained_while_paused: bool = q.pending_count() == 0
+	paused = false
+	_check("Q3 queue drains while tree is PAUSED (process_mode ALWAYS)",
+		drained_while_paused, true)
+
+
+# Q4 — REPORTED only (needs a real DisplayServer for GUI picking). Drives a real
+# Button two ways and prints the press-count each yields, so the design doc can
+# cite why frame separation matters.
+func _q4_button_state_machine(q) -> void:
+	if DisplayServer.get_name() == "headless":
+		_data("Q4 button state-machine", "skipped (headless stubs GUI picking)")
+		return
+
+	var layer := Control.new()
+	layer.set_anchors_preset(Control.PRESET_FULL_RECT)
+	root.add_child(layer)
+	var btn := Button.new()
+	btn.position = Vector2(200, 200)
+	btn.size = Vector2(160, 60)
+	btn.action_mode = BaseButton.ACTION_MODE_BUTTON_RELEASE
+	layer.add_child(btn)
+	var presses := [0]
+	btn.pressed.connect(func() -> void: presses[0] += 1)
+	for i in 3:
+		await process_frame
+	var center := btn.get_global_rect().get_center()
+
+	# Path A: frame-stepped via the queue (hover, press, release on separate frames)
+	presses[0] = 0
+	q.enqueue_click(center, MOUSE_BUTTON_LEFT, true)
+	for i in 6:
+		await process_frame
+	var stepped_presses: int = presses[0]
+
+	# Path B: press + release injected in the SAME frame (no queue, no frame gap)
+	presses[0] = 0
+	var down := InputEventMouseButton.new()
+	down.button_index = MOUSE_BUTTON_LEFT
+	down.pressed = true
+	down.position = center
+	down.global_position = center
+	down.button_mask = MOUSE_BUTTON_MASK_LEFT
+	var up := InputEventMouseButton.new()
+	up.button_index = MOUSE_BUTTON_LEFT
+	up.pressed = false
+	up.position = center
+	up.global_position = center
+	Input.parse_input_event(down)
+	Input.parse_input_event(up)
+	Input.flush_buffered_events()
+	for i in 3:
+		await process_frame
+	var samef_presses: int = presses[0]
+
+	_data("Q4 Button.pressed count", "frame-stepped(queue)=%d  same-frame=%d"
+		% [stepped_presses, samef_presses])
+	# Frame-stepped is the supported path and MUST work; assert that half only.
+	_check("Q4 frame-stepped click fires Button.pressed exactly once",
+		stepped_presses == 1, true)
+	btn.queue_free()
+	layer.queue_free()
+
+
+# Q5 — the concrete reason frame separation matters: a hold/duration consumer.
+# Frame-stepped: the button stays down across frames, so a polling hold-to-paint
+# loop observes it held. Same-frame press+release: a zero-duration hold the poller
+# NEVER sees. (Button state via Input.is_mouse_button_pressed is drivable on every
+# platform — unlike polled cursor POSITION — so this runs headless too.)
+func _q5_hold_requires_frame_separation(q) -> void:
+	var poller := HoldPoller.new()
+	root.add_child(poller)
+	await process_frame
+
+	# Frame-stepped hold via the queue: press, two moves while held, release.
+	poller.down_frames = 0
+	q.enqueue_button(Vector2(120, 120), MOUSE_BUTTON_LEFT, true)
+	q.enqueue_move(Vector2(121, 121))
+	q.enqueue_move(Vector2(122, 122))
+	q.enqueue_button(Vector2(122, 122), MOUSE_BUTTON_LEFT, false)
+	for i in 8:
+		await process_frame
+	var stepped_down: int = poller.down_frames
+
+	# Same-frame press+release: both injected before any _process poll sees it.
+	poller.down_frames = 0
+	var d := InputEventMouseButton.new()
+	d.button_index = MOUSE_BUTTON_LEFT
+	d.pressed = true
+	d.position = Vector2(120, 120)
+	d.global_position = d.position
+	d.button_mask = MOUSE_BUTTON_MASK_LEFT
+	var u := InputEventMouseButton.new()
+	u.button_index = MOUSE_BUTTON_LEFT
+	u.pressed = false
+	u.position = Vector2(120, 120)
+	u.global_position = u.position
+	Input.parse_input_event(d)
+	Input.parse_input_event(u)
+	Input.flush_buffered_events()
+	for i in 4:
+		await process_frame
+	var samef_down: int = poller.down_frames
+
+	_data("hold poller down-frames", "frame-stepped=%d  same-frame=%d"
+		% [stepped_down, samef_down])
+	_check("Q5 frame-stepped hold is observed down across >=1 frame", stepped_down >= 1, true)
+	_check("Q5 same-frame press+release is NEVER observed as held", samef_down == 0, true)
+	_check("Q5 nothing left held after both", q.held_count() == 0, true)
+	poller.queue_free()
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+func _data(label: String, value: Variant) -> void:
+	print("   . %s = %s" % [label, str(value)])

--- a/godot/addons/godot_mcp/test/mouse_queue_engine_test.gd.uid
+++ b/godot/addons/godot_mcp/test/mouse_queue_engine_test.gd.uid
@@ -1,0 +1,1 @@
+uid://di1apdeqqy815

--- a/godot/addons/godot_mcp/test/mouse_transform_completeness_test.gd
+++ b/godot/addons/godot_mcp/test/mouse_transform_completeness_test.gd
@@ -1,0 +1,202 @@
+extends SceneTree
+
+## Tier-2 probe (godot-mcp #228): is get_final_transform() a COMPLETE description
+## of the window<->canvas mapping for injected mouse input, across every stretch
+## configuration — not just the aspect=IGNORE pure-scale case the existing
+## mouse_dpi_scale_test proved?
+##
+## WHY IT MATTERS. The bridge targets a CANVAS pixel (e.g. Camera.unproject_position
+## of a world cell, or a Control's global rect centre) and must inject a WINDOW-space
+## position so the event LANDS on that pixel. The proven recipe is: inject
+## get_final_transform() * C_canvas. mouse_dpi_scale_test verified that under
+## CANVAS_ITEMS + ASPECT_IGNORE (pure scale, ZERO offset). The untested configs each
+## add something that case lacks:
+##   - aspect=KEEP -> a LETTERBOX TRANSLATION OFFSET (non-zero transform origin)
+##   - content_scale_factor != 1 -> an extra multiplier
+##   - stretch mode=VIEWPORT -> a different input mapping path
+## If get_final_transform() fails to capture any of these, the forward-transform
+## SILENTLY misses and every click lands on the wrong cell. This probe tests the
+## real bridge op as a ROUND-TRIP INVARIANT across a config matrix:
+##   pick C_canvas -> inject get_final_transform()*C -> assert event arrives at C.
+## Two canvas points per config separate a scale error from an offset error; each
+## config also asserts a precondition (it actually created the transform feature it
+## claims to test, so no config passes vacuously). A wait-for-stable on the
+## transform kills the cold-start settle flake mouse_dpi_scale_test exhibited.
+##
+## WINDOWED — letterbox/viewport need a real window. Headless runs the scale-only
+## subset (the rest are skipped + reported).
+##   & "<godot.exe>" --path "<city-builder>" \
+##       --script "res://addons/godot_mcp/test/mouse_transform_completeness_test.gd"
+## Exit 0 = all checks passed, 1 = at least one failed.
+
+var _count := 0
+var _failures := 0
+
+
+class Probe extends Node:
+	var last_position := Vector2(-9999, -9999)
+	func _unhandled_input(event: InputEvent) -> void:
+		if event is InputEventMouseMotion:
+			last_position = (event as InputEventMouseMotion).position
+
+
+var _probe: Probe
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _approx(a: Vector2, b: Vector2, eps := 2.5) -> bool:
+	# canvas-space tolerance; a sub-1x inverse magnifies window jitter, so allow a
+	# little proportional slack.
+	return a.distance_to(b) <= maxf(eps, b.length() * 0.002)
+
+
+func _inject(pos: Vector2) -> void:
+	var mm := InputEventMouseMotion.new()
+	mm.position = pos
+	mm.global_position = pos
+	Input.parse_input_event(mm)
+	Input.flush_buffered_events()
+
+
+# Poll get_final_transform() until it stops changing (the settle the dpi test
+# lacked), or a frame budget elapses.
+func _settle_transform() -> Transform2D:
+	var prev := root.get_final_transform()
+	for i in 60:
+		await process_frame
+		var cur := root.get_final_transform()
+		if cur.is_equal_approx(prev):
+			return cur
+		prev = cur
+	return prev
+
+
+func _reset_to_identity() -> void:
+	root.content_scale_mode = Window.CONTENT_SCALE_MODE_DISABLED
+	root.content_scale_aspect = Window.CONTENT_SCALE_ASPECT_IGNORE
+	root.content_scale_factor = 1.0
+	root.content_scale_size = Vector2i(0, 0)
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n================= TRANSFORM COMPLETENESS PROBE =================\n")
+	var ds := DisplayServer.get_name()
+	print("DisplayServer: %s" % ds)
+	var windowed := ds != "headless"
+	print("OS DPI diagnostics: screen_get_scale=%s  screen_dpi=%d" % [
+		str(DisplayServer.screen_get_scale()), DisplayServer.screen_get_dpi()])
+	print("(injected position is WINDOW-client space, so OS display scaling — which maps")
+	print(" window px -> physical px — does NOT enter the position calculation.)\n")
+
+	_probe = Probe.new()
+	root.add_child(_probe)
+
+	# name, mode, aspect, size, factor, win, needs_window, precondition tag
+	var configs := [
+		{"name": "identity (DISABLED)", "mode": Window.CONTENT_SCALE_MODE_DISABLED,
+			"aspect": Window.CONTENT_SCALE_ASPECT_IGNORE, "size": Vector2i(0, 0),
+			"factor": 1.0, "win": Vector2i(1280, 720), "needs_window": false, "pre": "identity"},
+		{"name": "canvas_items IGNORE 2x", "mode": Window.CONTENT_SCALE_MODE_CANVAS_ITEMS,
+			"aspect": Window.CONTENT_SCALE_ASPECT_IGNORE, "size": Vector2i(640, 360),
+			"factor": 1.0, "win": Vector2i(1280, 720), "needs_window": false, "pre": "scale"},
+		{"name": "canvas_items KEEP letterbox", "mode": Window.CONTENT_SCALE_MODE_CANVAS_ITEMS,
+			"aspect": Window.CONTENT_SCALE_ASPECT_KEEP, "size": Vector2i(640, 360),
+			"factor": 1.0, "win": Vector2i(1280, 800), "needs_window": true, "pre": "offset"},
+		{"name": "canvas_items factor 1.5", "mode": Window.CONTENT_SCALE_MODE_CANVAS_ITEMS,
+			"aspect": Window.CONTENT_SCALE_ASPECT_IGNORE, "size": Vector2i(640, 360),
+			"factor": 1.5, "win": Vector2i(1280, 720), "needs_window": true, "pre": "scale"},
+		{"name": "VIEWPORT mode 2x", "mode": Window.CONTENT_SCALE_MODE_VIEWPORT,
+			"aspect": Window.CONTENT_SCALE_ASPECT_IGNORE, "size": Vector2i(640, 360),
+			"factor": 1.0, "win": Vector2i(1280, 720), "needs_window": true, "pre": "scale"},
+	]
+
+	for cfg in configs:
+		await _run_config(cfg, windowed)
+
+	_reset_to_identity()
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _run_config(cfg: Dictionary, windowed: bool) -> void:
+	print("\n--- config: %s ---" % cfg["name"])
+	if cfg["needs_window"] and not windowed:
+		print("   . skipped (needs a real window; headless can't letterbox/viewport)")
+		return
+
+	_reset_to_identity()
+	for i in 4:
+		await process_frame
+
+	if windowed:
+		root.size = cfg["win"]
+	root.content_scale_mode = cfg["mode"]
+	root.content_scale_aspect = cfg["aspect"]
+	root.content_scale_size = cfg["size"]
+	root.content_scale_factor = cfg["factor"]
+
+	var fxform := await _settle_transform()
+	var inv := fxform.affine_inverse()
+	_data("get_final_transform()", str(fxform))
+	_data("scale / origin", "%s / %s" % [str(fxform.get_scale()), str(fxform.get_origin())])
+
+	# Precondition: this config actually built the feature it claims to test.
+	match cfg["pre"]:
+		"identity":
+			_check("[%s] transform is ~identity" % cfg["name"],
+				fxform.is_equal_approx(Transform2D.IDENTITY), true)
+		"scale":
+			_check("[%s] a non-identity SCALE is in effect" % cfg["name"],
+				absf(fxform.get_scale().x - 1.0) > 0.05, true)
+		"offset":
+			# The whole point of the letterbox case: a NON-ZERO translation offset.
+			_check("[%s] a non-zero letterbox OFFSET is in effect" % cfg["name"],
+				fxform.get_origin().length() > 1.0, true)
+
+	# The canvas extent we can safely aim inside (the logical/visible canvas).
+	var extent := Vector2(cfg["size"]) if cfg["size"] != Vector2i(0, 0) else Vector2(cfg["win"])
+	# Two interior canvas targets: separates a scale error from an offset error.
+	var targets := [extent * 0.4, extent * 0.6]
+	for c in targets:
+		await _assert_roundtrip(cfg["name"], fxform, inv, c)
+
+
+# THE bridge invariant: to hit canvas target C, inject get_final_transform()*C and
+# the event must arrive at C.
+func _assert_roundtrip(name: String, fxform: Transform2D, inv: Transform2D, c_canvas: Vector2) -> void:
+	var inject_win := fxform * c_canvas
+	_probe.last_position = Vector2(-9999, -9999)
+	_inject(inject_win)
+	await process_frame
+	var got := _probe.last_position
+	_data("canvas target %s -> inject window %s -> event %s" % [
+		str(c_canvas), str(inject_win), str(got)], "")
+	_check("[%s] forward-transformed click LANDS on canvas target %s" % [name, str(c_canvas)],
+		_approx(got, c_canvas), true)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+func _data(label: String, value: Variant) -> void:
+	if str(value) == "":
+		print("   . %s" % label)
+	else:
+		print("   . %s = %s" % [label, str(value)])

--- a/godot/addons/godot_mcp/test/mouse_transform_completeness_test.gd.uid
+++ b/godot/addons/godot_mcp/test/mouse_transform_completeness_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b3r5a4vc7iq7b

--- a/godot/addons/godot_mcp/test/mouse_unfocused_poll_test.gd
+++ b/godot/addons/godot_mcp/test/mouse_unfocused_poll_test.gd
@@ -1,0 +1,198 @@
+extends SceneTree
+
+## Tier-2 probe (godot-mcp #228): does the POLLED Viewport.get_mouse_position() —
+## the exact value PlacementController.gd:77 reads to position the placement ghost
+## and to pick the hold-to-paint cell — follow injected mouse motion when the game
+## window is UNFOCUSED? That is the real MCP topology: the editor (or any other
+## app) holds OS focus while the game runs in the background and the in-process
+## bridge injects into the game's own Input singleton.
+##
+## WHY IT MATTERS. The proven keystone (mouse_polled_position_test) is that on a
+## FOCUSED real window the poll live-reflects the physical OS cursor and injection
+## does NOT move it. That bounds "robust mouse support": event-path clicks work,
+## but cursor-follow / hover-preview / poll-based hold-to-paint do not. The open
+## question is whether that ceiling is PERMANENT or only holds while the game
+## window has focus. If an unfocused window stops receiving physical-cursor
+## updates, the injected motion may be the only thing left driving the poll — and
+## the ceiling collapses to a hover-only edge case.
+##
+## METHOD. Drop the main window's focus with a second NATIVE window (empirically
+## flips window_is_focused(MAIN)->false while the main loop keeps ticking). In each
+## focus state inject TWO distinct motions and ask: does the POLL DELTA track the
+## EVENT-PATH DELTA? Comparing deltas (not absolute positions) is scale-invariant
+## (cancels content-scale) and robust against wherever the physical cursor sits. An
+## _input spy on root confirms the injected event actually REACHED root's viewport;
+## if it did not (a same-process sibling stole routing — impossible cross-process),
+## the unfocused result is flagged INCONCLUSIVE rather than mis-read as "undrivable".
+##
+## WINDOWED ONLY — focus is meaningless headless (and headless poll is trivially
+## driven; that baseline is already guarded by mouse_polled_position_test).
+##   & "<godot.exe>" --path "<city-builder>" \
+##       --script "res://addons/godot_mcp/test/mouse_unfocused_poll_test.gd"
+## Exit 0 = ran and reached a DEFINITIVE answer (either ceiling outcome);
+## Exit 1 = a measurement invariant broke, or the unfocused result was inconclusive.
+
+var _count := 0
+var _failures := 0
+var _evt_pos := Vector2(-1, -1)   # last motion position seen on root's event path
+
+
+class EvtSpy extends Node:
+	var owner_test
+	func _input(event: InputEvent) -> void:
+		if event is InputEventMouseMotion:
+			owner_test._evt_pos = (event as InputEventMouseMotion).position
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _approx(a: Vector2, b: Vector2, eps := 3.0) -> bool:
+	return a.distance_to(b) < eps
+
+
+func _inject(p: Vector2) -> void:
+	var mm := InputEventMouseMotion.new()
+	mm.position = p
+	mm.global_position = p
+	Input.parse_input_event(mm)
+	Input.flush_buffered_events()
+
+
+# Inject two distinct motions; return poll + event-path readings for each so the
+# caller can compare DELTAS (scale-invariant, physical-cursor-independent).
+func _two_point(a: Vector2, b: Vector2) -> Dictionary:
+	_inject(a)
+	await process_frame
+	var poll_a := root.get_mouse_position()
+	var evt_a := _evt_pos
+	_inject(b)
+	await process_frame
+	var poll_b := root.get_mouse_position()
+	var evt_b := _evt_pos
+	# settle read: did the OS reassert the cursor a few frames later?
+	for i in 5:
+		await process_frame
+	var poll_settle := root.get_mouse_position()
+	return {
+		"poll_delta": poll_b - poll_a,
+		"evt_delta": evt_b - evt_a,
+		"poll_a": poll_a, "poll_b": poll_b,
+		"evt_a": evt_a, "evt_b": evt_b,
+		"poll_settle": poll_settle,
+	}
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n================= UNFOCUSED POLLED-POSITION PROBE =================\n")
+	var ds := DisplayServer.get_name()
+	print("DisplayServer: %s" % ds)
+	if ds == "headless":
+		print("Headless has no OS focus and drives the poll trivially — run WINDOWED.")
+		print("(baseline guarded by mouse_polled_position_test). Skipping.")
+		quit(0)
+		return
+	print("NOTE: assumes the physical mouse is NOT moved during the run.")
+
+	var main := DisplayServer.MAIN_WINDOW_ID
+	root.gui_embed_subwindows = false  # so the focus-stealer is a real OS window
+
+	var spy := EvtSpy.new()
+	spy.owner_test = self
+	root.add_child(spy)
+
+	DisplayServer.window_move_to_foreground(main)
+	for i in 10:
+		await process_frame
+	_check("precondition: main window starts FOCUSED", DisplayServer.window_is_focused(main), true)
+
+	# ---------- Phase 1: FOCUSED ----------
+	print("\n[FOCUSED] inject two motions, compare poll-delta vs event-delta")
+	var f = await _two_point(Vector2(160, 140), Vector2(520, 420))
+	_dump("focused", f)
+	var f_events_arrived: bool = (f["evt_delta"] as Vector2).length() > 50.0
+	_check("FOCUSED: injected events reached root's event path", f_events_arrived, true)
+	var f_poll_driven: bool = f_events_arrived and _approx(f["poll_delta"], f["evt_delta"])
+	_check("FOCUSED: poll does NOT track injection (proven keystone)", f_poll_driven, false)
+
+	# ---------- Phase 2: UNFOCUSED ----------
+	print("\n[UNFOCUSED] spawn a second native window to steal focus, then re-measure")
+	var stealer := Window.new()
+	stealer.title = "focus-stealer"
+	stealer.size = Vector2i(240, 160)
+	stealer.position = Vector2i(40, 40)
+	root.add_child(stealer)
+	stealer.show()
+	for i in 5:
+		await process_frame
+	stealer.grab_focus()
+	for i in 10:
+		await process_frame
+
+	var dropped := not DisplayServer.window_is_focused(main)
+	_check("precondition: main window is now UNFOCUSED", dropped, true)
+
+	if not dropped:
+		print("Could not drop focus — cannot answer. INCONCLUSIVE.")
+		_failures += 1
+	else:
+		var u = await _two_point(Vector2(180, 160), Vector2(560, 460))
+		_dump("unfocused", u)
+		var u_events_arrived: bool = (u["evt_delta"] as Vector2).length() > 50.0
+		var u_poll_driven: bool = u_events_arrived and _approx(u["poll_delta"], u["evt_delta"])
+
+		print("\n---------------------------- VERDICT ----------------------------")
+		if not u_events_arrived:
+			# Injected event never reached root while unfocused: in THIS single
+			# process a focused sibling window may have stolen routing. That cannot
+			# happen across processes, so this is inconclusive, not a "no".
+			print("INCONCLUSIVE — injected motion did not reach root's event path while")
+			print("unfocused (a same-process sibling window likely stole routing).")
+			print("Needs a TWO-PROCESS test (editor focused, game backgrounded).")
+			_failures += 1
+		elif u_poll_driven:
+			print("*** CEILING COLLAPSES ***")
+			print("Unfocused, injection DRIVES the polled get_mouse_position(): the")
+			print("placement ghost and poll-based hold-to-paint ARE drivable in the")
+			print("real MCP topology. The keystone limit is a focused-window-only,")
+			print("human-actively-hovering edge case.")
+		else:
+			print("*** CEILING STANDS ***")
+			print("Even unfocused, the event reached root but the poll IGNORED it:")
+			print("get_mouse_position() does not follow injection on a real window.")
+			print("Cursor-follow / hover-preview / poll-based hold-to-paint remain")
+			print("undrivable; drive only event-path interactions and confirm by")
+			print("game-state delta, never by the polled cursor.")
+		print("-----------------------------------------------------------------")
+
+	if is_instance_valid(stealer):
+		stealer.queue_free()
+	for i in 5:
+		await process_frame
+
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks, definitive answer reached" % _count)
+	else:
+		printerr("FAILED/INCONCLUSIVE — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _dump(tag: String, r: Dictionary) -> void:
+	print("   . %s poll:  a=%s b=%s  delta=%s  settle=%s" % [
+		tag, str(r["poll_a"]), str(r["poll_b"]), str(r["poll_delta"]), str(r["poll_settle"])])
+	print("   . %s event: a=%s b=%s  delta=%s" % [
+		tag, str(r["evt_a"]), str(r["evt_b"]), str(r["evt_delta"])])
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/godot/addons/godot_mcp/test/mouse_unfocused_poll_test.gd.uid
+++ b/godot/addons/godot_mcp/test/mouse_unfocused_poll_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b7dimapuo6ft7


### PR DESCRIPTION
## Summary

The `mouse-input-spike.md` decision doc cited the `test/mouse-injection-fixtures` branch as its evidence trail. A branch is a fragile anchor for permanent documentation — it's mutable and exactly what branch-cleanup sweeps delete. This moves the load-bearing evidence into `main` and de-references the branch, so it can be retired with no dangling reference.

## What moved into main

- **Design writeup** → `docs/design/mouse-injection-spike.md` (the build-oriented companion to the already-merged decision doc), with an archival preamble clarifying it records the full 13-probe suite by findings while only a keystone subset of scripts is retained.
- **Keystone probe scripts** → `godot/addons/godot_mcp/test/`: `mouse_polled_position_test.gd` (the keystone the no-go decision rests on), `mouse_unfocused_poll_test.gd` (focus-independence), `mouse_transform_completeness_test.gd` (targeting), `mouse_queue_engine_test.gd` (the sequencing/lifecycle engine).
- **The prototype `mcp_input_queue.gd`** the queue test depends on — placed under `test/` (stripped from the shipped npm addon), **not** `game_bridge/`, since it was never wired into the bridge and shouldn't ship to consumers. Its preload path and header were updated to match.
- **`test/README.md`** rewritten to document the retained probes and how to run them.

## What did not move

- The other **9 probes** are recorded as findings in the two design docs rather than kept as files (your "curated subset" call). The decision doc's evidence trail now lists retained-vs-recorded explicitly, so nothing dangles.
- `input_sequence_stuck_held_test.gd` — the guard for the one real bug the spike shipped (PR #231) — already lives in `main` and is untouched.

## Notes

- No shipped code or behavior changes: everything under `test/` is dev-only and stripped from the npm addon; `.gd` probes never run in CI (CI is npm/vitest only).
- After this merges, the `test/mouse-injection-fixtures` remote branch will be deleted (it's now fully superseded).

## Test plan

- [x] No tracked file references the `mouse-injection-fixtures` branch anymore
- [x] No reference to the prototype's old `game_bridge/mcp_input_queue.gd` path remains
- [x] The queue test's `preload` and the relocated file agree on the `test/` path
- [x] README's relative links to both design docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)