### PR TITLE
fix: sequence report type changes, fail fast on game exit, UI facts in digest

### DIFF
--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -20,13 +20,13 @@ Snapshot current game entity state as structured JSON — exact positions, veloc
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `select` | `group`, `method`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "auto" = best available (default: auto picks group → method → a visibility fallback that surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), "none" = no automatic selection; return only the nodes named in paths |
+| `select` | `group`, `method`, `visible`, `auto`, `none` | No | Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), "visible" = the visibility tier explicitly (visible 2D CanvasItems including runtime-spawned UI, AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), "auto" = best available (default: auto picks group → method → the visibility tier as a fallback), "none" = no automatic selection; return only the nodes named in paths. Use "visible" with name/type filters to reach UI that is not in the group, e.g. select="visible", type="Label". |
 | `group` | string | No | Group name to use when select="group" or "auto" (default: "mcp_watch") |
 | `paths` | string[] | No | Explicit absolute node paths to include in addition to tier selection, e.g. ["/root/GameState"]. The digest walks the current scene only, so autoload singletons — where global game state often lives (cash, score, settings) — are otherwise unreachable. Each path returns _mcp_state() if present, else a snapshot of the node's script variables (scalars/arrays, ~1 KB cap). Paths that do not resolve are returned in unresolved_paths. |
 | `name` | string | No | Glob filter on node name (e.g. "Player*") |
 | `type` | string | No | Class filter (e.g. "CharacterBody2D") |
 | `max_nodes` | integer | No | Maximum nodes in result (default: 40) |
-| `include` | string[] | No | Subset of fields to include (default: all available) |
+| `include` | string[] | No | Subset of fields to include (default: all available). "ui" adds global_rect / visible_in_tree / has_focus / text on Controls. |
 
 #### `watch_start`
 

--- a/godot/addons/godot_mcp/commands/exec_commands.gd
+++ b/godot/addons/godot_mcp/commands/exec_commands.gd
@@ -98,6 +98,9 @@ func _send_and_wait(msg_type: String, args: Array, timeout: float, call_id: int)
 		# break in the window — including a developer's own breakpoint hit by
 		# unrelated game code while an exec call is in flight. Accepted for the
 		# dev-tooling threat model and surfaced in the tool description.
+		if not debugger_plugin.has_active_session():
+			_last_error = _error("GAME_EXITED", "The game exited while waiting for %s (stopped, quit, or crashed)" % msg_type)
+			return null
 		if debugger_plugin.is_session_breaked():
 			debugger_plugin.continue_session()
 		if debugger_plugin.has_response(msg_type):

--- a/godot/addons/godot_mcp/commands/game_time_commands.gd
+++ b/godot/addons/godot_mcp/commands/game_time_commands.gd
@@ -81,6 +81,9 @@ func _send_and_wait(msg_type: String, args: Array, timeout: float):
 	var start_time := Time.get_ticks_msec()
 	while not debugger_plugin.has_response(msg_type):
 		await Engine.get_main_loop().process_frame
+		if not debugger_plugin.has_active_session():
+			_last_error = _error("GAME_EXITED", "The game exited while waiting for %s (stopped, quit, or crashed)" % msg_type)
+			return null
 		if (Time.get_ticks_msec() - start_time) / 1000.0 > timeout:
 			debugger_plugin.clear_response(msg_type)
 			_last_error = _error("TIMEOUT", "Timed out waiting for %s response" % msg_type)

--- a/godot/addons/godot_mcp/commands/input_commands.gd
+++ b/godot/addons/godot_mcp/commands/input_commands.gd
@@ -3,6 +3,8 @@ extends MCPBaseCommand
 class_name MCPInputCommands
 
 const INPUT_TIMEOUT := 30.0
+# Error text the debugger plugin emits when the session ends mid-call (#359).
+const SESSION_ENDED := "Game session ended"
 # How long to wait for the game bridge to report it is ready to receive input
 # before giving up. The natural workflow is run -> immediately drive the game;
 # the session connects before the scene loads, so this short wait absorbs that
