### PR TITLE
ci: auto-publish to the MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,36 @@ jobs:
           gh release upload ${{ needs.release-please.outputs.tag_name }} \
             godot-mcp-addon-${{ needs.release-please.outputs.version }}.zip \
             --clobber
+
+  # Publish server.json to the official MCP Registry. Runs only on a real release
+  # and only after `npm publish` succeeds, because the registry validates the
+  # mcpName against the published npm tarball. Auth is GitHub OIDC — no secrets:
+  # the io.github.satelliteoflove/* namespace is owned by this repo's owner, and
+  # the id-token permission lets the runner prove that identity to the registry.
+  publish-registry:
+    needs: [release-please, publish]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install mcp-publisher
+        run: curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+      - name: Log in to the MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to the MCP Registry
+        run: |
+          # npm can take a moment to propagate after the publish job, and the
+          # registry rejects until it can validate the mcpName against the new
+          # version on npm — so retry before giving up.
+          for attempt in 1 2 3 4 5; do
+            if ./mcp-publisher publish server/server.json; then
+              exit 0
+            fi
+            echo "::warning::MCP Registry publish attempt $attempt failed; retrying in 20s"
+            sleep 20
+          done
+          echo "::error::MCP Registry publish failed after 5 attempts"
+          exit 1

--- a/server/server.json
+++ b/server/server.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.satelliteoflove/godot-mcp",
+  "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
   "version": "4.0.0",
   "repository": {
@@ -14,6 +15,29 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
       "version": "4.0.0",
+      "runtimeHint": "npx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-y",
+          "isRequired": false
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "GODOT_HOST",
+          "description": "Override the host used to reach the Godot editor bridge (e.g. for WSL2 or remote setups). Auto-detected when unset.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "GODOT_MCP_READ_ONLY",
+          "description": "Set to 1 (or true) to register only read-only observation tools: no scene/node/animation edits, no game control, no input injection. Same as the --read-only flag.",
+          "format": "boolean",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ],
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What

Makes MCP Registry publication automatic, so future releases land in the [official registry](https://registry.modelcontextprotocol.io) with no manual steps — closing the loop opened in #318.

### New `publish-registry` job in the Release workflow
- Runs **only on a real release** (`release_created`) and **only after `npm publish` succeeds** — the registry validates the `mcpName` against the published npm tarball, so npm has to go first.
- Authenticates via **GitHub OIDC** (`id-token: write`) — **no secrets**. The `io.github.satelliteoflove/*` namespace is owned by this repo's owner, and the OIDC token proves that identity to the registry.
- **Retries** the publish to absorb npm propagation lag after the publish job.

### `server.json` enrichment (syncs the repo to what was published for 4.0.0)
- `title: "Godot MCP"` — a human-readable display name (otherwise clients show the raw `io.github.satelliteoflove/godot-mcp` id).
- `runtimeHint: "npx"` + `runtimeArguments: ["-y"]` — matches the README's `npx -y @satelliteoflove/godot-mcp` launch.
- Optional `GODOT_HOST` and `GODOT_MCP_READ_ONLY` env vars so client UIs can surface them (both non-required; defaults unchanged).

release-please updates `server.json` via surgical JSONPaths (`$.version`, `$.packages[0].version`), so these added fields survive future version bumps.

## Context
4.0.0 was published to the registry manually (status `active`, live now). This PR makes every subsequent release do it automatically as part of the existing release pipeline.

## Verification
- `mcp-publisher validate` passes on the enriched `server.json`.
- YAML parses; job gating mirrors the existing `publish` / `upload-addon` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)