### PR TITLE
feat: add godot_scene reload action to refresh an open scene from disk

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -6,7 +6,7 @@ This documentation is auto-generated from the tool definitions.
 
 Scene management tools
 
-- `godot_scene` - Manage scenes in the editor: open a scene, or save the open scene. To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.
+- `godot_scene` - Manage scenes in the editor: open a scene, save the open scene, or reload an open scene from disk after you edit its .tscn directly (so the editor picks up the change without a full restart). To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.
 
 ## [Node](node.md)
 

--- a/docs/tools/scene.md
+++ b/docs/tools/scene.md
@@ -10,7 +10,7 @@ Scene management tools
 
 ## godot_scene
 
-Manage scenes in the editor: open a scene, or save the open scene. To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.
+Manage scenes in the editor: open a scene, save the open scene, or reload an open scene from disk after you edit its .tscn directly (so the editor picks up the change without a full restart). To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.
 
 ### Actions
 
@@ -30,6 +30,14 @@ Save the current scene
 |-----------|------|----------|-------------|
 | `scene_path` | string | No | Path to save to (defaults to the current scene path) |
 
+#### `reload`
+
+Reload an open scene from disk, discarding the editor's unsaved in-memory copy. Use after editing a .tscn file directly to refresh the editor without a full restart; the scene must already be open.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_path` | string | No | Path of the open scene to reload (defaults to the current scene) |
+
 ### Examples
 
 ```json
@@ -44,6 +52,13 @@ Save the current scene
 // save
 {
   "action": "save"
+}
+```
+
+```json
+// reload
+{
+  "action": "reload"
 }
 ```
 

--- a/godot/addons/godot_mcp/commands/scene_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene_commands.gd
@@ -77,16 +77,14 @@ func open_scene(params: Dictionary) -> Dictionary:
 
 
 func save_scene(params: Dictionary) -> Dictionary:
+	var resolved: Variant = _resolve_scene_path(params.get("path", ""))
+	if resolved is Dictionary:
+		return resolved
+	var path: String = resolved
+
 	var root := EditorInterface.get_edited_scene_root()
 	if not root:
 		return _error("NO_SCENE", "No scene is currently open")
-
-	var path: String = params.get("path", "")
-	if path.is_empty():
-		path = root.scene_file_path
-
-	if path.is_empty():
-		return _error("NO_PATH", "Scene has no path and none was provided")
 
 	var packed_scene := PackedScene.new()
 	var err := packed_scene.pack(root)
@@ -105,14 +103,10 @@ func save_scene(params: Dictionary) -> Dictionary:
 # (e.g. an unsaved godot_node_edit) are discarded. Only open scenes can be
 # reloaded in place; an unopened path is rejected so the caller uses open_scene.
 func reload_scene(params: Dictionary) -> Dictionary:
-	var scene_path: String = params.get("scene_path", "")
-	if scene_path.is_empty():
-		var root := EditorInterface.get_edited_scene_root()
-		if not root:
-			return _error("NO_SCENE", "No scene is currently open and no scene_path was provided")
-		scene_path = root.scene_file_path
-		if scene_path.is_empty():
-			return _error("NO_PATH", "The current scene has not been saved to a file; nothing to reload")
+	var resolved: Variant = _resolve_scene_path(params.get("scene_path", ""))
+	if resolved is Dictionary:
+		return resolved
+	var scene_path := _localize_scene_path(resolved)
 
 	if not FileAccess.file_exists(scene_path):
 		return _error("FILE_NOT_FOUND", "Scene file not found: %s" % scene_path)
@@ -122,4 +116,33 @@ func reload_scene(params: Dictionary) -> Dictionary:
 
 	EditorInterface.reload_scene_from_path(scene_path)
 	return _success({"path": scene_path})
+
+
+# Resolve the scene-file path to act on: the caller-supplied path, or the current
+# edited scene's file when none was given. Returns the path String, or an error
+# Dictionary (NO_SCENE / NO_PATH) the caller returns unchanged. Shared by
+# save_scene and reload_scene so the NO_SCENE/NO_PATH handling lives in one place.
+func _resolve_scene_path(provided_path: String) -> Variant:
+	if not provided_path.is_empty():
+		return provided_path
+	var err := _require_scene_open()
+	if err:
+		return err
+	var path := EditorInterface.get_edited_scene_root().scene_file_path
+	if path.is_empty():
+		return _error("NO_PATH", "The current scene has not been saved to a file and no scene path was provided")
+	return path
+
+
+# Normalize a scene path to the canonical res:// form that get_open_scenes() and
+# FileAccess use. A uid:// reference (the editor writes these into .tscn since
+# 4.4) is resolved to its res:// path; an absolute path is localized. An
+# unresolvable uid is returned unchanged so the existence check reports it.
+func _localize_scene_path(path: String) -> String:
+	if path.begins_with("uid://"):
+		var id := ResourceUID.text_to_id(path)
+		if ResourceUID.has_id(id):
+			return ResourceUID.get_id_path(id)
+		return path
+	return ProjectSettings.localize_path(path)
 