@@ -221,6 +223,9 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 
 	while _sequence_pending:
 		await Engine.get_main_loop().process_frame
+		if _sequence_pending and not debugger_plugin.has_active_session():
+			_sequence_pending = false
+			_sequence_result = {"error": SESSION_ENDED}
 		if (Time.get_ticks_msec() - op_start) / 1000.0 > timeout:
 			_sequence_pending = false
 			if debugger_plugin.input_sequence_completed.is_connected(_on_sequence_completed):
@@ -232,6 +237,8 @@ func execute_input_sequence(params: Dictionary) -> Dictionary:
 	if debugger_plugin.sequence_capture_received.is_connected(_on_sequence_capture):
 		debugger_plugin.sequence_capture_received.disconnect(_on_sequence_capture)
 
+	if _sequence_result.get("error", "") == SESSION_ENDED:
+		return _error("GAME_EXITED", "The game exited during the input sequence (stopped, quit, or crashed)")
 	if _sequence_result.has("error"):
 		return _error("SEQUENCE_ERROR", _sequence_result.get("error", "Unknown error"))
 
@@ -289,12 +296,17 @@ func type_text(params: Dictionary) -> Dictionary:
 
 	while _type_text_pending:
 		await Engine.get_main_loop().process_frame
+		if _type_text_pending and not debugger_plugin.has_active_session():
+			_type_text_pending = false
+			_type_text_result = {"error": SESSION_ENDED}
 		if (Time.get_ticks_msec() - op_start) / 1000.0 > timeout:
 			_type_text_pending = false
 			if debugger_plugin.type_text_completed.is_connected(_on_type_text_completed):
 				debugger_plugin.type_text_completed.disconnect(_on_type_text_completed)
 			return _error("TIMEOUT", "Timed out waiting for text input to complete")
 
+	if _type_text_result.get("error", "") == SESSION_ENDED:
+		return _error("GAME_EXITED", "The game exited during text input (stopped, quit, or crashed)")
 	if _type_text_result.has("error"):
 		return _error("TYPE_TEXT_ERROR", _type_text_result.get("error", "Unknown error"))
 

--- a/godot/addons/godot_mcp/commands/runtime_state_commands.gd
+++ b/godot/addons/godot_mcp/commands/runtime_state_commands.gd
@@ -73,6 +73,9 @@ func _send_and_wait(msg_type: String, args: Array = []):
 	var start_time := Time.get_ticks_msec()
 	while not debugger_plugin.has_response(msg_type):
 		await Engine.get_main_loop().process_frame
+		if not debugger_plugin.has_active_session():
+			_last_error = _error("GAME_EXITED", "The game exited while waiting for %s (stopped, quit, or crashed)" % msg_type)
+			return null
 		if (Time.get_ticks_msec() - start_time) / 1000.0 > GENERIC_TIMEOUT:
 			debugger_plugin.clear_response(msg_type)
 			_last_error = _error("TIMEOUT", "Timed out waiting for %s response" % msg_type)

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -79,6 +79,11 @@ func _setup_session(session_id: int) -> void:
 	_active_session_id = session_id
 	# New game session: its bridge has not announced readiness yet.
 	_bridge_ready = false
+	# Without this the game quitting (or crashing, or being stopped) mid-call
+	# was invisible to every relay, which then sat out its full timeout (#359).
+	var session := get_session(session_id)
+	if session and not session.stopped.is_connected(_session_stopped):
+		session.stopped.connect(_session_stopped)
 
 
 func _session_stopped() -> void:
@@ -102,8 +107,11 @@ func _session_stopped() -> void:
 	if _pending_type_text:
 		_pending_type_text = false
 		type_text_completed.emit({"error": "Game session ended"})
+	# Drop pending relays rather than answering them with an empty dictionary,
+	# which callers would have read as a successful (empty) response. The relay
+	# loops notice has_active_session() going false and report GAME_EXITED.
 	for msg_type in _pending_requests:
