### PR TITLE
fix: align tool annotation hints across the surface

### DIFF
--- a/server/src/__tests__/core/__toolsnaps__/godot_docs.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_docs.json
@@ -52,6 +52,7 @@
   "annotations": {
     "title": "Godot Docs",
     "readOnlyHint": true,
+    "destructiveHint": false,
     "openWorldHint": true
   }
 }

--- a/server/src/__tests__/core/__toolsnaps__/godot_profiler.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_profiler.json
@@ -28,6 +28,7 @@
   "annotations": {
     "title": "Profiler",
     "readOnlyHint": true,
+    "destructiveHint": false,
     "openWorldHint": false
   }
 }

--- a/server/src/__tests__/core/__toolsnaps__/godot_project.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_project.json
@@ -30,6 +30,7 @@
   "annotations": {
     "title": "Project Info",
     "readOnlyHint": true,
+    "destructiveHint": false,
     "openWorldHint": false
   }
 }

--- a/server/src/__tests__/core/__toolsnaps__/godot_resource.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_resource.json
@@ -32,6 +32,7 @@
   "annotations": {
     "title": "Resource Inspector",
     "readOnlyHint": true,
+    "destructiveHint": false,
     "openWorldHint": false
   }
 }

--- a/server/src/__tests__/core/__toolsnaps__/godot_scene.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_scene.json
@@ -25,6 +25,7 @@
     "title": "Scene",
     "readOnlyHint": false,
     "destructiveHint": false,
+    "idempotentHint": true,
     "openWorldHint": false
   }
 }

--- a/server/src/__tests__/core/__toolsnaps__/godot_scene3d.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_scene3d.json
@@ -92,6 +92,7 @@
   "annotations": {
     "title": "3D Scene Info",
     "readOnlyHint": true,
+    "destructiveHint": false,
     "openWorldHint": false
   }
 }

--- a/server/src/tools/docs.ts
+++ b/server/src/tools/docs.ts
@@ -148,7 +148,7 @@ function extractSection(markdown: string, section: string): string {
 
 export const docs = defineTool({
   name: 'godot_docs',
-  annotations: { title: 'Godot Docs', readOnlyHint: true, openWorldHint: true },
+  annotations: { title: 'Godot Docs', readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   description:
     'Fetch Godot Engine documentation. Use fetch_class for class references (e.g. CharacterBody2D), fetch_page for tutorials/guides. Auto-detects Godot version from editor connection. Returns clean markdown.',
   schema: DocsSchema,

--- a/server/src/tools/profiler.ts
+++ b/server/src/tools/profiler.ts
@@ -181,7 +181,7 @@ type ProfilerArgs = z.infer<typeof ProfilerSchema>;
 
 export const profiler = defineTool({
   name: 'godot_profiler',
-  annotations: { title: 'Profiler', readOnlyHint: true, openWorldHint: false },
+  annotations: { title: 'Profiler', readOnlyHint: true, destructiveHint: false, openWorldHint: false },
   description:
     'Profile a running game; every action errors if no game is playing. Use snapshot for one-shot engine metrics, or start → get_data for a per-frame time series with percentile stats, frame-budget usage, spike detection, and monitor trends. get_active_processes lists scripts with live _process/_physics_process callbacks (useful for finding per-frame cost sources); get_signal_connections maps signal wiring. For observing game state rather than performance, use godot_runtime_state.',
   schema: ProfilerSchema,

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -39,7 +39,7 @@ type ProjectArgs = z.infer<typeof ProjectSchema>;
 
 export const project = defineTool({
   name: 'godot_project',
-  annotations: { title: 'Project Info', readOnlyHint: true, openWorldHint: false },
+  annotations: { title: 'Project Info', readOnlyHint: true, destructiveHint: false, openWorldHint: false },
   description:
     'Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops. For scene contents or node properties, use godot_node_read instead.',
   schema: ProjectSchema,

--- a/server/src/tools/resource.ts
+++ b/server/src/tools/resource.ts
@@ -31,7 +31,7 @@ type ResourceArgs = z.infer<typeof ResourceSchema>;
 
 export const resource = defineTool({
   name: 'godot_resource',
-  annotations: { title: 'Resource Inspector', readOnlyHint: true, openWorldHint: false },
+  annotations: { title: 'Resource Inspector', readOnlyHint: true, destructiveHint: false, openWorldHint: false },
   description:
     'Inspect a Resource file by path with type-aware structured output (SpriteFrames animations, TileSet, Material, Texture2D, etc.). Use it for imported or binary resources (.res, .scn, compressed textures) that a plain file read cannot parse, or when you want sub-resources resolved into the engine\'s view rather than raw .tres text. For nodes inside a scene, use godot_node_read instead.',
   schema: ResourceSchema,

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -20,7 +20,7 @@ type SceneArgs = z.infer<typeof SceneSchema>;
 
 export const scene = defineTool({
   name: 'godot_scene',
-  annotations: { title: 'Scene', readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+  annotations: { title: 'Scene', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   description:
     'Manage scenes in the editor: open a scene, or save the open scene. To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.',
   schema: SceneSchema,

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -74,7 +74,7 @@ function formatAABB(aabb: AABB): string {
 
 export const scene3d = defineTool({
   name: 'godot_scene3d',
-  annotations: { title: '3D Scene Info', readOnlyHint: true, openWorldHint: false },
+  annotations: { title: '3D Scene Info', readOnlyHint: true, destructiveHint: false, openWorldHint: false },
   description:
     'Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs, combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.',
   schema: Scene3DSchema,


### PR DESCRIPTION
## What

Tightens the MCP tool annotation hints so they are consistent across all 21 tools. Metadata only; no behavioral or schema change.

- **Five read tools** (`godot_project`, `godot_resource`, `godot_scene3d`, `godot_profiler`, `godot_docs`) did not declare `destructiveHint`. The MCP spec defaults `destructiveHint` to **true**, so a client that consults that hint without first checking `readOnlyHint` would treat these read-only tools as destructive. They now pin `destructiveHint: false`, matching the other seven read tools.
- **`godot_scene`** now declares `idempotentHint: true` (`open` and `save` are both idempotent), matching its peer `godot_node_edit`.

## Why

These are advisory hints that more capable clients use to decide what to auto-approve or confirm. The `destructiveHint` gap is the one that actually matters: a read tool that looks destructive to a hint-aware client is misleading. The rest is consistency polish.

The destructive/idempotent values on the other write tools are already accurate and were left untouched; the non-idempotent write tools correctly rely on the spec default.

## Verification

- `npm run build` clean
- `npm test` green (600 passed, 7 skipped); the 6 per-tool snapshots in `__toolsnaps__` regenerated to match
- Generated docs do not surface annotations, so no docs change

Lands as a patch (4.0.1) via release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)