--- a/godot/addons/godot_mcp/commands/scene_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene_commands.gd
@@ -7,7 +7,8 @@ func get_commands() -> Dictionary:
 	return {
 		"get_scene_tree": get_scene_tree,
 		"open_scene": open_scene,
-		"save_scene": save_scene
+		"save_scene": save_scene,
+		"reload_scene": reload_scene
 	}
 
 
@@ -97,4 +98,28 @@ func save_scene(params: Dictionary) -> Dictionary:
 		return _error("SAVE_FAILED", "Failed to save scene: %s" % error_string(err))
 
 	return _success({"path": path})
+
+
+# Reload an already-open scene from disk, picking up a direct .tscn edit without
+# the heavyweight `restart`. Disk wins: any unsaved in-memory edits to this scene
+# (e.g. an unsaved godot_node_edit) are discarded. Only open scenes can be
+# reloaded in place; an unopened path is rejected so the caller uses open_scene.
+func reload_scene(params: Dictionary) -> Dictionary:
+	var scene_path: String = params.get("scene_path", "")
+	if scene_path.is_empty():
+		var root := EditorInterface.get_edited_scene_root()
+		if not root:
+			return _error("NO_SCENE", "No scene is currently open and no scene_path was provided")
+		scene_path = root.scene_file_path
+		if scene_path.is_empty():
+			return _error("NO_PATH", "The current scene has not been saved to a file; nothing to reload")
+
+	if not FileAccess.file_exists(scene_path):
+		return _error("FILE_NOT_FOUND", "Scene file not found: %s" % scene_path)
+
+	if not scene_path in EditorInterface.get_open_scenes():
+		return _error("NOT_OPEN", "Scene is not open in the editor; use open_scene to open it: %s" % scene_path)
+
+	EditorInterface.reload_scene_from_path(scene_path)
+	return _success({"path": scene_path})
 

--- a/godot/addons/godot_mcp/core/mcp_utils.gd
+++ b/godot/addons/godot_mcp/core/mcp_utils.gd
@@ -66,7 +66,11 @@ static func serialize_value(value: Variant) -> Variant:
 
 
 static func deserialize_value(value: Variant) -> Variant:
-	if value is String and value.begins_with("res://"):
+	# uid:// references (written into .tscn by the editor since 4.4) resolve the
+	# same way res:// does — load() accepts both. Without the uid:// arm, a uid
+	# string handed to a resource-typed property silently fails to load and the
+	# property keeps its old value.
+	if value is String and (value.begins_with("res://") or value.begins_with("uid://")):
 		var resource := load(value)
 		if resource:
 			return resource

--- a/server/src/__tests__/core/__toolsnaps__/godot_scene.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_scene.json
@@ -1,6 +1,6 @@
 {
   "name": "godot_scene",
-  "description": "Manage scenes in the editor: open a scene, or save the open scene. To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name=\"X\" type=\"Node2D\"] block per node — and open it with this tool.",
+  "description": "Manage scenes in the editor: open a scene, save the open scene, or reload an open scene from disk after you edit its .tscn directly (so the editor picks up the change without a full restart). To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name=\"X\" type=\"Node2D\"] block per node — and open it with this tool.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -8,12 +8,13 @@
         "type": "string",
         "enum": [
           "open",
-          "save"
+          "save",
+          "reload"
         ],
-        "description": "open: Open a scene file\nsave: Save the current scene"
+        "description": "open: Open a scene file\nsave: Save the current scene\nreload: Reload an open scene from disk, discarding the editor's unsaved in-memory copy. Use after editing a .tscn file directly to refresh the editor without a full restart; the scene must already be open."
       },
       "scene_path": {
-        "description": "for open: Path to scene file to open; for save: Path to save to (defaults to the current scene path) (required for: open; optional for: save)",
+        "description": "for open: Path to scene file to open; for save: Path to save to (defaults to the current scene path); for reload: Path of the open scene to reload (defaults to the current scene) (required for: open; optional for: save, reload)",
         "type": "string"
       }
     },

--- a/server/src/__tests__/core/__toolsnaps__/godot_scene.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_scene.json
@@ -25,7 +25,7 @@
   "annotations": {
     "title": "Scene",
     "readOnlyHint": false,
-    "destructiveHint": false,
+    "destructiveHint": true,
     "idempotentHint": true,
     "openWorldHint": false
   }