-		_responses[msg_type] = {}
+		_responses.erase(msg_type)
 	_pending_requests.clear()
 
 

--- a/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
+++ b/godot/addons/godot_mcp/core/mcp_debugger_plugin.gd
@@ -76,14 +76,25 @@ func _handle_bridge_ready(session_id: int) -> void:
 
 
 func _setup_session(session_id: int) -> void:
+	_session_started(session_id)
+	# Godot reuses the EditorDebuggerSession across runs, so this virtual fires
+	# once per editor lifetime. Both lifecycle signals are wired here: without
+	# `stopped`, the game quitting mid-call was invisible to every relay, which
+	# then sat out its full timeout (#359); without `started`, the id cleared
+	# on stop would never come back for the next run.
+	var session := get_session(session_id)
+	if session == null:
+		return
+	if not session.started.is_connected(_session_started):
+		session.started.connect(_session_started.bind(session_id))
+	if not session.stopped.is_connected(_session_stopped):
+		session.stopped.connect(_session_stopped)
+
+
+func _session_started(session_id: int) -> void:
 	_active_session_id = session_id
 	# New game session: its bridge has not announced readiness yet.
 	_bridge_ready = false
-	# Without this the game quitting (or crashing, or being stopped) mid-call
-	# was invisible to every relay, which then sat out its full timeout (#359).
-	var session := get_session(session_id)
-	if session and not session.stopped.is_connected(_session_stopped):
-		session.stopped.connect(_session_stopped)
 
 
 func _session_stopped() -> void:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -264,7 +264,10 @@ func _compute_report_deltas(before: Dictionary, after: Dictionary) -> Dictionary
 	for src in before:
 		var b: Variant = before[src]
 		var a: Variant = after.get(src, null)
-		var changed: bool = b != a
+		# Compare type first: `!=` across Variant types (a String reading that
+		# turned into an {error} Dictionary) raises in GDScript 4 and would abort
+		# the emit, leaving the caller to time out (#358).
+		var changed: bool = typeof(a) != typeof(b) or a != b
 		if changed:
 			any_changed = true
 		deltas[src] = {"before": b, "after": a, "changed": changed}
@@ -789,7 +792,11 @@ func _handle_get_runtime_state(data: Array) -> void:
 
 	# Determine which selection tier to use
 	var actual_selection: String = select_mode
-	if select_mode == "auto":
+	if select_mode == "visible":
+		# Explicit request for the visibility tier (#360): reaches runtime-spawned
+		# UI and world nodes even when an mcp_watch group or _mcp_state() exists.
+		actual_selection = "fallback"
+	elif select_mode == "auto":
 		if _has_group_members(scene_root, group_name):
 			actual_selection = "group"
 		elif _has_mcp_state_nodes(scene_root):
@@ -845,6 +852,14 @@ func _handle_get_runtime_state(data: Array) -> void:
 
 	var autoloads := _list_autoload_paths(scene_root)
 
