### PR TITLE
docs: review-cleanup pass (setup guidance, tool-doc example fixes, GODOT_HOST default)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,7 +107,7 @@ Or add to your Copilot CLI settings file (`~/.config/github-copilot/mcp.json`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GODOT_HOST` | `localhost` | WebSocket host for the Godot addon. Auto-detected in WSL. |
+| `GODOT_HOST` | `127.0.0.1` | WebSocket host for the Godot addon. Auto-detected in WSL. |
 | `GODOT_PORT` | `6550` | WebSocket port for the Godot addon. |
 | `GODOT_MCP_USAGE_LOG` | on | Local usage telemetry: each tool call appends a JSON line (tool, action, success, duration) to `~/.godot-mcp/usage.log`. **Enabled by default** — set to `0` or `false` to disable. The log never leaves your machine. |
 | `GODOT_MCP_USAGE_LOG_MAX_SIZE` | `10485760` (10MB) | Size in bytes at which `usage.log` is rotated. |

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -24,23 +24,22 @@ This project uses godot-mcp for AI-assisted development.
 - Editor-state operations: opening and saving scenes, updating node properties, reparenting
 - Verifying file edits landed: `godot_node_read` `get_scene_tree` and `get_properties`
 - Data files cannot express: tilemap and GridMap cell data is base64-encoded in .tscn, so use `godot_tilemap_edit` / `godot_gridmap_edit`
-- Everything involving the running game: run/stop, screenshots, input injection, game-time control, runtime state
+- Everything involving the running game: run/stop, screenshots, input injection, game-time control, runtime state, profiling, and scenario setup with `godot_exec`
 - Querying editor state, selection, project settings, 3D spatial data
 - Fetching Godot documentation
 - Inspecting resources like SpriteFrames, TileSets, and Materials
 
-**After external edits:**
-- To test an edited `.gd`, just `godot_editor_edit` `stop` then `run` - the launched game loads scripts fresh from disk, so no editor restart is needed. Reserve `restart` for *editor-side* staleness: `@tool`/plugin/addon code the editor has loaded, or an edited `.gdshader` it still renders from a cached compile
-- After editing project.godot, run `godot_project` `check_stale` - the editor never re-reads it on its own (`godot_editor_edit` `restart` to apply changed autoloads/input map)
+(After editing files outside MCP, the `godot_editor_edit` run/restart and `godot_project` `check_stale` descriptions cover when the editor needs a reload - in short: a launched game reads `.gd`/`.tscn` fresh, so reserve `restart` for editor-side staleness.)
 
 ### Testing the Running Game
 
-- **Make game time answer to your clock.** For anything timing-sensitive, prefer `godot_game_time` (freeze, observe, then `step` / `step_until`) over blind fixed-duration input. While frozen, screenshots and state digests still work; an `inputs` timeline rides inside the stepped window, and `step_until`'s `report` reads the state you care about in the same call.
-- **Verify effects from state, not screenshots.** Read outcomes with `godot_runtime_state` `digest` - include autoload paths (`/root/...`) for global score/wave/cash. Use screenshots for layout and visual quality, not for "did it work?".
-- **Screenshots don't decay - keep the tail short.** Every captured frame (including each `godot_input` `screenshot_at_ms` frame) stays in context for the rest of the session, so a long visual session is soon dominated by old frames you'll never look at again. Capture the fewest frames that answer "does it *look* right" at a modest width, use multi-frame only for transient/animated visuals (a static layout needs one), and don't re-shoot a view that hasn't changed. For "is the *value* right", read `godot_runtime_state` / `godot_exec` text instead - it's near-free.
+- **Make game time answer to your clock.** For anything timing-sensitive, freeze and `step` / `step_until` with `godot_game_time` rather than blind fixed-duration waits. (Its description carries the mechanics: observing while frozen, inputs riding the window, `report`, and the non-short-circuit predicate gotcha.)
+- **Set up the moment, don't grind to it.** When a test needs the game in a specific state - wave 3, low HP, a particular inventory - put it there with `godot_exec` rather than playing through to reach it. (The tool's own description covers the GDScript scope and the freeze-then-step pairing.)
+- **Verify effects from state, not screenshots.** For "did it work?", read `godot_runtime_state` `digest` (and signal timelines for event outcomes like a hit landing); reserve screenshots for "does it look right?".
+- **Report readings and guesses as different things.** The tools exist so that "the boss stayed in state 2 for the whole step" is something you read, not something you assume. When you explain a cause or a regression, keep the line visible between what the `digest`, profiler, or log actually showed and what you are inferring from it - for performance work especially, the profiler's spike data is evidence and everything else is a hypothesis to test.
+- **Screenshots accumulate across the whole session.** They never decay, so old frames pile up until they crowd everything else toward a lossy compaction. Capture the fewest that answer a genuine *appearance* question and read text for the rest. (Per-frame cost, the 640px floor, and the one-frame-for-static-layout rule live in the screenshot tool descriptions.)
 - **Isolate screenshot-heavy checks in a sub-agent.** For a multi-frame or genuinely visual check, dispatch a sub-agent (Claude Code's Task tool) that drives the game, *looks* at the frames, and reports back a short text verdict - the frames die with the sub-agent's context instead of piling up in yours.
-- **Keep full-speed input self-contained.** If you drive the game in real time with `godot_input` `sequence`, put the run-starting menu press and the gameplay inputs in ONE sequence - input split across two tool calls has seconds of game time between the halves.
-- **Check the editor log after every change.** `godot_editor_read` `get_log_messages` with `severity: "error"` answers "did my edit break the editor?"; pass a prior `cursor` back as `since` to read only what is new. It is editor-side only - for errors from the running game, use the companion server's game console.
+- **Open a runtime investigation with one sweep.** When something misbehaves at runtime, pull the whole signal set before theorizing: both error channels (editor `get_log_messages` and the companion server's game console), a `godot_runtime_state` `digest` of the entities involved, the scene tree, and a `godot_profiler` capture if it is frame- or timing-related. One channel rarely tells the whole story, and a theory built on the first thing you read is how you end up debugging the wrong problem.
 - **Respect pause hygiene.** Gameplay state must not advance while paused (a correct pause menu already requires this - gameplay `get_tree().create_timer()` should pass `false` for its `process_always` argument). Cosmetic, audio, and juice systems under `PROCESS_MODE_ALWAYS` are meant to run during pause - do not "fix" them.
 
 ### Companion Server
@@ -76,6 +75,15 @@ follow-up observation into the same call. One gotcha: predicate and report expre
 maybe-absent node with `arr.size() > 0 and arr[0].state == 4`. Sequence two calls instead:
 `step_until` the node exists (`tree.get_nodes_in_group("boss").size() >= 1`), then `step_until`
 the thing you actually wanted to read.
+
+### Set the scene before you test it
+
+The slow way to test a wave-3 boss is to play through waves one and two. The fast way is
+`godot_exec`: run a line of GDScript inside the live game to put it exactly where you want it -
+`GameState.wave = 3`, grant the weapon, spawn the bot, drop the player to 1 HP - then freeze and
+step. This is also how you reach states normal play can barely produce on demand (a specific RNG
+roll, a half-built save, an edge-case inventory) without baking debug hooks into your game code.
+Setup, freeze, step, observe: a scenario you defined beats whatever the game happened to roll.
 
 ### Two error channels, not one
 

--- a/docs/tools/docs.md
+++ b/docs/tools/docs.md
@@ -47,7 +47,7 @@ Get any docs page by path
 // fetch_page
 {
   "action": "fetch_page",
-  "path": "/root/Main/Player"
+  "path": "/tutorials/2d/2d_movement.html"
 }
 ```
 

--- a/docs/tools/input.md
+++ b/docs/tools/input.md
@@ -22,7 +22,7 @@ List available input actions from the project Input Map
 
 #### `sequence`
 
-Execute an input timeline
+Execute an input timeline. While the game runs at real speed, keep tightly-timed inputs in ONE call — e.g. the run-starting menu press AND the gameplay that follows — because seconds of uncontrolled game time pass between two separate tool calls. For a window longer than one call can hold, drive input through godot_game_time step instead.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/docs/tools/node.md
+++ b/docs/tools/node.md
@@ -100,7 +100,12 @@ Move a node to a new parent
 {
   "action": "update",
   "node_path": "/root/Main/Player",
-  "properties": {}
+  "properties": {
+    "position": {
+      "x": 100,
+      "y": 50
+    }
+  }
 }
 ```
 

--- a/server/scripts/generate-docs.ts
+++ b/server/scripts/generate-docs.ts
@@ -383,11 +383,11 @@ function generateUnionActionDocs(variants: ActionVariant[]): string {
   return md;
 }
 
-function generateUnionExamples(variants: ActionVariant[], toolSchema: z.ZodType): string {
+function generateUnionExamples(variants: ActionVariant[], toolSchema: z.ZodType, toolName: string): string {
   let md = '### Examples\n\n';
 
   for (const variant of variants.slice(0, 3)) {
-    const example = buildVariantExample(variant, toolSchema);
+    const example = buildVariantExample(variant, toolSchema, toolName);
     md += `\`\`\`json\n// ${variant.action}\n${JSON.stringify(example, null, 2)}\n\`\`\`\n\n`;
   }
 
