### PR TITLE
fix: runtime_state watch tracks game time, not wall clock

### DIFF
--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -13,8 +13,10 @@ var _active: bool = false
 var _specs: Array = []       # [{node, fields: [{key, resolver}]}]
 var _hz: int = 20
 var _duration_ms: int = 1000
-var _start_time: int = 0
-var _stop_time: int = 0      # set on auto-stop or manual stop; 0 = still running
+# GAME time accumulated (unpaused, time_scale-scaled), NOT wall clock: under a
+# godot_game_time freeze the tree is paused between steps, and counting wall time
+# there would run the window down / log stale samples before the step that moves.
+var _elapsed_ms: float = 0.0
 var _frame_index: int = 0
 var _sample_interval: int = 1  # sample every N frames
 var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
@@ -41,7 +43,7 @@ func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) ->
 	_field_truncated = {}
 	_hz = clampi(hz, 1, 60)
 	_duration_ms = clampi(duration_ms, 100, 5000)
-	_start_time = Time.get_ticks_msec()
+	_elapsed_ms = 0.0
 	_frame_index = 0
 	_sample_interval = max(1, int(Engine.get_frames_per_second() / _hz)) if Engine.get_frames_per_second() > 0 else max(1, int(60.0 / _hz))
 
@@ -70,7 +72,6 @@ func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) ->
 		if not resolved_fields.is_empty():
 			_specs.append({"node": node, "node_path": node_path, "fields": resolved_fields})
 
-	_stop_time = 0
 	_active = true
 	set_process(true)
 
@@ -174,7 +175,7 @@ func _record_event(source: String, sig_name: String, args: Array) -> void:
 		_events_truncated = true
 		return
 	var ev := {
-		"t_ms": Time.get_ticks_msec() - _start_time,
+		"t_ms": int(_elapsed_ms),
 		"source": source,
 		"signal": sig_name,
 	}
@@ -217,18 +218,26 @@ func _exit_tree() -> void:
 	_disconnect_all()
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
 	if not _active:
 		return
 
-	var elapsed := Time.get_ticks_msec() - _start_time
+	# Measure the window in GAME time and only sample while it actually advances.
+	# The sampler inherits PROCESS_MODE_ALWAYS, so _process keeps firing under a
+	# godot_game_time freeze (tree paused) even though gameplay is static. Counting
+	# those frames would (1) fill the window with stale values and (2) run the
+	# auto-stop down during frozen idle, so a later step lands outside the window.
+	# Skipping while paused makes the window span only live gameplay / step time.
+	var tree := get_tree()
+	if tree != null and tree.paused:
+		return
+	_elapsed_ms += delta * 1000.0  # time_scale-scaled, unpaused-only == game time
 
-	if elapsed >= _duration_ms:
+	if _elapsed_ms >= float(_duration_ms):
 		_active = false
-		_stop_time = Time.get_ticks_msec()
 		set_process(false)
 		# Window over: stop recording signal emissions too. An emission landing
-		# between duration_ms elapsing and this frame is recorded with t_ms
+		# between the window closing and this frame is recorded with t_ms
 		# slightly past the window -- harmless and honest.
 		_disconnect_all()
 		return
@@ -246,7 +255,7 @@ func _process(_delta: float) -> void:
 			for field_info in spec.fields:
 				var arr: Array = _samples.get(field_info.full_key, [])
 				if arr.size() < MAX_SAMPLES_PER_FIELD:
-					arr.append({"t_ms": elapsed, "value": "freed"})
+					arr.append({"t_ms": int(_elapsed_ms), "value": "freed"})
 				else:
 					_field_truncated[field_info.full_key] = true
 			continue
@@ -257,19 +266,13 @@ func _process(_delta: float) -> void:
 				continue
 			var arr: Array = _samples.get(field_info.full_key, [])
 			if arr.size() < MAX_SAMPLES_PER_FIELD:
-				arr.append({"t_ms": elapsed, "value": value})
+				arr.append({"t_ms": int(_elapsed_ms), "value": value})
 			else:
 				_field_truncated[field_info.full_key] = true
 
 
 func collect() -> Dictionary:
-	var elapsed: int
-	if _stop_time > 0:
-		elapsed = _stop_time - _start_time
-	elif _start_time > 0:
-		elapsed = Time.get_ticks_msec() - _start_time
-	else:
-		elapsed = 0  # never started
+	var elapsed := int(_elapsed_ms)
 	var total_samples := 0
 	for key in _samples:
 		total_samples += (_samples[key] as Array).size()
@@ -288,11 +291,9 @@ func collect() -> Dictionary:
 
 
 func stop() -> Dictionary:
+	# _elapsed_ms already holds the game-time window and freezes once _active is
+	# false, so a late manual stop can't inflate window_ms past the real window end.
 	_active = false