+	# Which Control has keyboard/controller focus, for UI navigation checks (#360).
+	var focus_owner_path := ""
+	var scene_viewport := scene_root.get_viewport()
+	if scene_viewport != null:
+		var focus_owner := scene_viewport.gui_get_focus_owner()
+		if focus_owner != null:
+			focus_owner_path = _node_path_string(focus_owner, scene_root)
+
 	var hint := ""
 	if actual_selection == "fallback":
 		hint = ("No nodes found in group '%s' and no _mcp_state() methods detected; " +
@@ -874,6 +889,8 @@ func _handle_get_runtime_state(data: Array) -> void:
 		result["available_autoloads"] = autoloads
 	if camera_entity:
 		result["camera"] = camera_entity
+	if not focus_owner_path.is_empty():
+		result["focus_owner"] = focus_owner_path
 	if not hint.is_empty():
 		result["hint"] = hint
 	if not unresolved_paths.is_empty():
@@ -978,6 +995,7 @@ func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 	var want_groups := want or include_fields.has("groups")
 	var want_onscreen := want or include_fields.has("onscreen")
 	var want_state := want or include_fields.has("state")
+	var want_ui := want or include_fields.has("ui")
 
 	var entity: Dictionary = {
 		"path": _node_path_string(node, scene_root),
@@ -1037,6 +1055,9 @@ func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 			entity["anim"] = asp.animation
 			entity["anim_frame"] = asp.frame
 
+	if want_ui and node is Control:
+		entity["ui"] = _control_ui_state(node as Control)
+
 	if want_onscreen:
 		# Resolve the camera from the node's own viewport (handles SubViewport
 		# cameras) and use the correct geometry per dimension — 3D frustum, 2D
@@ -1058,6 +1079,26 @@ func _extract_node_state(node: Node, scene_root: Node, include_fields: Array,
 				entity["state"] = snap
 
 	return entity
+
+
+# Layout-engine facts about a Control that only the running process can
+# answer (#360): where it actually landed, whether it is shown, what it says,
+# and whether it holds focus. `text` covers Label, Button, LineEdit,
+# RichTextLabel and anything else exposing a String `text` property.
+func _control_ui_state(c: Control) -> Dictionary:
+	var r := c.get_global_rect()
+	var ui: Dictionary = {
+		"global_rect": {
+			"x": snapped(r.position.x, 0.01), "y": snapped(r.position.y, 0.01),
+			"w": snapped(r.size.x, 0.01), "h": snapped(r.size.y, 0.01),
+		},
+		"visible_in_tree": c.is_visible_in_tree(),
+		"has_focus": c.has_focus(),
+	}
+	var text: Variant = c.get("text")
+	if text is String:
+		ui["text"] = (text as String).substr(0, 200)
+	return ui
 
 
 const _MCP_STATE_MAX_BYTES := 1024

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.2"
+version="4.1.3"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd
+++ b/godot/addons/godot_mcp/test/digest_fallback_3d_test.gd
@@ -49,6 +49,7 @@ func _run() -> void:
 	_test_entity_data_and_onscreen()
 	_test_max_nodes_and_type_filter()
 	_test_fallback_branch_conditions_hold()
+	_test_ui_fields()
 
 	print("1..%d" % _count)
 	if _failures == 0:
@@ -130,6 +131,7 @@ func _build_scene() -> void:
 	_scene.add_child(ui)
 	var label := Label.new()
 	label.name = "Score"
+	label.text = "Score: 12"
 	ui.add_child(label)
 	var button := Button.new()
 	button.name = "Start"
@@ -241,6 +243,23 @@ func _test_fallback_branch_conditions_hold() -> void:
 	# nodes, auto would resolve to fallback (per the resolver order in the bridge).
 	_check("no mcp_watch members (auto would pick fallback)", get_nodes_in_group("mcp_watch").size(), 0)
 	_check("no _mcp_state() nodes (auto would pick fallback)", _bridge._has_mcp_state_nodes(_scene), false)
+
+
+func _test_ui_fields() -> void:
+	# Controls carry a `ui` block with layout facts from the running process (#360).
+	var r := _collect(40, "")
+	var label = _find_by_name(r, "/UI/Score")
+	_check("Label selected by the visibility tier", label != null, true)
+	if label == null:
+		return
+	var ui: Dictionary = label.get("ui", {})
+	_check("ui.text carries the label text", ui.get("text", ""), "Score: 12")
+	_check("ui.visible_in_tree", ui.get("visible_in_tree", false), true)
+	_check("ui.has_focus false for an unfocused label", ui.get("has_focus", true), false)
+	var rect: Dictionary = ui.get("global_rect", {})
+	_check("ui.global_rect has a positive width", float(rect.get("w", 0.0)) > 0.0, true)
+	var mesh = _find_by_name(r, "/MeshFront")
+	_check("non-Control entities carry no ui block", mesh != null and not mesh.has("ui"), true)
 
 
 # ── Tiny TAP-ish harness ──────────────────────────────────────────────────────

--- a/godot/addons/godot_mcp/test/input_sequence_effect_probe_test.gd
+++ b/godot/addons/godot_mcp/test/input_sequence_effect_probe_test.gd
@@ -63,6 +63,13 @@ func _run() -> void:
 	_check("missing after reads as null", d3["report"]["a"]["after"], null)
 	_check("missing after counts as changed", d3["report"]["a"]["changed"], true)
 
+	# A reading that changes Variant type across the window (a String path that
+	# became an {error} Dictionary) must diff as changed, not raise (#358).
+	var d4 := bridge._compute_report_deltas({"a": "/root/Menu/Resume"}, {"a": {"error": "On call to 'get_path':"}})
+	_check("type change across window counts as changed", d4["report"]["a"]["changed"], true)
+	var d5 := bridge._compute_report_deltas({"a": 3}, {"a": 3.0})
+	_check("int vs float of same value counts as changed", d5["report"]["a"]["changed"], true)
+
 	# --- 2. drain/settle + clean emit on a report-ful sequence --------------
 	# `1 + 1` evaluates in the predicate context (tree/root always present), so the
 	# probe path is exercised with no game-specific autoload.
@@ -81,12 +88,25 @@ func _run() -> void:
 	_check("probe state reset after emit", bridge._sequence_report.is_empty(), true)
 	_check("the tap registered and released (not latched)", Input.is_action_pressed(ACTION), false)
 
-	# --- 3. a bad report expression rejects without starting a sequence -----
+	# --- 3. a report expression that fails to PARSE rejects without starting a
+	# sequence. One that parses but cannot evaluate yet (unknown identifier) is
+	# accepted since #353 — it reads as {error} in the diff instead.
+	bridge._handle_execute_input_sequence([
+		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 10}],
+		["1 +"],
+	])
+	_check("unparseable report expression does NOT start a sequence", bridge._sequence_running, false)
+
 	bridge._handle_execute_input_sequence([
 		[{"action_name": ACTION, "start_ms": 0, "duration_ms": 10}],
 		["bogus_identifier_xyz + 1"],
 	])
-	_check("invalid report expression does NOT start a sequence", bridge._sequence_running, false)
+	_check("eval-failing report expression still starts a sequence (#353)", bridge._sequence_running, true)
+	var baseline: Variant = bridge._sequence_report_before.get("bogus_identifier_xyz + 1")
+	_check("its baseline reads as {error}", baseline is Dictionary and baseline.has("error"), true)
+	for i in 6:
+		await process_frame
+	_check("that sequence finished cleanly", bridge._sequence_running, false)
 
 	root.remove_child(bridge)
 	bridge.free()

--- a/godot/addons/godot_mcp/test/report_lenient_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/report_lenient_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dimxhr16qo5qu

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/core/__toolsnaps__/godot_runtime_state.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_runtime_state.json
@@ -15,11 +15,12 @@
         "description": "digest: Snapshot current game entity state as structured JSON — exact positions, velocities, animation state, and custom game data. Much cheaper than screenshot_game (no vision tokens). Works on any game with no setup; add nodes to the \"mcp_watch\" group or implement `func _mcp_state() -> Dictionary` on key nodes for richer, targeted data. WHAT TO PUT IN _mcp_state(): include BOTH (1) live runtime values that change during play (cursor position, health, score, fill counts) AND (2) static definition context an agent needs to interpret them — e.g. a puzzle node should expose its clue data, a level node its objective list, a shop its item catalog. Without definition context, an agent can observe state changes but cannot verify correctness. Also include layout geometry for renderable nodes (bounds, sizes, offsets) to enable programmatic layout checks without a screenshot.\nwatch_start: Start an in-engine sampler that records specified node fields over a time window. Returns immediately; call watch_collect after duration_ms to get the summarized digest. Field keys: \"pos.x\", \"pos.y\", \"vel.x\", \"vel.y\" for built-in properties; any key from _mcp_state() for custom game state (e.g. \"health\", \"ammo\"). TIMING: watch_start and the action that drives state change (godot_input sequence, player input, etc.) must overlap within the watch window. Send both in the same parallel tool call batch, or use a duration_ms large enough (3000–4000ms) to cover the round-trip latency before the driving action is approved and sent. NODE PATHS: if a path in specs cannot be resolved, that spec is silently skipped; check resolved_fields in the response — 0 means all paths were invalid.\nwatch_collect: Collect the current sampler buffer and return a per-field summary (start/end/min/max/mean/slope for numeric fields; transition events for string fields) plus a time-sorted `timeline` merging watched signal emissions with string-field transitions (kinds: signal, anim_transition, field_change). TIMESTAMPS: signal t_ms is emission time (ms resolution); anim/field t_ms is DETECTION time at the sample rate — the change happened up to one sample interval earlier, so do not infer cross-kind ordering from nearby timestamps. Safe to call before auto-stop — returns whatever has been recorded so far; signal connections stay live until the window ends.\nwatch_stop: Stop the sampler early (disconnecting watched signals) and return the final per-field summary and merged `timeline`. Equivalent to watch_collect + stopping the sampler."
       },
       "select": {
-        "description": "Selection tier: \"group\" = nodes in mcp_watch group, \"method\" = nodes with _mcp_state(), \"auto\" = best available (default: auto picks group → method → a visibility fallback that surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), \"none\" = no automatic selection; return only the nodes named in paths (for: digest)",
+        "description": "Selection tier: \"group\" = nodes in mcp_watch group, \"method\" = nodes with _mcp_state(), \"visible\" = the visibility tier explicitly (visible 2D CanvasItems including runtime-spawned UI, AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), \"auto\" = best available (default: auto picks group → method → the visibility tier as a fallback), \"none\" = no automatic selection; return only the nodes named in paths. Use \"visible\" with name/type filters to reach UI that is not in the group, e.g. select=\"visible\", type=\"Label\". (for: digest)",
         "type": "string",
         "enum": [
           "group",
           "method",
+          "visible",
           "auto",
           "none"
         ]
@@ -50,7 +51,7 @@
         "maximum": 200
       },
       "include": {
-        "description": "Subset of fields to include (default: all available) (for: digest)",
+        "description": "Subset of fields to include (default: all available). \"ui\" adds global_rect / visible_in_tree / has_focus / text on Controls. (for: digest)",
         "type": "array",
         "items": {
           "type": "string",
@@ -60,7 +61,8 @@
             "anim",
             "groups",
             "onscreen",
-            "state"
+            "state",
+            "ui"
           ]
         }
       },

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -60,6 +60,11 @@ describe('runtimeState tool', () => {
       expect(runtimeState.schema.safeParse({ action: 'digest', select: 'fallback' }).success).toBe(false);
     });
 
