### PR TITLE
fix: support multiple concurrent WebSocket clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For richer runtime observation, add key nodes to the `mcp_watch` group or give t
 
 The server talks to an editor addon over a local WebSocket; the addon reaches into the running game over Godot's own debugger protocol, so the game process needs no extra ports or setup. The addon binds to `127.0.0.1` by default. WSL2 is fully supported (auto-detection, host IP discovery, configurable bind modes) — see the [Installation Guide](INSTALL.md#wsl-support).
 
-Curious about connection lifecycles, the single-client policy, or how frozen-time stepping works under the hood? The [Architecture Guide](docs/architecture.md) goes deep.
+Curious about connection lifecycles, how the bridge handles concurrent clients, or how frozen-time stepping works under the hood? The [Architecture Guide](docs/architecture.md) goes deep.
 
 ## Works well with minimal-godot-mcp
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,13 +29,13 @@ The server connects eagerly and assumes the editor may not be there yet:
 - **Reconnection** uses exponential backoff: 1s, 2s, 4s, 8s, 16s, then every 30s. You can start the server and the editor in either order.
 - **Heartbeats** go out every 30 seconds so the addon can tell a quiet-but-alive client from a dead one.
 
-### One client at a time
+### Concurrent clients
 
-The editor bridge serves a single client. When a second client connects while one is active:
+The editor bridge serves multiple clients at once, each tracked independently:
 
-- The newcomer is rejected with WebSocket close code `4001` ("another client is already connected") instead of displacing the incumbent — a subagent that inherited your MCP config can't hijack your session mid-edit.
-- Rejected clients retry with backoff and connect automatically once the slot frees up.
-- If the incumbent goes silent for **45 seconds** (no messages, no heartbeats) or its TCP connection drops, it's considered stale and the next client takes over. A crashed session never permanently wedges the bridge.
+- Each connection gets its own `conn_id`, and command/response routing keys off that id, so one client's in-flight request can't be clobbered or misrouted by another connecting or disconnecting.
+- Concurrency is capped at `MAX_CONNECTIONS` (8 connections). A client arriving once the cap is full is rejected with WebSocket close code `4001` ("Too many connections (limit reached)"); it retries with backoff and connects once a slot frees.
+- A connection idle past 45 seconds (live clients heartbeat every 30 seconds) is closed with code `4002` ("Connection timed out (no activity)"), and one that completes TCP but never finishes the WebSocket handshake is dropped after 10 seconds so it can't hold a slot open.
 
 This logic lives in `godot/addons/godot_mcp/websocket_server.gd`.
 
@@ -79,7 +79,7 @@ server/src/connection/    WebSocket client to the editor addon
 server/src/installer/     --install-addon implementation
 godot/addons/godot_mcp/
   plugin.gd               EditorPlugin entry point; registers the autoload
-  websocket_server.gd     WebSocket listener + single-client policy
+  websocket_server.gd     WebSocket listener + concurrent connection cap
   command_router.gd       Routes commands to handlers
   commands/               GDScript command handlers (one file per domain)
   core/                   Debugger plugin, logger, shared utilities

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,19 +8,17 @@ Most "it doesn't work" reports come down to one of these:
 
 1. **Is the Godot editor open?** The server connects to an addon running *inside the editor*. No editor, no connection.
 2. **Is the addon enabled?** Check **Project > Project Settings > Plugins > Godot MCP**. Installing the addon doesn't enable it.