-	# Don't clobber an auto-stop's timestamp: a late manual stop would inflate
-	# window_ms to the call time instead of the actual window end.
-	if _stop_time == 0:
-		_stop_time = Time.get_ticks_msec()
 	set_process(false)
 	_disconnect_all()
 	return collect()

--- a/godot/addons/godot_mcp/test/mesh_validator_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/mesh_validator_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cha7vsokqo6dn

--- a/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
@@ -49,6 +49,7 @@ func _run() -> void:
 	_test_fairness(sampler, emitter)
 	_test_fairness_three(sampler, emitter)
 	_test_field_samples_truncated(sampler, emitter)
+	_test_freeze_pauses_sampling(sampler, emitter)
 	_test_arg_caps(sampler, emitter)
 	await _test_window_semantics(sampler, emitter)
 	await _test_auto_stop(sampler, emitter)
@@ -212,6 +213,34 @@ func _test_field_samples_truncated(sampler: MCPRuntimeStateSampler, emitter: _Em
 	_check("field saturation: the un-saturated ghost field is NOT flagged",
 		ft.has("/root/FakeAutoload:ghost"), false)
 	_check("field saturation: only the saturated field is flagged", ft.size(), 1)
+
+
+func _test_freeze_pauses_sampling(sampler: MCPRuntimeStateSampler, _emitter: _Emitter) -> void:
+	# Regression: under a godot_game_time freeze the bridge holds the tree paused,
+	# but the sampler inherits PROCESS_MODE_ALWAYS so _process keeps firing. Those
+	# paused frames must NOT advance the window or record samples — otherwise the
+	# window (formerly wall-clock) ran down during frozen idle and stepped tests
+	# came back flat. Drive _process directly with the interval forced to 1.
+	sampler.start([{"path": "/root/FakeAutoload", "fields": ["score"]}], 60, 5000, [])
+	sampler._sample_interval = 1
+	paused = true
+	for i in 5:
+		sampler._process(0.5)  # 5 frames @ 500ms each — would be 2500ms of WALL time
+	var frozen: Dictionary = sampler.collect()
+	var frozen_samples: int = ((frozen.get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", []) as Array).size()
+	_check("freeze: no samples recorded while the tree is paused", frozen_samples, 0)
+	_check("freeze: window_ms does not advance while paused", frozen.get("window_ms"), 0)
+	_check("freeze: window did NOT auto-stop during frozen idle", sampler.is_active(), true)
+	# Unpause (a step): the same _process calls now sample and advance GAME time.
+	paused = false
+	for i in 3:
+		sampler._process(0.5)  # 3 x 500ms == 1500ms of game time
+	var live: Dictionary = sampler.collect()
+	var live_samples: int = ((live.get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", []) as Array).size()
+	_check("freeze: sampling resumes once unpaused (step)", live_samples > 0, true)
+	_check("freeze: window advances in GAME time once unpaused (~1500ms)",
+		int(live.get("window_ms")) >= 1400, true)
+	sampler.stop()
 
 
 func _test_arg_caps(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:


### PR DESCRIPTION
## Problem

`godot_runtime_state` `watch_start` → `watch_collect` returns flat / stale samples when the game is driven under a `godot_game_time` freeze/step. On a stepped traversal test the player demonstrably moved, yet the watch reported its position as constant — making it look like nothing happened, and nearly sending a debugging session down a false "the body is stuck" path.

## Root cause

The sampler (`mcp_runtime_state_sampler.gd`) measured its window, sample cadence, and sample/event `t_ms` against **wall clock** (`Time.get_ticks_msec()`) and **rendered-frame counts**. The sampler is parented to the game bridge, which is `PROCESS_MODE_ALWAYS`, so the sampler inherits ALWAYS and keeps ticking while a freeze holds the tree paused. As a result:

- it records the static (paused) values over and over, and
- the wall-clock auto-stop runs down during frozen idle (plus the latency between the `watch_start` call and the `step`), so the window expires misaligned with the step that actually advances game time.

The window had no relationship to game-time progression under freeze/step.

## Fix

Measure the window in **game time**: in `_process`, skip while `get_tree().paused`, and accumulate the unpaused, `time_scale`-scaled `delta`. Sample/event `t_ms` and `window_ms` are now game time, and the window spans only live gameplay / step time — so `watch_start(duration_ms=N)` captures N ms of game time across however many steps and never expires during frozen idle.

Normal (unpaused) real-time play is unchanged: `tree.paused` is false and `delta` ≈ wall clock at `time_scale` 1, matching the prior behavior.

## Tests

- `watch_timeline` headless suite passes (84 checks), including a new `_test_freeze_pauses_sampling` regression: while `paused = true`, `_process` ticks record no samples and neither advance the window nor auto-stop; once unpaused, sampling resumes and the window advances in game time.
- `watch_contract` headless suite passes (18 checks) — the wire contract is unchanged.

Also commits the Godot-generated `.uid` for `mesh_validator_headless_test.gd` (previously untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