+    it('accepts select="visible" and include "ui" (#360)', () => {
+      expect(runtimeState.schema.safeParse({ action: 'digest', select: 'visible', type: 'Label' }).success).toBe(true);
+      expect(runtimeState.schema.safeParse({ action: 'digest', include: ['ui'] }).success).toBe(true);
+    });
+
     it('accepts select="none" with explicit paths', () => {
       expect(
         runtimeState.schema.safeParse({ action: 'digest', select: 'none', paths: ['/root/GameState'] }).success

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -22,6 +22,13 @@ interface EntitySnapshot {
   zoom?: { x: number; y: number };
   onscreen?: boolean;
   state?: Record<string, unknown>;
+  // Controls only (#360): layout facts from the running process.
+  ui?: {
+    global_rect: { x: number; y: number; w: number; h: number };
+    visible_in_tree: boolean;
+    has_focus: boolean;
+    text?: string;
+  };
 }
 
 interface DigestResponse {
@@ -29,6 +36,7 @@ interface DigestResponse {
   selection: 'group' | 'method' | 'fallback';
   entity_count: number;
   camera?: EntitySnapshot;
+  focus_owner?: string;
   entities: EntitySnapshot[];
   hint?: string;
   unresolved_paths?: string[];
@@ -246,7 +254,7 @@ function summarizeWatchResponse(raw: WatchRawResponse) {
 
 // ── Schema ───────────────────────────────────────────────────────────────────
 
-const INCLUDE_VALUES = ['transform', 'velocity', 'anim', 'groups', 'onscreen', 'state'] as const;
+const INCLUDE_VALUES = ['transform', 'velocity', 'anim', 'groups', 'onscreen', 'state', 'ui'] as const;
 
 const RuntimeStateSchema = z.discriminatedUnion('action', [
   z.object({
@@ -266,13 +274,15 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
         'checks without a screenshot.'
       ),
     select: z
-      .enum(['group', 'method', 'auto', 'none'])
+      .enum(['group', 'method', 'visible', 'auto', 'none'])
       .optional()
       .describe(
         'Selection tier: "group" = nodes in mcp_watch group, "method" = nodes with _mcp_state(), ' +
-        '"auto" = best available (default: auto picks group → method → a visibility fallback that ' +
-        'surfaces visible 2D nodes (CanvasItems) AND 3D world nodes — meshes, gridmaps, cameras, ' +
-        'lights, physics bodies and areas), "none" = no automatic selection; return only the nodes named in paths'
+        '"visible" = the visibility tier explicitly (visible 2D CanvasItems including runtime-spawned UI, ' +
+        'AND 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas), ' +
+        '"auto" = best available (default: auto picks group → method → the visibility tier as a fallback), ' +
+        '"none" = no automatic selection; return only the nodes named in paths. Use "visible" with name/type ' +
+        'filters to reach UI that is not in the group, e.g. select="visible", type="Label".'
       ),
     group: z
       .string()
@@ -301,7 +311,7 @@ const RuntimeStateSchema = z.discriminatedUnion('action', [
     include: z
       .array(z.enum(INCLUDE_VALUES))
       .optional()
-      .describe('Subset of fields to include (default: all available)'),
+      .describe('Subset of fields to include (default: all available). "ui" adds global_rect / visible_in_tree / has_focus / text on Controls.'),
   }),
   z.object({
     action: z


### PR DESCRIPTION
- #358: `_compute_report_deltas` compares Variant type before value. A probe reading that changes type across the window (a String path that becomes an `{error}` dictionary) now diffs as changed instead of raising inside the emit and leaving the call to time out.
- #359: the root cause was that `_session_stopped` in the debugger plugin was never connected to the session's `stopped` signal, so all of its cleanup was dead code. It is connected now, and every relay loop (sequence, type_text, step, step_until, exec, runtime state) also polls `has_active_session()` and returns `GAME_EXITED` when the game stops, quits or crashes mid-call. A stopped session used to answer pending relays with an empty dictionary, which callers read as an empty success; it now drops them.
- #360, the first two items: `select="visible"` picks the visibility tier explicitly so runtime-spawned UI is reachable regardless of `mcp_watch`; Control entities carry a `ui` block (`global_rect`, `visible_in_tree`, `has_focus`, `text`); the digest has a top-level `focus_owner`; `include` accepts `"ui"`. Resolved theme lookups (item 3) are left for `report`.

Tests: 613 vitest; headless digest (30 checks, 6 new for `ui`), effect probe (20 checks, 2 new for the type-change diff, plus the lenient-report case from 4.1.2 which that test had not been updated for), report lenient, watch timeline, stuck-held all pass. Nine addon scripts parse-checked. Dev version bumped to 4.1.3.

Worth a manual pass: a `sequence` whose last input quits the game (expect `GAME_EXITED` in under a second), a `sequence` with the focus-owner ternary probe from #358, and `digest select="visible" type="Label"` on a HUD.

Closes #358
Closes #359
Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