@@ -407,7 +407,7 @@ function generateToolMarkdown(tool: AnyToolDefinition): string {
   const variants = getActionVariants(rawJsonSchema(tool));
   if (variants) {
     md += generateUnionActionDocs(variants);
-    md += generateUnionExamples(variants, tool.schema);
+    md += generateUnionExamples(variants, tool.schema, tool.name);
     return md;
   }
 

--- a/server/src/__tests__/core/__toolsnaps__/godot_input.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_input.json
@@ -11,7 +11,7 @@
           "sequence",
           "type_text"
         ],
-        "description": "get_map: List available input actions from the project Input Map\nsequence: Execute an input timeline\ntype_text: Type text into the focused UI element"
+        "description": "get_map: List available input actions from the project Input Map\nsequence: Execute an input timeline. While the game runs at real speed, keep tightly-timed inputs in ONE call — e.g. the run-starting menu press AND the gameplay that follows — because seconds of uncontrolled game time pass between two separate tool calls. For a window longer than one call can hold, drive input through godot_game_time step instead.\ntype_text: Type text into the focused UI element"
       },
       "inputs": {
         "minItems": 1,

--- a/server/src/__tests__/core/doc-examples.test.ts
+++ b/server/src/__tests__/core/doc-examples.test.ts
@@ -144,4 +144,18 @@ describe('generated doc examples (#287)', () => {
       expect(val).toEqual({ path: '/root/Main/Player' });
     });
   });