--- a/server/src/__tests__/core/annotations.test.ts
+++ b/server/src/__tests__/core/annotations.test.ts
@@ -62,6 +62,7 @@ describe('tool annotations', () => {
       'godot_animation_edit',
       'godot_exec',
       'godot_gridmap_edit',
+      'godot_scene',
       'godot_tilemap_edit',
     ]);
   });

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -14,6 +14,17 @@ const SceneSchema = z.discriminatedUnion('action', [
       .optional()
       .describe('Path to save to (defaults to the current scene path)'),
   }),
+  z.object({
+    action: z
+      .literal('reload')
+      .describe(
+        "Reload an open scene from disk, discarding the editor's unsaved in-memory copy. Use after editing a .tscn file directly to refresh the editor without a full restart; the scene must already be open.",
+      ),
+    scene_path: z
+      .string()
+      .optional()
+      .describe('Path of the open scene to reload (defaults to the current scene)'),
+  }),
 ]);
 
 type SceneArgs = z.infer<typeof SceneSchema>;
@@ -22,7 +33,7 @@ export const scene = defineTool({
   name: 'godot_scene',
   annotations: { title: 'Scene', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   description:
-    'Manage scenes in the editor: open a scene, or save the open scene. To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.',
+    'Manage scenes in the editor: open a scene, save the open scene, or reload an open scene from disk after you edit its .tscn directly (so the editor picks up the change without a full restart). To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.',
   schema: SceneSchema,
   async execute(args: SceneArgs, { godot }) {
     switch (args.action) {
@@ -36,6 +47,13 @@ export const scene = defineTool({
           path: args.scene_path,
         });
         return `Saved scene: ${result.path}`;
+      }
+
+      case 'reload': {
+        const result = await godot.sendCommand<{ path: string }>('reload_scene', {
+          scene_path: args.scene_path,
+        });
+        return `Reloaded scene from disk: ${result.path}`;
       }
     }
   },

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -31,7 +31,7 @@ type SceneArgs = z.infer<typeof SceneSchema>;
 
 export const scene = defineTool({
   name: 'godot_scene',
-  annotations: { title: 'Scene', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: { title: 'Scene', readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
   description:
     'Manage scenes in the editor: open a scene, save the open scene, or reload an open scene from disk after you edit its .tscn directly (so the editor picks up the change without a full restart). To create a new scene, write the .tscn file directly — header [gd_scene format=3] without a uid (the editor assigns one when it imports the file), then one [node name="X" type="Node2D"] block per node — and open it with this tool.',
   schema: SceneSchema,


### PR DESCRIPTION
## Summary

Adds a `reload` action to the `godot_scene` MCP tool and a related `uid://` resolution fix, for the 4.1.0 release.

### feat: godot_scene `reload`
Reloads an already-open scene from disk via `EditorInterface.reload_scene_from_path`, so an agent that hand-edits a `.tscn` directly picks up the change without the heavyweight editor `restart` (which drops the MCP bridge). Defaults to the current scene; rejects a path that is not open so the caller uses `open_scene`. Disk wins: unsaved in-memory edits to that scene are discarded.

### fix: resolve `uid://` resource references
`deserialize_value` only resolved `res://`, so a `uid://` reference (written into `.tscn` by the editor since 4.4) handed to a resource-typed property silently failed to load and kept its old value. `load()` accepts both, so resolve both.

### review hardening
A recall-focused review of the above surfaced three issues, all fixed here:
- **Path normalization** — `reload` now resolves a `uid://` or absolute/non-canonical `scene_path` to canonical `res://` before its existence/open checks, so a scene referenced by its uid is no longer wrongly rejected as not-found/not-open.
- **Shared resolver** — `save_scene` and `reload_scene` now share one `_resolve_scene_path` helper (built on the existing `_require_scene_open()`), collapsing the duplicated `NO_SCENE`/`NO_PATH` handling.
- **Destructive annotation** — `godot_scene` is now `destructiveHint: true` since `reload` discards unsaved in-memory edits; the annotations destructive-set test and tool snapshot are updated.

## Validation
- `npm run build` (tsc) clean and the full vitest suite passes (603 tests); the `godot_scene` tool snapshot reflects the new action and annotation.
- The GDScript handler itself is exercised only through a live editor (no headless coverage for scene commands), so its logic was verified by review rather than execution.

## Known limitation (not fixed)
`reload_scene_from_path` returns `void`, so a failed or no-op reload (a malformed `.tscn`, or Godot's known unreliable reload of a non-active background tab) is reported as success. This is engine-constrained; a best-effort re-verify or a documented caveat is the realistic follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)