-3. **What does the MCP panel say?** The **MCP** tab in the editor's bottom panel shows connection status: green means a client is connected, orange means the addon is listening but no client has connected yet.
+3. **What does the MCP panel say?** The **MCP** tab in the editor's bottom panel shows connection status: green means at least one client is connected (the text reads `Connected: N client(s)`), orange means the addon is listening but no client has connected yet.
 4. **Did you restart your AI assistant after installing?** MCP clients typically launch servers at startup. A client started before the config change won't see the server.
 5. **Do the ports match?** The addon listens on `6550` by default. If you enabled **Port override** in the MCP panel, the server needs a matching `GODOT_PORT` (see [Environment Variables](../INSTALL.md#environment-variables)).
 
-## One client at a time
+## "Too many connections" (close code 4001)
 
-A Godot editor bridge serves a **single** godot-mcp connection. This matters once subagents or multiple terminals inherit the same MCP config.
+A Godot editor bridge accepts multiple simultaneous godot-mcp connections, so subagents, multiple terminals, and your main session can all stay connected at once; that's normal and expected.
 
-- If a second godot-mcp client connects while the first is active, it is **rejected** (WebSocket close code `4001`) rather than displacing the original — your session keeps working.
-- The rejected client retries automatically with backoff and connects as soon as the first client disconnects.
-- A client that crashes without closing its socket doesn't block anyone for long: the addon considers a connection stale after **45 seconds** of silence (live clients heartbeat every 30 seconds) and lets the next client take over.
-
-So if a tool call reports that another client holds the connection: close the other session, or just wait — the takeover is automatic.
+- A `4001` rejection means the connection cap is full, not that another client owns the bridge. If you're not deliberately running that many sessions, check for stray duplicate client processes.
+- The rejected client retries automatically with backoff and connects as soon as a slot frees up.
+- A client that crashes without closing its socket doesn't hold its slot for long: the addon considers a connection stale after **45 seconds** of silence (live clients heartbeat every 30 seconds) and frees the slot automatically.
 
 ## Port conflicts and overrides
 

--- a/godot/addons/godot_mcp/plugin.gd
+++ b/godot/addons/godot_mcp/plugin.gd
@@ -258,26 +258,33 @@ func get_debugger_plugin() -> MCPDebuggerPlugin:
 	return _debugger_plugin
 
 
-func _on_command_received(id: String, command: String, params: Dictionary) -> void:
+func _on_command_received(conn_id: int, id: String, command: String, params: Dictionary) -> void:
+	# conn_id has to come from the signal rather than any "current connection" state:
+	# commands from different clients interleave across this await.
 	var response = await _command_router.handle_command(command, params)
 	response["id"] = id
-	_websocket_server.send_response(response)
+	_websocket_server.send_response(conn_id, response)
 
 
-func _on_client_connected() -> void:
+func _on_client_connected(conn_id: int) -> void:
+	var info := _websocket_server.get_connection_info(conn_id)
 	var host_info := ""
-	if _websocket_server.get_connected_host():
-		host_info = " from %s:%d" % [_websocket_server.get_connected_host(), _websocket_server.get_connected_port()]
+	if info.has("host"):
+		host_info = " from %s:%d" % [info["host"], info["port"]]
 	var bind_info := "(%s: %s:%d)" % [MCPEnums.get_mode_name(_current_bind_mode), _current_bind_address, _get_listen_port()]
-	_update_status("Connected%s %s" % [host_info, bind_info])
+	_update_status("Connected: %d client(s)%s %s" % [_websocket_server.get_connection_count(), host_info, bind_info])
 	MCPLog.info("Client connected%s %s" % [host_info, bind_info])
 
 
-func _on_client_disconnected() -> void:
-	_update_status("Disconnected")
-	if _status_panel and _status_panel.has_method("clear_server_version"):
-		_status_panel.clear_server_version()
-	MCPLog.info("Client disconnected")
+func _on_client_disconnected(conn_id: int) -> void:
+	var remaining := _websocket_server.get_connection_count()
+	if remaining == 0:
+		_update_status("Disconnected")
+		if _status_panel and _status_panel.has_method("clear_server_version"):
+			_status_panel.clear_server_version()
+	else:
+		_update_status("Connected: %d client(s)" % remaining)
+	MCPLog.info("Client disconnected (conn %d), %d remaining" % [conn_id, remaining])
 
 
 func _update_status(status: String) -> void:

--- a/godot/addons/godot_mcp/test/websocket_connection_churn_test.gd
+++ b/godot/addons/godot_mcp/test/websocket_connection_churn_test.gd
@@ -1,0 +1,329 @@
+extends SceneTree
+
+## Regression guard for issue #74 ("awaiting WebSocket handshake" instability),
+## re-checked now that MCPWebSocketServer accepts several clients at once.
+##
+## THE BUG: a newcomer silently took over the single stored peer, so the client
+## that was mid-request lost its reply, the console repeated the "TCP connection
+## received, awaiting WebSocket handshake" line every second, and the MCP server
+## fell into a reconnect loop.
+##
+## Covered here, in order: a busy single client is never dropped; a reply issued
+## after a second client joined still reaches its own sender; connect/disconnect
+## churn (including peers that never upgrade) leaves nothing behind; and the
+## MAX_CONNECTIONS overflow path hands the newcomer a coded 4001 close and then
+## frees the slot again.
+##
+## Companion to websocket_multi_client_test.gd, which covers the concurrent-connect
+## and per-conn_id reply-isolation basics that this file does not repeat.
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/websocket_connection_churn_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const TEST_PORT := 6598
+const POLL_TIMEOUT_FRAMES := 600  # ~10s at 60Hz; the cap scenario opens 9 peers
+const BURST_SIZE := 25
+const CHURN_CYCLES := 10
+
+var _count := 0
+var _failures := 0
+
+var _server: MCPWebSocketServer
+var _connect_order: Array[int] = []
+# Set by the "slow" command instead of replying, so the test controls exactly when
+# the response is sent relative to another client connecting.
+var _deferred: Dictionary = {}
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n================= WEBSOCKET CONNECTION CHURN TEST =================\n")
+
+	_server = MCPWebSocketServer.new()
+	root.add_child(_server)
+	_server.command_received.connect(_on_command_received)
+	_server.client_connected.connect(_on_client_connected)
+
+	var start_err := _server.start_server(TEST_PORT, "127.0.0.1")
+	_check("server starts on port %d" % TEST_PORT, start_err, OK)
+	if start_err != OK:
+		_finish()
+		return
+
+	await _scenario_rapid_burst()
+	await _scenario_join_during_inflight_command()
+	await _scenario_churn_leaves_nothing_behind()
+	await _scenario_connection_cap()
+
+	_server.stop_server()
+	root.remove_child(_server)
+	_server.free()
+	_finish()
+
+
+# One client, many commands back to back with no waiting in between. The original
+# report was a single busy client being knocked offline, so this is the baseline.
+func _scenario_rapid_burst() -> void:
+	print("\n-- rapid burst on one client --")
+	var client := WebSocketPeer.new()
+	_check("burst client initiates connection", client.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT), OK)
+	var opened := await _step_until([client], func() -> bool:
+		return client.get_ready_state() == WebSocketPeer.STATE_OPEN
+	)
+	_check("burst client reaches STATE_OPEN", opened, true)
+
+	for i in BURST_SIZE:
+		client.send_text(JSON.stringify({"id": "burst-%d" % i, "command": "ping", "params": {}}))
+
+	var seen: Dictionary = {}
+	var duplicates: Dictionary = {"count": 0}
+	await _step_until([client], func() -> bool:
+		var reply = _drain_reply(client)
+		while reply != null:
+			var reply_id: String = str(reply.get("id", ""))
+			if seen.has(reply_id):
+				duplicates["count"] += 1
+			seen[reply_id] = true
+			reply = _drain_reply(client)
+		return seen.size() >= BURST_SIZE
+	)
+
+	_check("every command in the burst got a reply", seen.size(), BURST_SIZE)
+	_check("no reply arrived twice", duplicates["count"], 0)
+	_check("last id in the burst came back", seen.has("burst-%d" % (BURST_SIZE - 1)), true)
+	_check("burst client still open after the burst", client.get_ready_state(), WebSocketPeer.STATE_OPEN)
+	_check("burst client is still the only connection", _server.get_connection_count(), 1)
+
+	client.close()
+	await _step_until([client], func() -> bool:
+		return _server.get_connection_count() == 0
+	)
+
+
+# The literal #74 failure: a request is in flight when someone else connects. The
+# response is sent after the connection table has changed, and must still land on
+# the original sender.
+func _scenario_join_during_inflight_command() -> void:
+	print("\n-- a second client joins mid-request --")
+	_connect_order.clear()
+	_deferred = {}
+
+	var client_a := WebSocketPeer.new()
+	_check("client A initiates connection", client_a.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT), OK)
+	await _step_until([client_a], func() -> bool:
+		return client_a.get_ready_state() == WebSocketPeer.STATE_OPEN
+	)
+
+	client_a.send_text(JSON.stringify({"id": "inflight-1", "command": "slow", "params": {}}))
+	var command_arrived := await _step_until([client_a], func() -> bool:
+		return not _deferred.is_empty()
+	)
+	_check("client A's command reached the server and is still unanswered", command_arrived, true)
+	if not command_arrived:
+		return
+
+	var client_b := WebSocketPeer.new()
+	_check("client B initiates connection while A waits", client_b.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT), OK)
+	var b_open := await _step_until([client_a, client_b], func() -> bool:
+		return client_b.get_ready_state() == WebSocketPeer.STATE_OPEN
+	)
+	_check("client B completes its handshake while A's request is pending", b_open, true)
+	_check("client A was not displaced by client B", client_a.get_ready_state(), WebSocketPeer.STATE_OPEN)
+	_check("server holds both connections", _server.get_connection_count(), 2)
+
+	var conn_id_a: int = _deferred["conn_id"]
+	_server.send_response(conn_id_a, {
+		"id": _deferred["id"],
+		"status": "ok",
+		"marker": "reply-for-conn-%d" % conn_id_a,
+	})
+
+	var reply_a: Dictionary = {"value": null}
+	await _step_until([client_a, client_b], func() -> bool:
+		if reply_a["value"] == null:
+			reply_a["value"] = _drain_reply(client_a)
+		return reply_a["value"] != null
+	)
+	_check("client A received its deferred reply", reply_a["value"] != null, true)
+	if reply_a["value"] != null:
+		_check("the deferred reply carries A's request id", str(reply_a["value"].get("id", "")), "inflight-1")
+		_check("the deferred reply is addressed to A's connection",
+			reply_a["value"].get("marker", ""), "reply-for-conn-%d" % conn_id_a)
+
+	# Give any stray packet a few frames to show up on B before declaring it clean.
+	for _i in 10:
+		client_b.poll()
+		await process_frame
+	_check("client B never saw A's reply", client_b.get_available_packet_count(), 0)
+
+	client_b.send_text(JSON.stringify({"id": "after-1", "command": "ping", "params": {}}))
+	var reply_b: Dictionary = {"value": null}
+	await _step_until([client_b], func() -> bool:
+		if reply_b["value"] == null:
+			reply_b["value"] = _drain_reply(client_b)
+		return reply_b["value"] != null
+	)
+	_check("client B is served normally afterwards",
+		reply_b["value"] != null and str(reply_b["value"].get("id", "")) == "after-1", true)
+
+	client_a.close()
+	client_b.close()
+	await _step_until([client_a, client_b], func() -> bool:
+		return _server.get_connection_count() == 0
+	)
+
+
+# Repeated connects and drops, mixing clean WebSocket clients with raw TCP peers that
+# never send an upgrade request. The raw peers are what produced the repeating
+# "awaiting WebSocket handshake" line, so they must be reaped, not accumulated.
+func _scenario_churn_leaves_nothing_behind() -> void:
+	print("\n-- connect/disconnect churn --")
+	var conn_id_before: int = _server._next_conn_id
+
+	for i in CHURN_CYCLES:
+		var client := WebSocketPeer.new()
+		client.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT)
+		await _step_until([client], func() -> bool:
+			return client.get_ready_state() == WebSocketPeer.STATE_OPEN
+		)
+		client.close()
+		await _step_until([client], func() -> bool:
+			return _server.get_connection_count() == 0
+		)
+
+	_check("every churn cycle completed its handshake", _server._next_conn_id - conn_id_before, CHURN_CYCLES)
+	_check("no connection entries survive the churn", _server._connections.size(), 0)
+
+	# A peer that opens TCP and then vanishes without ever upgrading. Rather than wait
+	# out HANDSHAKE_TIMEOUT_MSEC, drop the socket so the TCP-dead branch reaps it.
+	for i in 2:
+		var raw := StreamPeerTCP.new()
+		_check("raw TCP peer %d connects" % i, raw.connect_to_host("127.0.0.1", TEST_PORT), OK)
+		var accepted := await _step_until([], func() -> bool:
+			raw.poll()
+			return _server._connections.size() == 1
+		)
+		_check("raw TCP peer %d is tracked while it waits to upgrade" % i, accepted, true)
+		_check("a peer that never upgraded is not counted as connected" if i == 0 else
+			"a peer that never upgraded is still not counted as connected",
+			_server.get_connection_count(), 1)
+		raw.disconnect_from_host()
+		var reaped := await _step_until([], func() -> bool:
+			return _server._connections.size() == 0
+		)
+		_check("raw TCP peer %d is reaped once its socket dies" % i, reaped, true)
+
+	_check("no rejection peers left over after churn", _server._rejecting_peers.is_empty(), true)
+
+
+# Past MAX_CONNECTIONS the newcomer is refused. It must get a real coded close rather
+# than a bare TCP reset, and the slot must come back once someone leaves.
+func _scenario_connection_cap() -> void:
+	print("\n-- connection cap and the 4001 rejection --")
+	var limit: int = MCPWebSocketServer.MAX_CONNECTIONS
+	var clients: Array[WebSocketPeer] = []
+	for i in limit:
+		var client := WebSocketPeer.new()
+		client.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT)
+		clients.append(client)
+
+	var all_open := await _step_until(clients, func() -> bool:
+		for peer: WebSocketPeer in clients:
+			if peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
+				return false
+		return true
+	)
+	_check("all %d clients up to the cap connect" % limit, all_open, true)
+	_check("server reports %d connections" % limit, _server.get_connection_count(), limit)
+
+	var overflow := WebSocketPeer.new()
+	_check("overflow client initiates connection", overflow.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT), OK)
+	var closed := await _step_until(clients + [overflow], func() -> bool:
+		return overflow.get_ready_state() == WebSocketPeer.STATE_CLOSED
+	)
+	_check("overflow client is closed rather than served", closed, true)
+	_check("overflow client got a coded close, not a reset", overflow.get_close_code(), MCPWebSocketServer.CLOSE_CODE_TOO_MANY)
+	_check("the close carries the cap reason", overflow.get_close_reason(), MCPWebSocketServer.CLOSE_REASON_TOO_MANY)
+	_check("the cap was never exceeded", _server.get_connection_count(), limit)
+
+	var drained := await _step_until(clients, func() -> bool:
+		return _server._rejecting_peers.is_empty()
+	)
+	_check("the rejected peer is dropped once its close is flushed", drained, true)
+
+	clients[0].close()
+	await _step_until(clients, func() -> bool:
+		return _server.get_connection_count() == limit - 1
+	)
+
+	var latecomer := WebSocketPeer.new()
+	latecomer.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT)
+	var latecomer_open := await _step_until(clients + [latecomer], func() -> bool:
+		return latecomer.get_ready_state() == WebSocketPeer.STATE_OPEN
+	)
+	_check("a fresh client gets in once a slot frees", latecomer_open, true)
+	_check("server is back at the cap", _server.get_connection_count(), limit)
+
+	latecomer.close()
+	for peer: WebSocketPeer in clients:
+		peer.close()
+	await _step_until(clients + [latecomer], func() -> bool:
+		return _server.get_connection_count() == 0
+	)
+
+
+func _on_command_received(conn_id: int, id: String, command: String, _params: Dictionary) -> void:
+	if command == "slow":
+		_deferred = {"conn_id": conn_id, "id": id}
+		return
+	_server.send_response(conn_id, {"id": id, "status": "ok", "marker": "reply-for-conn-%d" % conn_id})
+
+
+func _on_client_connected(conn_id: int) -> void:
+	_connect_order.append(conn_id)
+
+
+func _drain_reply(ws: WebSocketPeer) -> Variant:
+	if ws.get_available_packet_count() == 0:
+		return null
+	var packet := ws.get_packet()
+	var json := JSON.new()
+	if json.parse(packet.get_string_from_utf8()) != OK:
+		return null
+	return json.data
+
+
+# WebSocketPeer only advances its handshake/close state machine while polled, and the
+# server node only advances on its own _process, so both sides need pumping each frame.
+func _step_until(peers: Array, predicate: Callable) -> bool:
+	for _i in POLL_TIMEOUT_FRAMES:
+		for peer: WebSocketPeer in peers:
+			peer.poll()
+		if predicate.call():
+			return true
+		await process_frame
+	return predicate.call()
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+func _finish() -> void:
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS: %d checks" % _count)
+	else:
+		printerr("FAILED: %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)

--- a/godot/addons/godot_mcp/test/websocket_connection_churn_test.gd.uid
+++ b/godot/addons/godot_mcp/test/websocket_connection_churn_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dssluj2i0oi1h

--- a/godot/addons/godot_mcp/test/websocket_multi_client_test.gd
+++ b/godot/addons/godot_mcp/test/websocket_multi_client_test.gd
@@ -1,0 +1,169 @@
+extends SceneTree
+
+## Regression guard for multi-client support in MCPWebSocketServer.
+## Drives the REAL server node with two live WebSocketPeer clients.
+##
+## THE BUG: the server held one client and closed any second connection with 4001,
+## so a second concurrently-running MCP client retried forever and never got in.
+##
+## THE FIX: per-connection state keyed by a monotonic conn_id, with 4001 demoted to
+## an overflow-only path past MAX_CONNECTIONS.
+##
+## Both clients deliberately send the SAME request id, the realistic case since
+## independent clients each count their ids from 1, and the reply marker comes from
+## the server-side conn_id rather than from params, so a pass proves routing by
+## connection identity instead of echoing caller data back.
+##   & "<godot.exe>" --headless --path "<project-with-addon>" \
+##       --script "res://addons/godot_mcp/test/websocket_multi_client_test.gd"
+## Exit code 0 = all checks passed, 1 = at least one failed.
+
+const TEST_PORT := 6599
+const POLL_TIMEOUT_FRAMES := 300  # ~5s at 60Hz; generous for local loopback
+
+var _count := 0
+var _failures := 0
+
+var _server: MCPWebSocketServer
+# Order conn_ids reached STATE_OPEN in. TCPServer accepts are FIFO, so this maps back
+# to "client A" / "client B" without trusting anything the client claims about itself.
+var _connect_order: Array[int] = []
+var _count_at_disconnect := -1
+
+
+func _initialize() -> void:
+	_run()
+
+
+func _run() -> void:
+	for i in 5:
+		await process_frame
+
+	print("\n===================== WEBSOCKET MULTI-CLIENT TEST =====================\n")
+
+	_server = MCPWebSocketServer.new()
+	root.add_child(_server)
+	_server.command_received.connect(_on_command_received)
+	_server.client_connected.connect(_on_client_connected)
+	_server.client_disconnected.connect(_on_client_disconnected)
+
+	var start_err := _server.start_server(TEST_PORT, "127.0.0.1")
+	_check("server starts on port %d" % TEST_PORT, start_err, OK)
+	if start_err != OK:
+		_finish()
+		return
+
+	var client_a := WebSocketPeer.new()
+	var client_b := WebSocketPeer.new()
+	_check("client A initiates connection", client_a.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT), OK)
+	_check("client B initiates connection", client_b.connect_to_url("ws://127.0.0.1:%d" % TEST_PORT), OK)
+
+	var both_open := await _step_until_polling([client_a, client_b], func() -> bool:
+		return client_a.get_ready_state() == WebSocketPeer.STATE_OPEN and client_b.get_ready_state() == WebSocketPeer.STATE_OPEN
+	)
+	_check("both clients reach STATE_OPEN (neither rejected with 4001)", both_open, true)
+	_check("server reports 2 connections", _server.get_connection_count(), 2)
+	_check("client_connected fired for both connections", _connect_order.size(), 2)
+	if _connect_order.size() != 2:
+		_finish()
+		return
+	var conn_id_a: int = _connect_order[0]
+	var conn_id_b: int = _connect_order[1]
+
+	client_a.send_text(JSON.stringify({"id": "1", "command": "ping", "params": {}}))
+	client_b.send_text(JSON.stringify({"id": "1", "command": "ping", "params": {}}))
+
+	# Mutable state lives in a Dictionary (a reference type): GDScript lambdas snapshot
+	# captured locals by value, so writes to a captured local would not be visible here.
+	var replies: Dictionary = {"a": null, "b": null}
+	await _step_until_polling([client_a, client_b], func() -> bool:
+		if replies["a"] == null:
+			replies["a"] = _drain_reply(client_a)
+		if replies["b"] == null:
+			replies["b"] = _drain_reply(client_b)
+		return replies["a"] != null and replies["b"] != null
+	)
+
+	_check("client A received a reply", replies["a"] != null, true)
+	_check("client B received a reply", replies["b"] != null, true)
+	if replies["a"] != null:
+		_check("client A got its own reply, not B's", replies["a"].get("marker", ""), "reply-for-conn-%d" % conn_id_a)
+	if replies["b"] != null:
+		_check("client B got its own reply, not A's", replies["b"].get("marker", ""), "reply-for-conn-%d" % conn_id_b)
+
+	client_a.close()
+	await _step_until_polling([client_b], func() -> bool:
+		return _count_at_disconnect >= 0
+	)
+	_check("count is already decremented inside the client_disconnected handler", _count_at_disconnect, 1)
+	_check("connection count drops to 1 after client A closes", _server.get_connection_count(), 1)
+	_check("client B still open after client A closed", client_b.get_ready_state(), WebSocketPeer.STATE_OPEN)
+
+	client_b.send_text(JSON.stringify({"id": "2", "command": "ping", "params": {}}))
+	var reply_b2: Dictionary = {"value": null}
+	await _step_until_polling([client_b], func() -> bool:
+		if reply_b2["value"] == null:
+			reply_b2["value"] = _drain_reply(client_b)
+		return reply_b2["value"] != null
+	)
+	_check("surviving client B still served after A disconnected",
+		reply_b2["value"] != null and reply_b2["value"].get("marker", "") == "reply-for-conn-%d" % conn_id_b, true)
+
+	client_b.close()
+	_server.stop_server()
+	root.remove_child(_server)
+	_server.free()
+	_finish()
+
+
+func _on_command_received(conn_id: int, id: String, _command: String, _params: Dictionary) -> void:
+	_server.send_response(conn_id, {"id": id, "status": "ok", "marker": "reply-for-conn-%d" % conn_id})
+
+
+func _on_client_connected(conn_id: int) -> void:
+	_connect_order.append(conn_id)
+
+
+func _on_client_disconnected(_conn_id: int) -> void:
+	# Reading from inside the handler, before pruning, is what caught a
+	# get_connection_count() off-by-one against a closed-but-not-yet-removed entry.
+	_count_at_disconnect = _server.get_connection_count()
+
+
+func _drain_reply(ws: WebSocketPeer) -> Variant:
+	if ws.get_available_packet_count() == 0:
+		return null
+	var packet := ws.get_packet()
+	var json := JSON.new()
+	if json.parse(packet.get_string_from_utf8()) != OK:
+		return null
+	return json.data
+
+
+# WebSocketPeer only advances its handshake/close state machine while polled, and the
+# server node only advances on its own _process, so both sides need pumping each frame.
+func _step_until_polling(peers: Array, predicate: Callable) -> bool:
+	for _i in POLL_TIMEOUT_FRAMES:
+		for peer: WebSocketPeer in peers:
+			peer.poll()
+		if predicate.call():
+			return true
+		await process_frame
+	return predicate.call()
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s : expected %s, got %s" % [_count, label, str(expected), str(got)])
+
+
+func _finish() -> void:
+	print("\n1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)

--- a/godot/addons/godot_mcp/test/websocket_multi_client_test.gd.uid
+++ b/godot/addons/godot_mcp/test/websocket_multi_client_test.gd.uid
@@ -1,0 +1,1 @@
+uid://ulr2fo5v82y4

--- a/godot/addons/godot_mcp/websocket_server.gd
+++ b/godot/addons/godot_mcp/websocket_server.gd
@@ -2,9 +2,9 @@
 extends Node
 class_name MCPWebSocketServer
 
-signal command_received(id: String, command: String, params: Dictionary)
-signal client_connected()
-signal client_disconnected()
+signal command_received(conn_id: int, id: String, command: String, params: Dictionary)
+signal client_connected(conn_id: int)
+signal client_disconnected(conn_id: int)
 
 const DEFAULT_PORT := 6550
 const STALE_CONNECTION_TIMEOUT_MSEC := 45000
@@ -14,18 +14,23 @@ const STALE_CONNECTION_TIMEOUT_MSEC := 45000
 const REJECT_TIMEOUT_MSEC := 5000
 const CLOSE_CODE_STALE := 4002
 const CLOSE_REASON_STALE := "Connection timed out (no activity)"
-const CLOSE_CODE_ALREADY_CONNECTED := 4001
-const CLOSE_REASON_ALREADY_CONNECTED := "Another client is already connected"
+const CLOSE_CODE_TOO_MANY := 4001
+const CLOSE_REASON_TOO_MANY := "Too many connections (limit reached)"
+const CLOSE_CODE_NORMAL := 1000
+# Real usage is a handful of concurrent agent sessions; the cap only exists to stop a
+# runaway client (a retry loop with no backoff) from spawning unbounded connections.
+const MAX_CONNECTIONS := 8
+# Without this, a peer that completes TCP but never upgrades sits in STATE_CONNECTING
+# forever, holding a MAX_CONNECTIONS slot.
+const HANDSHAKE_TIMEOUT_MSEC := 10000
 
 var _server: TCPServer
-var _peer: StreamPeerTCP
-var _ws_peer: WebSocketPeer
-var _is_connected := false
-var _connected_host: String = ""
-var _connected_port: int = 0
-var _last_activity_msec: int = 0
+var _next_conn_id: int = 1
+# Each entry: { "conn_id": int, "ws": WebSocketPeer, "tcp": StreamPeerTCP, "host": String,
+# "port": int, "last_activity_msec": int, "is_open": bool }.
+var _connections: Array[Dictionary] = []
 var _stale_reason: String = ""
-# Newcomers that arrived while a live client already held the bridge. Each entry
+# Newcomers that arrived while the server was already at MAX_CONNECTIONS. Each entry
 # is { "ws": WebSocketPeer, "tcp": StreamPeerTCP, "since_msec": int, "close_sent": bool }.
 # They are handshaked just far enough to receive a clean 4001 close, then dropped.
 var _rejecting_peers: Array = []
@@ -35,12 +40,15 @@ func _process(_delta: float) -> void:
 	if not _server:
 		return
 
-	if _server.is_connection_available():
-		_accept_connection()
+	# is_connection_available() alone is not a safe loop condition: take_connection()
+	# can still return null if the peer dropped mid-accept, spinning this loop forever.
+	while _server.is_connection_available():
+		if not _accept_connection():
+			break
 
-	if _ws_peer:
-		_ws_peer.poll()
-		_process_websocket()
+	for entry in _connections:
+		_poll_connection(entry)
+	_prune_closed_connections()
 
 	if not _rejecting_peers.is_empty():
 		_process_rejecting_peers()
@@ -58,13 +66,9 @@ func start_server(port: int = DEFAULT_PORT, bind_address: String = "127.0.0.1") 
 
 
 func stop_server() -> void:
-	if _ws_peer:
-		_ws_peer.close()
-		_ws_peer = null
-
-	if _peer:
-		_peer.disconnect_from_host()
-		_peer = null
+	for entry in _connections:
+		_close_connection(entry, CLOSE_CODE_NORMAL, "")
+	_connections.clear()
 
 	for entry in _rejecting_peers:
 		var rej_ws: WebSocketPeer = entry.get("ws")
@@ -79,71 +83,73 @@ func stop_server() -> void:
 		_server.stop()
 		_server = null
 
-	_is_connected = false
-	_connected_host = ""
-	_connected_port = 0
-	_last_activity_msec = 0
+
+func get_connection_count() -> int:
+	# client_disconnected fires a frame before the dead entry is pruned, and handlers
+	# read this count, so size() would be one too high for the duration of that signal.
+	var count := 0
+	for entry in _connections:
+		if entry["ws"] != null:
+			count += 1
+	return count
 
 
-func get_connected_host() -> String:
-	return _connected_host
+func get_connection_info(conn_id: int) -> Dictionary:
+	var entry := _find_connection(conn_id)
+	if entry.is_empty():
+		return {}
+	return {"host": entry["host"], "port": entry["port"]}
 
 
-func get_connected_port() -> int:
-	return _connected_port
-
-
-func send_response(response: Dictionary) -> void:
-	if not _ws_peer or _ws_peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
-		MCPLog.warn("Cannot send response: not connected")
+func send_response(conn_id: int, response: Dictionary) -> void:
+	var entry := _find_connection(conn_id)
+	var ws: WebSocketPeer = entry.get("ws")
+	if entry.is_empty() or not ws or ws.get_ready_state() != WebSocketPeer.STATE_OPEN:
+		MCPLog.warn("Cannot send response to conn %d: not connected" % conn_id)
 		return
 
 	var json := JSON.stringify(response)
-	_ws_peer.send_text(json)
+	ws.send_text(json)
 
 
-func _accept_connection() -> void:
+func _accept_connection() -> bool:
 	var incoming := _server.take_connection()
 	if not incoming:
-		return
+		return false
 
-	if _ws_peer != null:
-		if _is_stale_connection():
-			# The incumbent looks dead (TCP dropped, or no activity past the
-			# timeout). Hand the bridge to the newcomer so a crashed client can
-			# never permanently block reconnection.
-			MCPLog.warn("Replacing stale connection with new client (%s)" % _stale_reason)
-			_force_close_connection()
-		else:
-			# A live client already holds the bridge. Protect the incumbent and
-			# reject the newcomer with a clean close code instead of displacing
-			# it. This keeps a transient second client (e.g. a subagent that
-			# inherited the same MCP config) from bricking the active session.
-			MCPLog.warn("Rejecting new connection from %s:%d: another client is already connected" % [incoming.get_connected_host(), incoming.get_connected_port()])
-			_begin_reject(incoming)
-			return
+	if get_connection_count() >= MAX_CONNECTIONS:
+		MCPLog.warn("Rejecting new connection from %s:%d: connection cap (%d) reached" % [incoming.get_connected_host(), incoming.get_connected_port(), MAX_CONNECTIONS])
+		_begin_reject(incoming)
+		return true
 
-	_peer = incoming
-	_ws_peer = WebSocketPeer.new()
-	_ws_peer.outbound_buffer_size = 16 * 1024 * 1024  # 16MB for screenshot data
-	var err := _ws_peer.accept_stream(_peer)
+	var ws := WebSocketPeer.new()
+	ws.outbound_buffer_size = 16 * 1024 * 1024  # 16MB for screenshot data
+	var err := ws.accept_stream(incoming)
 	if err != OK:
 		MCPLog.error("Failed to accept WebSocket stream: %s" % error_string(err))
-		_ws_peer = null
-		_peer = null
-		return
+		return true
 
-	_connected_host = _peer.get_connected_host()
-	_connected_port = _peer.get_connected_port()
-	_last_activity_msec = Time.get_ticks_msec()
+	var conn_id := _next_conn_id
+	_next_conn_id += 1
+	var entry: Dictionary = {
+		"conn_id": conn_id,
+		"ws": ws,
+		"tcp": incoming,
+		"host": incoming.get_connected_host(),
+		"port": incoming.get_connected_port(),
+		"last_activity_msec": Time.get_ticks_msec(),
+		"is_open": false,
+	}
+	_connections.append(entry)
 
-	MCPLog.info("TCP connection received from %s:%d, awaiting WebSocket handshake..." % [_connected_host, _connected_port])
+	MCPLog.info("TCP connection received from %s:%d (conn %d), awaiting WebSocket handshake..." % [entry["host"], entry["port"], conn_id])
+	return true
 
 
 func _begin_reject(incoming: StreamPeerTCP) -> void:
 	# Complete just enough of the WebSocket handshake on a throwaway peer to send
 	# a proper coded close frame (4001), so the rejected client gets a clear
-	# diagnostic rather than an opaque TCP reset. The incumbent's peer is never
+	# diagnostic rather than an opaque TCP reset. Live connections are never
 	# touched. Driven to completion in _process_rejecting_peers().
 	var ws := WebSocketPeer.new()
 	var err := ws.accept_stream(incoming)
@@ -177,7 +183,7 @@ func _process_rejecting_peers() -> void:
 		match state:
 			WebSocketPeer.STATE_OPEN:
 				if not entry["close_sent"]:
-					ws.close(CLOSE_CODE_ALREADY_CONNECTED, CLOSE_REASON_ALREADY_CONNECTED)
+					ws.close(CLOSE_CODE_TOO_MANY, CLOSE_REASON_TOO_MANY)
 					entry["close_sent"] = true
 				# Keep polling so the close frame is actually flushed.
 				keep.append(entry)
@@ -198,101 +204,127 @@ func _drop_rejecting_peer(entry: Dictionary) -> void:
 	entry["tcp"] = null
 
 
-func _process_websocket() -> void:
-	if not _ws_peer:
-		return
-
-	var state := _ws_peer.get_ready_state()
+func _poll_connection(entry: Dictionary) -> void:
+	var ws: WebSocketPeer = entry["ws"]
+	ws.poll()
+	var state := ws.get_ready_state()
+	var conn_id: int = entry["conn_id"]
 
 	match state:
 		WebSocketPeer.STATE_CONNECTING:
-			pass
+			var tcp: StreamPeerTCP = entry["tcp"]
+			var timed_out: bool = Time.get_ticks_msec() - int(entry["last_activity_msec"]) > HANDSHAKE_TIMEOUT_MSEC
+			var tcp_dead: bool = tcp and tcp.get_status() != StreamPeerTCP.STATUS_CONNECTED
+			if timed_out or tcp_dead:
+				MCPLog.warn("Dropping conn %d: handshake never completed (%s)" % [conn_id, "timed out" if timed_out else "TCP peer disconnected"])
+				_close_connection(entry, CLOSE_CODE_STALE, CLOSE_REASON_STALE)
 
 		WebSocketPeer.STATE_OPEN:
-			if not _is_connected:
-				_is_connected = true
-				_last_activity_msec = Time.get_ticks_msec()
-				client_connected.emit()
-				MCPLog.info("WebSocket handshake complete")
+			if not entry["is_open"]:
+				entry["is_open"] = true
+				entry["last_activity_msec"] = Time.get_ticks_msec()
+				client_connected.emit(conn_id)
+				MCPLog.info("WebSocket handshake complete (conn %d)" % conn_id)
 
-			if _is_stale_connection():
-				MCPLog.warn("Closing stale connection (%s)" % _stale_reason)
-				_ws_peer.close(CLOSE_CODE_STALE, CLOSE_REASON_STALE)
+			if _is_stale_connection(entry):
+				MCPLog.warn("Closing stale connection (conn %d, %s)" % [conn_id, _stale_reason])
+				_close_connection(entry, CLOSE_CODE_STALE, CLOSE_REASON_STALE)
 				return
 
-			while _ws_peer.get_available_packet_count() > 0:
-				_last_activity_msec = Time.get_ticks_msec()
-				var packet := _ws_peer.get_packet()
-				_handle_packet(packet)
+			while ws.get_available_packet_count() > 0:
+				entry["last_activity_msec"] = Time.get_ticks_msec()
+				var packet := ws.get_packet()
+				_handle_packet(conn_id, packet)
 
 		WebSocketPeer.STATE_CLOSING:
 			pass
 
 		WebSocketPeer.STATE_CLOSED:
-			if _is_connected:
-				_is_connected = false
-				client_disconnected.emit()
-			_ws_peer = null
-			_peer = null
+			_mark_closed(entry)
 
 
-func _force_close_connection(close_code: int = CLOSE_CODE_STALE, close_reason: String = CLOSE_REASON_STALE) -> void:
-	if _ws_peer:
-		_ws_peer.close(close_code, close_reason)
-		_ws_peer = null
-	if _peer:
-		_peer.disconnect_from_host()
-		_peer = null
-	if _is_connected:
-		_is_connected = false
-		client_disconnected.emit()
-	_last_activity_msec = 0
-	_connected_host = ""
-	_connected_port = 0
+func _prune_closed_connections() -> void:
+	var keep: Array[Dictionary] = []
+	for entry in _connections:
+		if entry["ws"] == null:
+			continue
+		keep.append(entry)
+	_connections = keep
 
 
-func _is_stale_connection() -> bool:
-	if _last_activity_msec == 0:
+func _mark_closed(entry: Dictionary) -> void:
+	# Null out before emitting: get_connection_count() and _find_connection() key off
+	# ws == null, so a handler must not see this connection as still live.
+	var was_open: bool = entry["is_open"]
+	var conn_id: int = entry["conn_id"]
+	entry["is_open"] = false
+	entry["ws"] = null
+	entry["tcp"] = null
+	if was_open:
+		client_disconnected.emit(conn_id)
+
+
+func _close_connection(entry: Dictionary, close_code: int, close_reason: String) -> void:
+	var ws: WebSocketPeer = entry.get("ws")
+	if ws:
+		ws.close(close_code, close_reason)
+	var tcp: StreamPeerTCP = entry.get("tcp")
+	if tcp:
+		tcp.disconnect_from_host()
+	_mark_closed(entry)
+
+
+func _is_stale_connection(entry: Dictionary) -> bool:
+	var last_activity: int = entry["last_activity_msec"]
+	if last_activity == 0:
 		return false
-	if _peer and _peer.get_status() != StreamPeerTCP.STATUS_CONNECTED:
+	var tcp: StreamPeerTCP = entry["tcp"]
+	if tcp and tcp.get_status() != StreamPeerTCP.STATUS_CONNECTED:
 		_stale_reason = "TCP peer disconnected"
 		return true
-	if Time.get_ticks_msec() - _last_activity_msec > STALE_CONNECTION_TIMEOUT_MSEC:
+	if Time.get_ticks_msec() - last_activity > STALE_CONNECTION_TIMEOUT_MSEC:
 		_stale_reason = "no activity for %ds" % (STALE_CONNECTION_TIMEOUT_MSEC / 1000)
 		return true
 	return false
 
 
-func _handle_packet(packet: PackedByteArray) -> void:
+func _find_connection(conn_id: int) -> Dictionary:
+	for entry in _connections:
+		if entry["conn_id"] == conn_id and entry["ws"] != null:
+			return entry
+	return {}
+
+
+func _handle_packet(conn_id: int, packet: PackedByteArray) -> void:
 	var text := packet.get_string_from_utf8()
 
 	var json := JSON.new()
 	var err := json.parse(text)
 	if err != OK:
 		MCPLog.error("Failed to parse command: %s" % json.get_error_message())
-		_send_error_response("", "PARSE_ERROR", "Invalid JSON: %s" % json.get_error_message())
+		_send_error_response(conn_id, "", "PARSE_ERROR", "Invalid JSON: %s" % json.get_error_message())
 		return
 
 	if not json.data is Dictionary:
 		MCPLog.error("Invalid command format: expected JSON object")
-		_send_error_response("", "INVALID_FORMAT", "Expected JSON object")
+		_send_error_response(conn_id, "", "INVALID_FORMAT", "Expected JSON object")
 		return
 
 	var data: Dictionary = json.data
 	if not data.has("id") or not data.has("command"):
 		MCPLog.error("Invalid command format")
-		_send_error_response(data.get("id", ""), "INVALID_FORMAT", "Missing 'id' or 'command' field")
+		_send_error_response(conn_id, data.get("id", ""), "INVALID_FORMAT", "Missing 'id' or 'command' field")
 		return
 
 	var id: String = str(data.get("id"))
 	var command: String = data.get("command")
 	var params: Dictionary = data.get("params", {})
 
-	command_received.emit(id, command, params)
+	command_received.emit(conn_id, id, command, params)
 
 
-func _send_error_response(id: String, code: String, message: String) -> void:
-	send_response({
+func _send_error_response(conn_id: int, id: String, code: String, message: String) -> void:
+	send_response(conn_id, {
 		"id": id,
 		"status": "error",
 		"error": {

--- a/godot/addons/godot_mcp/websocket_server.gd
+++ b/godot/addons/godot_mcp/websocket_server.gd
@@ -127,6 +127,9 @@ func _accept_connection() -> bool:
 	var err := ws.accept_stream(incoming)
 	if err != OK:
 		MCPLog.error("Failed to accept WebSocket stream: %s" % error_string(err))
+		# Nothing tracks this peer, so drop it here or the socket lingers until
+		# the last reference happens to be released.
+		incoming.disconnect_from_host()
 		return true
 
 	var conn_id := _next_conn_id

--- a/server/README.md
+++ b/server/README.md
@@ -112,7 +112,7 @@ For richer runtime observation, add key nodes to the `mcp_watch` group or give t
 
 The server talks to an editor addon over a local WebSocket; the addon reaches into the running game over Godot's own debugger protocol, so the game process needs no extra ports or setup. The addon binds to `127.0.0.1` by default. WSL2 is fully supported (auto-detection, host IP discovery, configurable bind modes) — see the [Installation Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/INSTALL.md#wsl-support).
 
-Curious about connection lifecycles, the single-client policy, or how frozen-time stepping works under the hood? The [Architecture Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/architecture.md) goes deep.
+Curious about connection lifecycles, how the bridge handles concurrent clients, or how frozen-time stepping works under the hood? The [Architecture Guide](https://github.com/satelliteoflove/godot-mcp/blob/main/docs/architecture.md) goes deep.
 
 ## Works well with minimal-godot-mcp
 

--- a/server/src/__tests__/connection/websocket.test.ts
+++ b/server/src/__tests__/connection/websocket.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../utils/logger.js', () => ({
 }));
 
 // Application close codes the Godot addon uses on the bridge.
-const CLOSE_CODE_ALREADY_CONNECTED = 4001;
+const CLOSE_CODE_CONNECTION_LIMIT = 4001;
 const CLOSE_CODE_REPLACED = 4003;
 
 /**
@@ -95,9 +95,9 @@ describe('GodotConnection contention handling (#237)', () => {
     expect(connection.getDiagnostics().lastDisconnectReason).toBe('replaced_by_new_client');
   });
 
-  it('keeps retrying when rejected because another client is connected (4001)', async () => {
+  it('keeps retrying when rejected because the connection cap is reached (4001)', async () => {
     const bridge = await startFakeBridge((socket) => {
-      socket.on('message', () => socket.close(CLOSE_CODE_ALREADY_CONNECTED, 'Another client is already connected'));
+      socket.on('message', () => socket.close(CLOSE_CODE_CONNECTION_LIMIT, 'Too many connections (limit reached)'));
     });
     wss = bridge.wss;
 
@@ -106,8 +106,24 @@ describe('GodotConnection contention handling (#237)', () => {
 
     await connection.connect().catch(() => {});
     await expect(reconnecting).resolves.toBeUndefined();
-    expect(connection.getDiagnostics().lastDisconnectReason).toBe('rejected_another_client');
+    expect(connection.getDiagnostics().lastDisconnectReason).toBe('rejected_connection_limit');
     expect(connection.getDiagnostics().rejectionCount).toBe(1);
+  });
+
+  it('echoes the addon-supplied reason in the diagnostic message for a 4001 rejection', async () => {
+    const bridge = await startFakeBridge((socket) => {
+      socket.on('message', () => socket.close(CLOSE_CODE_CONNECTION_LIMIT, 'Too many connections (limit reached)'));
+    });
+    wss = bridge.wss;
+
+    connection = new GodotConnection({ host: '127.0.0.1', port: bridge.port });
+    const reconnecting = waitForEvent(connection, 'reconnecting');
+    await connection.connect().catch(() => {});
+    await reconnecting;
+
+    const message = connection.getDiagnosticMessage();
+    expect(message).toContain('Too many connections (limit reached)');
+    expect(message).not.toContain('Only one client');
   });
 
   it('no longer tells a replaced client to restart; reports automatic recovery', async () => {

--- a/server/src/connection/websocket.ts
+++ b/server/src/connection/websocket.ts
@@ -18,13 +18,13 @@ const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
 const PING_INTERVAL_MS = 30000;
 const PONG_TIMEOUT_MS = 10000;
 
-const CLOSE_CODE_ALREADY_CONNECTED = 4001;
+const CLOSE_CODE_CONNECTION_LIMIT = 4001;
 const CLOSE_CODE_STALE = 4002;
 const CLOSE_CODE_REPLACED = 4003;
 
 export type DisconnectReason =
   | 'never_connected'
-  | 'rejected_another_client'
+  | 'rejected_connection_limit'
   | 'replaced_by_new_client'
   | 'connection_refused'
   | 'connection_lost'
@@ -75,6 +75,9 @@ export class GodotConnection extends EventEmitter {
   private handshakeResult: HandshakeResult | null = null;
 
   private lastDisconnectReason: DisconnectReason = 'never_connected';
+  // Echoed verbatim in getDiagnosticMessage() rather than assuming a fixed policy string,
+  // since an older addon still sends 4001 for its old "one client only" meaning.
+  private lastCloseReason: string | null = null;
   private rejectionCount = 0;
   private lastErrorMessage: string | null = null;
   private currentState: 'connected' | 'disconnected' | 'connecting' | 'reconnecting' = 'disconnected';
@@ -145,14 +148,17 @@ export class GodotConnection extends EventEmitter {
     const lines: string[] = [];
 
     switch (diag.lastDisconnectReason) {
-      case 'rejected_another_client':
-        lines.push('Status: Another client is already connected to Godot');
+      case 'rejected_connection_limit':
+        lines.push(
+          this.lastCloseReason
+            ? `Status: Godot refused the connection: ${this.lastCloseReason}`
+            : 'Status: Godot refused the connection'
+        );
         if (diag.rejectionCount > 1) {
           lines.push(`Details: ${diag.rejectionCount} connection attempts rejected`);
         }
-        lines.push('Suggestion: Only one client can drive the Godot bridge at a time.');
-        lines.push('  This client keeps retrying and will connect once the other disconnects.');
-        lines.push('  If you did not expect another client, check for duplicate godot-mcp processes:');
+        lines.push('Suggestion: This client keeps retrying and will connect once a slot frees up.');
+        lines.push('  If this persists, check for duplicate godot-mcp processes:');
         lines.push('    macOS/Linux: ps aux | grep godot-mcp');
         lines.push('    Windows: Get-Process -Name node | ? CommandLine -Like "*godot-mcp*"');
         break;
@@ -244,17 +250,18 @@ export class GodotConnection extends EventEmitter {
         const wasConnected = this.currentState === 'connected';
         this.currentState = 'disconnected';
 
-        if (code === CLOSE_CODE_ALREADY_CONNECTED) {
-          this.lastDisconnectReason = 'rejected_another_client';
+        if (code === CLOSE_CODE_CONNECTION_LIMIT) {
+          this.lastDisconnectReason = 'rejected_connection_limit';
           this.rejectionCount++;
           // Back off in proportion to how many times we've been rejected so a
           // lingering second client doesn't busy-loop reconnecting every second
           // (each brief 'open' resets reconnectAttempt before this close fires).
           this.reconnectAttempt = Math.min(this.rejectionCount - 1, RECONNECT_DELAYS.length - 1);
-          const reasonStr = reason?.toString() || 'Another client is already connected';
+          const reasonStr = reason?.toString() || 'Too many connections (limit reached)';
+          this.lastCloseReason = reasonStr;
           logger.warningRateLimited(
-            'rejected-another-client',
-            'Another client holds the Godot bridge; will keep retrying',
+            'rejected-connection-limit',
+            'Godot connection cap reached; will keep retrying',
             {
               reason: reasonStr,
               rejectionCount: this.rejectionCount,


### PR DESCRIPTION
Closes #74 for the multi-client case. Supersedes the single-client policy from #76.

## The symptom

Only one MCP client can drive a running Godot editor. The addon's WebSocket server holds exactly one client, and any second connection is closed with code 4001. A second Claude Code session pointed at the same editor therefore loops on rejection forever: its client retries with backoff, so it never crashes and never recovers, it just hangs. Every one of those rejected clients is alive and ready; the server simply has nowhere to put them. With N concurrent sessions, one works and N-1 wait indefinitely.

## Why addon-side rather than a local broker

A local broker (one process that owns the single editor socket and fans several clients into it) needs a fork or wrapper of the published npm package to redirect its socket at the broker instead of at the editor. That is new distribution surface for a problem that is entirely internal.

The addon already carries everything routing needs: a per-request `id` on the wire and a per-connection socket. The only missing piece was keeping more than one of those sockets and remembering which reply belongs to which. Both approaches require zero protocol changes, but this one is a couple hundred lines in a file we already own, and it ships with the addon that has the bug.

## The design

`websocket_server.gd` keeps `_connections: Array[Dictionary]`. Each entry carries a monotonic int `conn_id`, its `WebSocketPeer`, its `StreamPeerTCP`, host, port, `last_activity_msec`, and `is_open`.

Signals are connection-tagged: `command_received(conn_id, id, command, params)`, `client_connected(conn_id)`, `client_disconnected(conn_id)`. `send_response(conn_id, response)` routes per connection. `plugin.gd`'s `_on_command_received` captures `conn_id` before its `await`, so commands from different clients interleaving across awaits cannot cross wires.

Stale detection is per connection, still 4002, still a 45s activity timeout. `HANDSHAKE_TIMEOUT_MSEC := 10000` closes peers stuck in `STATE_CONNECTING`, so a half-open connection cannot permanently occupy a `MAX_CONNECTIONS` slot.

`get_connection_count()` and `get_connection_info(conn_id)` replace `get_connected_host()` / `get_connected_port()`. Both ignore entries whose `ws` is null, because `client_disconnected` fires before the dead entry is pruned, and a handler that reads the count during that signal must already see the connection as gone.

`_process` drains every pending TCP connection per frame instead of one, so a burst of simultaneous client startups does not trickle in one accept per tick. `_accept_connection()` returns `bool` so the drain loop cannot spin forever when `take_connection()` returns null. It also drops the incoming socket when `accept_stream()` fails, matching the cleanup `_begin_reject()` already does on that failure.

## What happens to the rejection path from #76

#76 closed #74 by refusing the second connection outright, which protected the session that was already working: a subagent inheriting the same MCP config could not take the bridge away from an editor mid-edit. That guarantee survives here, but by construction rather than by refusal. Nothing is ever displaced, so there is no incumbent to protect.

The machinery #76 built is kept and repurposed rather than deleted. 4001 is an overflow-only path now, fired past `MAX_CONNECTIONS := 8`, and it still runs a newcomer through enough of the handshake to receive a clean coded close instead of a bare TCP reset. The constants read `CLOSE_CODE_TOO_MANY` / `CLOSE_REASON_TOO_MANY`. The branch that handed the bridge to a newcomer when the incumbent looked stale is gone, because with multiplexing there is nothing to hand over.

Nothing from #76 is left unreachable: `_begin_reject()`, `_process_rejecting_peers()`, `_drop_rejecting_peer()` and `REJECT_TIMEOUT_MSEC` are all on the cap path and are exercised by the tests below.

## Client-side changes

The npm client reads 4001 to classify a disconnect. Under the cap it means the server is full, not that someone else owns the bridge, so `server/src/connection/websocket.ts` classifies it as `rejected_connection_limit` and `getDiagnosticMessage()` quotes the reason string the addon sent rather than asserting a policy. That keeps the message accurate when a user's project still has an addon predating the cap, where 4001 carries the older meaning.

Retry behaviour is unchanged: backoff still scales with the rejection count, capped at 30s, which is the right response either way since a slot can free up.

`plugin.cfg` stays at 4.1.0.

## Accepted trade-off

Two sessions issuing truly simultaneous commands can interleave against shared handler instances. This PR does not try to prevent that, and it is a real user-visible risk. It is also strictly better than one session working and the rest hanging.

## Verification

Two dev-only regression tests, both driving the real server node with live `WebSocketPeer` clients.

`godot/addons/godot_mcp/test/websocket_multi_client_test.gd` covers concurrent connect and reply isolation. Both clients send the SAME request id `"1"`, which is the realistic case since independent clients each count their ids from 1. The reply marker is derived from the server-side `conn_id`, never from client-supplied params, so a pass proves routing by connection identity rather than echoing caller data back.

```
& "C:\godot\Godot_v4.7.1-stable\Godot_v4.7.1-stable_win64_console.exe" --headless `
    --path "<project-with-addon>" `
    --script "res://addons/godot_mcp/test/websocket_multi_client_test.gd"
```

```
===================== WEBSOCKET MULTI-CLIENT TEST =====================

ok 1 - server starts on port 6599 (= 0)
ok 2 - client A initiates connection (= 0)
ok 3 - client B initiates connection (= 0)
[godot-mcp] TCP connection received from 127.0.0.1:54228 (conn 1), awaiting WebSocket handshake...
[godot-mcp] TCP connection received from 127.0.0.1:54229 (conn 2), awaiting WebSocket handshake...
[godot-mcp] WebSocket handshake complete (conn 1)
[godot-mcp] WebSocket handshake complete (conn 2)
ok 4 - both clients reach STATE_OPEN (neither rejected with 4001) (= true)
ok 5 - server reports 2 connections (= 2)
ok 6 - client_connected fired for both connections (= 2)
ok 7 - client A received a reply (= true)
ok 8 - client B received a reply (= true)
ok 9 - client A got its own reply, not B's (= reply-for-conn-1)
ok 10 - client B got its own reply, not A's (= reply-for-conn-2)
ok 11 - count is already decremented inside the client_disconnected handler (= 1)
ok 12 - connection count drops to 1 after client A closes (= 1)
ok 13 - client B still open after client A closed (= 1)
ok 14 - surviving client B still served after A disconnected (= true)

1..14
ALL PASS — 14 checks
```

`godot/addons/godot_mcp/test/websocket_connection_churn_test.gd` re-checks the #74 failure modes under the new rules, since allowing several clients reopens exactly the situations that report described.

- A single client sending 25 commands back to back gets 25 distinct replies and stays open. That is the busy-client case from the report.
- A reply issued while a second client is joining still reaches its own sender, carrying its own request id, and the newcomer never sees it. This is the literal takeover described in #74, where the in-flight client lost its response.
- Ten connect/disconnect cycles leave `_connections` empty, and two peers that open TCP and never send an upgrade are reaped once their sockets die rather than accumulating. Those unupgraded peers are what produced the repeating console line.
- Client nine hits the cap, receives 4001 with the cap reason, and a fresh client gets in once a slot frees. `_rejecting_peers` drains back to empty.

The "TCP connection received, awaiting WebSocket handshake" line is logged 24 times across that run, once per accept, against 24 accepts. The per-frame repetition from #74 does not reappear.

```
================= WEBSOCKET CONNECTION CHURN TEST =================

ok 1 - server starts on port 6598 (= 0)

-- rapid burst on one client --
ok 4 - every command in the burst got a reply (= 25)
ok 5 - no reply arrived twice (= 0)
ok 7 - burst client still open after the burst (= 1)

-- a second client joins mid-request --
ok 13 - client A was not displaced by client B (= 1)
ok 16 - the deferred reply carries A's request id (= inflight-1)
ok 17 - the deferred reply is addressed to A's connection (= reply-for-conn-2)
ok 18 - client B never saw A's reply (= 0)

-- connect/disconnect churn --
ok 20 - every churn cycle completed its handshake (= 10)
ok 21 - no connection entries survive the churn (= 0)
ok 25 - raw TCP peer 0 is reaped once its socket dies (= true)
ok 30 - no rejection peers left over after churn (= true)

-- connection cap and the 4001 rejection --
ok 32 - server reports 8 connections (= 8)
ok 35 - overflow client got a coded close, not a reset (= 4001)
ok 36 - the close carries the cap reason (= Too many connections (limit reached))
ok 37 - the cap was never exceeded (= 8)
ok 38 - the rejected peer is dropped once its close is flushed (= true)
ok 39 - a fresh client gets in once a slot frees (= true)

1..40
ALL PASS: 40 checks
```

End-to-end, two clients speaking the real 4.1.0 wire protocol against a headless editor running the patched addon on port 6599: both clients OPEN, both `mcp_handshake` success, `addon_version=4.1.0`, `godot_version=4.7.1-stable`, interleaved A/B batches with zero cross-delivery, surviving client still served after the other closed, and no 4001 at any point.

Server package green:

```
npm run build   # ok, addon copied
npm test        # Test Files 36 passed (36) | Tests 604 passed | 7 skipped (611)
npx tsc --noEmit
```

Neither GDScript test runs in CI, which has no Godot. `godot/addons/godot_mcp/test/README.md` covers how to run them.

## Docs

`docs/architecture.md`, `docs/troubleshooting.md` and both READMEs describe concurrent clients, the cap, and what a 4001 rejection means to a user hitting it.

## Known gap, not addressed here

`_close_connection()` severs the TCP socket in the same call that queues the close frame, so codes 4002 and 1000 never reach the client and a stale drop reads as an abrupt disconnect. The client reconnects either way, so this is a diagnostics defect. It predates this branch and is left for its own change.