+
+  it('applies tool-scoped example overrides (docs path is a URL, node_edit properties is non-empty)', () => {
+    const docsCase = variantOf('godot_docs', 'fetch_page');
+    const docsExample = buildVariantExample(docsCase.variant, docsCase.tool.schema, docsCase.tool.name);
+    expect(docsExample.path).toBe('/tutorials/2d/2d_movement.html');
+
+    const updateCase = variantOf('godot_node_edit', 'update');
+    const updateExample = buildVariantExample(
+      updateCase.variant, updateCase.tool.schema, updateCase.tool.name
+    ) as Record<string, unknown>;
+    // The addon rejects an empty update, so the published example must be non-empty + schema-valid.
+    expect(updateExample.properties).toEqual({ position: { x: 100, y: 50 } });
+    expect(updateCase.tool.schema.safeParse(updateExample).success).toBe(true);
+  });
 });

--- a/server/src/core/doc-examples.ts
+++ b/server/src/core/doc-examples.ts
@@ -65,19 +65,34 @@ const NAMED_EXAMPLES: Record<string, unknown> = {
   signal: 'body_entered',
 };
 
+// Per-tool overrides for parameter names whose generic example would be wrong in
+// a specific tool's context. Consulted before NAMED_EXAMPLES.
+const TOOL_NAMED_EXAMPLES: Record<string, Record<string, unknown>> = {
+  // `path` is a node path everywhere else, but a docs URL path here.
+  godot_docs: { path: '/tutorials/2d/2d_movement.html' },
+  // `properties` is a z.record (no JSON-Schema `properties`), so the generic
+  // object builder yields {}, which the addon rejects as an empty update.
+  godot_node_edit: { properties: { position: { x: 100, y: 50 } } },
+};
+
 // Build a representative, schema-VALID value for one JSON-Schema property.
 // Recurses through arrays/objects/unions and produces NON-EMPTY arrays +
 // populated required object fields, so min-length / nested-required constraints hold.
-export function exampleForProp(name: string, prop: Record<string, unknown>): unknown {
+export function exampleForProp(name: string, prop: Record<string, unknown>, toolName?: string): unknown {
   if (prop.const !== undefined) return prop.const;
   if (Array.isArray(prop.enum)) return (prop.enum as unknown[])[0];
+  // Tool-scoped overrides win over the generic name map: the same parameter name
+  // can mean different things in different tools (godot_docs `path` is a docs URL,
+  // godot_node_edit `properties` is a z.record that would otherwise render as {}).
+  const toolOverrides = toolName ? TOOL_NAMED_EXAMPLES[toolName] : undefined;
+  if (toolOverrides && name in toolOverrides) return toolOverrides[name];
   if (name in NAMED_EXAMPLES) return NAMED_EXAMPLES[name];
 
   // A prop that is itself a union (z.union / z.discriminatedUnion serialize to
   // anyOf / oneOf — e.g. the input `sequence` entry shapes): build the first branch.
   const branches = (prop.oneOf ?? prop.anyOf ?? prop.allOf) as Record<string, unknown>[] | undefined;
   if (Array.isArray(branches) && branches.length > 0) {
-    return exampleForProp(name, branches[0]);
+    return exampleForProp(name, branches[0], toolName);
   }
 
   switch (prop.type) {
@@ -93,14 +108,14 @@ export function exampleForProp(name: string, prop: Record<string, unknown>): unk
       const items = prop.items as Record<string, unknown> | undefined;
       // One representative element: keeps arrays non-empty so a length-based
       // refine (e.g. watch_start's specs/signals) is satisfied.
-      return items ? [exampleForProp(name, items)] : [];
+      return items ? [exampleForProp(name, items, toolName)] : [];
     }
     case 'object': {
       const props = (prop.properties as Record<string, Record<string, unknown>>) || {};
       const req = (prop.required as string[]) || [];
       const obj: Record<string, unknown> = {};
       for (const key of Object.keys(props)) {
-        if (req.includes(key)) obj[key] = exampleForProp(key, props[key]);
+        if (req.includes(key)) obj[key] = exampleForProp(key, props[key], toolName);
       }
       return obj;
     }
@@ -116,18 +131,19 @@ export function exampleForProp(name: string, prop: Record<string, unknown>): unk
 // validates — keeping the minimal field that unblocks it (#287).
 export function buildVariantExample(
   variant: ActionVariant,
-  toolSchema: z.ZodType
+  toolSchema: z.ZodType,
+  toolName?: string
 ): Record<string, unknown> {
   const example: Record<string, unknown> = { action: variant.action };
   for (const name of variant.required) {
     if (name === 'action') continue;
-    example[name] = exampleForProp(name, variant.properties[name]);
+    example[name] = exampleForProp(name, variant.properties[name], toolName);
   }
 
   if (!toolSchema.safeParse(example).success) {
     for (const [name, prop] of Object.entries(variant.properties)) {
       if (name === 'action' || name in example) continue;
-      example[name] = exampleForProp(name, prop);
+      example[name] = exampleForProp(name, prop, toolName);
       if (toolSchema.safeParse(example).success) break;
       delete example[name]; // this field didn't unblock it — don't over-specify
     }

--- a/server/src/tools/input.ts
+++ b/server/src/tools/input.ts
@@ -215,7 +215,7 @@ const InputSchema = z.discriminatedUnion('action', [
     action: z.literal('get_map').describe('List available input actions from the project Input Map'),
   }),
   z.object({
-    action: z.literal('sequence').describe('Execute an input timeline'),
+    action: z.literal('sequence').describe('Execute an input timeline. While the game runs at real speed, keep tightly-timed inputs in ONE call — e.g. the run-starting menu press AND the gameplay that follows — because seconds of uncontrolled game time pass between two separate tool calls. For a window longer than one call can hold, drive input through godot_game_time step instead.'),
     inputs: z
       .array(InputEntrySchema)
       .min(1)


### PR DESCRIPTION
Documentation review-and-cleanup pass.

## Changes
- Refine Claude Code setup guidance and relocate input-sequence advice (3fceb5f)
- Correct invalid auto-generated tool-doc examples, with the supporting doc-examples generator/test updates and a small input.ts tooltip tweak (0866ea4)
- Fix the GODOT_HOST default documented in INSTALL.md (efe3761)

No uncommitted doc content is included; this is the three commits already on the branch.