### PR TITLE
fix: type keyframe values against the track target, honor RESET on preview and save

### DIFF
--- a/docs/tools/animation.md
+++ b/docs/tools/animation.md
@@ -100,12 +100,12 @@ Play an animation
 
 #### `stop`
 
-Stop playback
+Stop playback. Godot leaves the first keyframe values on the nodes unless the player has a RESET animation; the reply warns when it does not.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `node_path` | string | Yes | Path to the AnimationPlayer |
-| `keep_state` | boolean | No | Keep current animation state |
+| `keep_state` | boolean | No | Keep the current pose instead of seeking to the first keyframe (default false) |
 
 #### `seek`
 
@@ -163,6 +163,7 @@ Add a track to an animation
 | `track_type` | `value`, `position_3d`, `rotation_3d`, `scale_3d`, `blend_shape`, `method`, `bezier`, `audio`, `animation` | Yes | Type of track |
 | `track_path` | string | Yes | Node path and property, e.g. "Sprite2D:frame" |
 | `insert_at` | number | No | Track index to insert at, -1 for end |
+| `create_reset` | boolean | No | Also key the property's current value into the player's RESET animation (created if missing), as the editor's track panel does, so previews are undone by RESET and save writes the rest pose. Default true. |
 
 #### `remove_track`
 
@@ -184,7 +185,7 @@ Add a keyframe to a track
 | `animation_name` | string | Yes | Animation name |
 | `track_index` | number | Yes | Track index |
 | `time` | number | Yes | Keyframe time in seconds |
-| `value` | unknown | No | Keyframe value |
+| `value` | unknown | No | Keyframe value, typed to match the track's target property: numbers and strings as-is; Color as {r, g, b, a}; Vector2 as {x, y}; Vector3 as {x, y, z}; Quaternion/Vector4 as {x, y, z, w} (the same shape get_keyframes and get_properties emit). A bare numeric array of the right length is accepted for those types; any other mismatch is rejected with TYPE_MISMATCH rather than stored and coerced to black/zero at play time. |
 | `transition` | number | No | Transition curve, 1.0 = linear |
 | `method_name` | string | No | Method name for method tracks |
 | `args` | array | No | Method arguments |
@@ -211,7 +212,7 @@ Update a keyframe
 | `track_index` | number | Yes | Track index |
 | `keyframe_index` | number | Yes | Keyframe index |
 | `time` | number | No | Keyframe time in seconds |
-| `value` | unknown | No | Keyframe value |
+| `value` | unknown | No | Keyframe value, typed to match the track's target property: numbers and strings as-is; Color as {r, g, b, a}; Vector2 as {x, y}; Vector3 as {x, y, z}; Quaternion/Vector4 as {x, y, z, w} (the same shape get_keyframes and get_properties emit). A bare numeric array of the right length is accepted for those types; any other mismatch is rejected with TYPE_MISMATCH rather than stored and coerced to black/zero at play time. |
 | `transition` | number | No | Transition curve, 1.0 = linear |
 
 ### Examples

--- a/docs/tools/scene.md
+++ b/docs/tools/scene.md
@@ -24,7 +24,7 @@ Open a scene file
 
 #### `save`
 
-Save the currently active scene to its own file
+Save the currently active scene to its own file. Honors reset_on_save: players with a RESET animation are written at their rest pose, not a previewed one.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/godot/addons/godot_mcp/commands/animation_commands.gd
+++ b/godot/addons/godot_mcp/commands/animation_commands.gd
@@ -21,6 +21,26 @@ const LOOP_MODE_MAP := {
 	"pingpong": Animation.LOOP_PINGPONG
 }
 
+# JSON shape an agent should send for each Variant type a key can hold.
+const VALUE_SHAPE_HINT := {
+	TYPE_COLOR: "{r, g, b, a}",
+	TYPE_VECTOR2: "{x, y}",
+	TYPE_VECTOR2I: "{x, y}",
+	TYPE_VECTOR3: "{x, y, z}",
+	TYPE_VECTOR3I: "{x, y, z}",
+	TYPE_VECTOR4: "{x, y, z, w}",
+	TYPE_QUATERNION: "{x, y, z, w}",
+}
+
+# Track types whose key value has a fixed Variant type regardless of target.
+const TRACK_VALUE_TYPE := {
+	Animation.TYPE_POSITION_3D: TYPE_VECTOR3,
+	Animation.TYPE_SCALE_3D: TYPE_VECTOR3,
+	Animation.TYPE_ROTATION_3D: TYPE_QUATERNION,
+	Animation.TYPE_BLEND_SHAPE: TYPE_FLOAT,
+	Animation.TYPE_BEZIER: TYPE_FLOAT,
+}
+
 
 func get_commands() -> Dictionary:
 	return {
@@ -69,6 +89,109 @@ func _loop_mode_to_string(loop_mode: int) -> String:
 		if LOOP_MODE_MAP[key] == loop_mode:
 			return key
 	return "none"
+
+
+# The Variant type a key on this track must hold: fixed by the track type for
+# transform/bezier/blend-shape tracks, otherwise read off the live target
+# property; falling back to the track's first key. TYPE_NIL = unknowable.
+func _expected_key_type(player: AnimationPlayer, anim: Animation, track_index: int) -> int:
+	var track_type := anim.track_get_type(track_index)
+	if TRACK_VALUE_TYPE.has(track_type):
+		return TRACK_VALUE_TYPE[track_type]
+	if track_type != Animation.TYPE_VALUE:
+		return TYPE_NIL
+	var target := MCPUtils.resolve_track_target(player, anim, track_index)
+	if target.get("found", false) and target["type"] != TYPE_NIL:
+		return target["type"]
+	if anim.track_get_key_count(track_index) > 0:
+		return typeof(anim.track_get_key_value(track_index, 0))
+	return TYPE_NIL
+
+
+# Fit a deserialized key value to the type the track writes (#363). A bare
+# numeric array is unambiguous once the target type is known, so [r,g,b,a]
+# becomes a Color and [x,y] a Vector2; anything else that does not match is
+# rejected instead of being stored and silently coerced to black/zero by the
+# property setter at play time. Returns {ok, value} or {ok: false, error}.
+func _coerce_key_value(value: Variant, expected_type: int) -> Dictionary:
+	if expected_type == TYPE_NIL or typeof(value) == expected_type:
+		return {"ok": true, "value": value}
+	var vt := typeof(value)
+	if expected_type == TYPE_FLOAT and vt == TYPE_INT:
+		return {"ok": true, "value": float(value)}
+	if expected_type == TYPE_INT and vt == TYPE_FLOAT and is_equal_approx(value, roundf(value)):
+		return {"ok": true, "value": int(value)}
+	if vt == TYPE_ARRAY and _is_numeric_array(value):
+		var a: Array = value
+		match expected_type:
+			TYPE_VECTOR2 when a.size() == 2: return {"ok": true, "value": Vector2(a[0], a[1])}
+			TYPE_VECTOR2I when a.size() == 2: return {"ok": true, "value": Vector2i(a[0], a[1])}
+			TYPE_VECTOR3 when a.size() == 3: return {"ok": true, "value": Vector3(a[0], a[1], a[2])}
+			TYPE_VECTOR3I when a.size() == 3: return {"ok": true, "value": Vector3i(a[0], a[1], a[2])}
+			TYPE_VECTOR4 when a.size() == 4: return {"ok": true, "value": Vector4(a[0], a[1], a[2], a[3])}
+			TYPE_QUATERNION when a.size() == 4: return {"ok": true, "value": Quaternion(a[0], a[1], a[2], a[3])}
+			TYPE_COLOR when a.size() == 3: return {"ok": true, "value": Color(a[0], a[1], a[2])}
+			TYPE_COLOR when a.size() == 4: return {"ok": true, "value": Color(a[0], a[1], a[2], a[3])}
+	var hint: String = VALUE_SHAPE_HINT.get(expected_type, type_string(expected_type))
+	return {"ok": false, "error": "expected %s as %s, got %s" % [type_string(expected_type), hint, type_string(vt)]}
+
+
+func _is_numeric_array(a: Array) -> bool:
+	if a.is_empty():
+		return false
+	for v in a:
+		if not (v is int or v is float):
+			return false
+	return true
+
+
+# Mirror the editor panel's default "Create RESET Track(s)": when a track is
+# added, the property's current value goes into a RESET animation key so a
+# preview can be undone and reset_on_save has something to apply (#364).
+# Returns {added: bool, value} — false when the target is unreachable or
+# RESET already has this track.
+func _ensure_reset_key(player: AnimationPlayer, anim: Animation, track_index: int) -> Dictionary:
+	var track_type := anim.track_get_type(track_index)
+	if track_type in [Animation.TYPE_METHOD, Animation.TYPE_AUDIO, Animation.TYPE_ANIMATION]:
+		return {"added": false}
+	var target := MCPUtils.resolve_track_target(player, anim, track_index)
+	if not target.get("found", false):
+		return {"added": false, "reason": "target not resolvable from the player's root_node"}
+	var track_path := anim.track_get_path(track_index)
+
+	var reset: Animation = player.get_animation("RESET") if player.has_animation("RESET") else null
+	if reset == null:
+		reset = Animation.new()
+		reset.length = 0.001
+		var lib: AnimationLibrary = player.get_animation_library("") if player.has_animation_library("") else null
+		if lib == null:
+			lib = AnimationLibrary.new()
+			player.add_animation_library("", lib)
+		lib.add_animation("RESET", reset)
+	elif reset == anim:
+		return {"added": false}
+
+	for i in reset.get_track_count():
+		if reset.track_get_path(i) == track_path and reset.track_get_type(i) == track_type:
+			return {"added": false, "reason": "RESET already has this track"}
+
+	var rt := reset.add_track(track_type)
+	reset.track_set_path(rt, track_path)
+	var current: Variant = target["value"]
+	match track_type:
+		Animation.TYPE_BEZIER:
+			reset.bezier_track_insert_key(rt, 0.0, float(current))
+		Animation.TYPE_BLEND_SHAPE:
+			reset.blend_shape_track_insert_key(rt, 0.0, float(current))
+		Animation.TYPE_POSITION_3D:
+			reset.position_track_insert_key(rt, 0.0, current)
+		Animation.TYPE_ROTATION_3D:
+			reset.rotation_track_insert_key(rt, 0.0, current)
+		Animation.TYPE_SCALE_3D:
+			reset.scale_track_insert_key(rt, 0.0, current)
+		_:
+			reset.track_insert_key(rt, 0.0, current)
+	return {"added": true, "value": _serialize_value(current)}
 
 
 func _find_animation_players(node: Node, result: Array, root: Node) -> void:
@@ -273,7 +396,14 @@ func stop_animation(params: Dictionary) -> Dictionary:
 
 	player.stop(keep_state)
 
-	return _success({"stopped": true})
+	var result := {"stopped": true}
+	if not keep_state and not player.has_animation("RESET") and player.get_animation_list().size() > 0:
+		# Godot's stop() leaves the first keyframe's values on the nodes; only a
+		# RESET animation puts them back (#364).
+		result["warning"] = ("No RESET animation on this player: the first keyframe values now sit on the " +
+			"animated nodes and would be written by godot_scene save. Tracks added with add_track get " +
+			"RESET keys automatically; for tracks authored elsewhere, add a RESET animation with the rest values.")
+	return _success(result)
 
 
 func seek_animation(params: Dictionary) -> Dictionary:
@@ -449,11 +579,19 @@ func add_animation_track(params: Dictionary) -> Dictionary:
 
 	anim.track_set_path(track_index, track_path)
 
-	return _success({
+	var result := {
 		"track_index": track_index,
 		"track_path": track_path,
-		"track_type": track_type
-	})
+		"track_type": track_type,
+	}
+	if params.get("create_reset", true):
+		var reset := _ensure_reset_key(player, anim, track_index)
+		result["reset_key_added"] = reset.get("added", false)
+		if reset.has("value"):
+			result["reset_value"] = reset["value"]
+		if reset.has("reason"):
+			result["reset_skipped"] = reset["reason"]
+	return _success(result)
 
 
 func remove_animation_track(params: Dictionary) -> Dictionary:
@@ -521,6 +659,11 @@ func add_keyframe(params: Dictionary) -> Dictionary:
 
 	var value = MCPUtils.deserialize_value(params["value"])
 	var track_type := anim.track_get_type(track_index)
+	if track_type != Animation.TYPE_METHOD:
+		var fit := _coerce_key_value(value, _expected_key_type(player, anim, track_index))
+		if not fit["ok"]:
+			return _error("TYPE_MISMATCH", "value for track %s: %s" % [anim.track_get_path(track_index), fit["error"]])
+		value = fit["value"]
 	var key_index: int
 
 	match track_type:
@@ -622,6 +765,11 @@ func update_keyframe(params: Dictionary) -> Dictionary:
 
 	if params.has("value"):
 		var new_value = MCPUtils.deserialize_value(params["value"])
+		if anim.track_get_type(track_index) != Animation.TYPE_METHOD:
+			var fit := _coerce_key_value(new_value, _expected_key_type(player, anim, track_index))
+			if not fit["ok"]:
+				return _error("TYPE_MISMATCH", "value for track %s: %s" % [anim.track_get_path(track_index), fit["error"]])
+			new_value = fit["value"]
 		anim.track_set_key_value(track_index, keyframe_index, new_value)
 		result["value"] = _serialize_value(new_value)
 

--- a/godot/addons/godot_mcp/commands/scene_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene_commands.gd
@@ -99,8 +99,15 @@ func save_scene(params: Dictionary) -> Dictionary:
 				"Open the target scene first, or omit scene_path to save the active one.")
 		path = target
 
+	# This save packs the tree directly rather than going through EditorNode,
+	# so the editor's reset_on_save never runs and a previewed animation pose
+	# would be written into the file (#364). Apply each mixer's RESET animation
+	# for the duration of the pack, then put the preview pose back.
+	var reset_backups := _apply_reset_for_save(root)
+
 	var packed_scene := PackedScene.new()
 	var err := packed_scene.pack(root)
+	_restore_after_save(reset_backups)
 	if err != OK:
 		return _error("PACK_FAILED", "Failed to pack scene: %s" % error_string(err))
 
@@ -108,7 +115,80 @@ func save_scene(params: Dictionary) -> Dictionary:
 	if err != OK:
 		return _error("SAVE_FAILED", "Failed to save scene: %s" % error_string(err))
 
-	return _success({"path": path})
+	var result := {"path": path}
+	var reset_players: Array[String] = []
+	for b in reset_backups:
+		reset_players.append(b["player"])
+	if not reset_players.is_empty():
+		result["reset_applied"] = reset_players
+	return _success(result)
+
+
+# Emulates AnimationMixer's reset-on-save (apply_reset/make_backup are not
+# scriptable): for every mixer under root with reset_on_save and a RESET
+# animation, remember each RESET-tracked property's current value, then write
+# the RESET key value in its place. Returns the backups for _restore_after_save.
+func _apply_reset_for_save(root: Node) -> Array:
+	var backups: Array = []
+	var mixers: Array = []
+	_collect_mixers(root, mixers)
+	for mixer in mixers:
+		if not mixer.reset_on_save or not mixer.has_animation("RESET"):
+			continue
+		var reset: Animation = mixer.get_animation("RESET")
+		var entries: Array = []
+		for t in reset.get_track_count():
+			if reset.track_get_key_count(t) == 0:
+				continue
+			var target := MCPUtils.resolve_track_target(mixer, reset, t)
+			if not target.get("found", false):
+				continue
+			var reset_value: Variant
+			match reset.track_get_type(t):
+				Animation.TYPE_VALUE:
+					reset_value = reset.track_get_key_value(t, 0)
+				Animation.TYPE_BEZIER:
+					reset_value = reset.bezier_track_get_key_value(t, 0)
+				Animation.TYPE_POSITION_3D:
+					reset_value = reset.position_track_interpolate(t, 0.0)
+				Animation.TYPE_ROTATION_3D:
+					reset_value = reset.rotation_track_interpolate(t, 0.0)
+				Animation.TYPE_SCALE_3D:
+					reset_value = reset.scale_track_interpolate(t, 0.0)
+				_:
+					continue
+			entries.append({"target": target["target"], "subpath": target["subpath"],
+				"type": reset.track_get_type(t), "value": target["value"]})
+			_write_track_value(target["target"], target["subpath"], reset.track_get_type(t), reset_value)
+		if not entries.is_empty():
+			backups.append({"player": str(root.get_path_to(mixer)), "entries": entries})
+	return backups
+
+
+func _restore_after_save(backups: Array) -> void:
+	for b in backups:
+		for e in b["entries"]:
+			if is_instance_valid(e["target"]):
+				_write_track_value(e["target"], e["subpath"], e["type"], e["value"])
+
+
+func _write_track_value(target: Object, subpath: NodePath, track_type: int, value: Variant) -> void:
+	match track_type:
+		Animation.TYPE_POSITION_3D:
+			(target as Node3D).position = value
+		Animation.TYPE_ROTATION_3D:
+			(target as Node3D).quaternion = value
+		Animation.TYPE_SCALE_3D:
+			(target as Node3D).scale = value
+		_:
+			target.set_indexed(subpath, value)
+
+
+func _collect_mixers(node: Node, out: Array) -> void:
+	if node is AnimationMixer:
+		out.append(node)
+	for c in node.get_children():
+		_collect_mixers(c, out)
 
 
 # Reload an already-open scene from disk, picking up a direct .tscn edit without

--- a/godot/addons/godot_mcp/core/mcp_utils.gd
+++ b/godot/addons/godot_mcp/core/mcp_utils.gd
@@ -65,6 +65,44 @@ static func serialize_value(value: Variant) -> Variant:
 			return value
 
 
+# Resolve what an animation track actually writes to: the node (or the
+# resource on it) named by the track path, the remaining property sub-path,
+# and the property's current value/type. This is how the editor knows a
+# `Zone:modulate` track holds a Color. Returns {found: false} when the root
+# node or target cannot be reached from the mixer.
+static func resolve_track_target(mixer: AnimationMixer, anim: Animation, track_index: int) -> Dictionary:
+	var root := mixer.get_node_or_null(mixer.root_node)
+	if root == null:
+		return {"found": false}
+	var track_path := anim.track_get_path(track_index)
+	if track_path.is_empty():
+		return {"found": false}
+	var track_type := anim.track_get_type(track_index)
+	# Transform tracks name a Node3D, not a property.
+	if track_type in [Animation.TYPE_POSITION_3D, Animation.TYPE_ROTATION_3D, Animation.TYPE_SCALE_3D]:
+		var n3d := root.get_node_or_null(NodePath(str(track_path).get_slice(":", 0)))
+		if n3d == null or not n3d is Node3D:
+			return {"found": false}
+		var value: Variant
+		match track_type:
+			Animation.TYPE_POSITION_3D: value = (n3d as Node3D).position
+			Animation.TYPE_ROTATION_3D: value = (n3d as Node3D).quaternion
+			_: value = (n3d as Node3D).scale
+		return {"found": true, "target": n3d, "subpath": NodePath(""), "value": value, "type": typeof(value)}
+	if track_path.get_subname_count() == 0:
+		return {"found": false}
+	var resolved := root.get_node_and_resource(track_path)
+	var node: Node = resolved[0]
+	if node == null:
+		return {"found": false}
+	var target: Object = resolved[1] if resolved[1] != null else node
+	var subpath: NodePath = resolved[2]
+	if subpath.get_subname_count() == 0:
+		return {"found": false}
+	var value: Variant = target.get_indexed(subpath)
+	return {"found": true, "target": target, "subpath": subpath, "value": value, "type": typeof(value)}
+
+
 static func deserialize_value(value: Variant) -> Variant:
 	# uid:// references (written into .tscn by the editor since 4.4) resolve the
 	# same way res:// does — load() accepts both. Without the uid:// arm, a uid

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.3"
+version="4.1.4"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/godot/addons/godot_mcp/test/animation_reset_headless_test.gd
+++ b/godot/addons/godot_mcp/test/animation_reset_headless_test.gd
@@ -1,0 +1,135 @@
+extends SceneTree
+
+## Headless test for keyframe value typing (#363) and RESET handling (#364).
+##
+## Builds a real AnimationPlayer over a ColorRect and a Node3D, then drives the
+## command helpers directly (no EditorInterface): the track-target resolver,
+## key-value coercion, RESET key creation on add_track, and the save-time
+## reset/restore round trip that stands in for the editor's reset_on_save.
+##
+## Not wired into CI (CI has no Godot). Run on demand:
+##   godot --headless --path <project-with-addon> \
+##     --script res://addons/godot_mcp/test/animation_reset_headless_test.gd
+
+const AnimCmd := preload("res://addons/godot_mcp/commands/animation_commands.gd")
+const SceneCmd := preload("res://addons/godot_mcp/commands/scene_commands.gd")
+
+var _count := 0
+var _failures := 0
+
+
+func _initialize() -> void:
+	var holder := Node.new()
+	holder.name = "Main"
+	root.add_child(holder)
+	var zone := ColorRect.new()
+	zone.name = "Zone"
+	zone.modulate = Color(1, 1, 1, 1)
+	holder.add_child(zone)
+	var cube := Node3D.new()
+	cube.name = "Cube"
+	cube.position = Vector3(1, 2, 3)
+	holder.add_child(cube)
+	var player := AnimationPlayer.new()
+	player.name = "AnimationPlayer"
+	holder.add_child(player)
+	player.root_node = NodePath("..")
+
+	var lib := AnimationLibrary.new()
+	player.add_animation_library("", lib)
+	var pulse := Animation.new()
+	pulse.length = 1.0
+	lib.add_animation("pulse", pulse)
+	var t_mod := pulse.add_track(Animation.TYPE_VALUE)
+	pulse.track_set_path(t_mod, NodePath("Zone:modulate"))
+	var t_pos := pulse.add_track(Animation.TYPE_POSITION_3D)
+	pulse.track_set_path(t_pos, NodePath("Cube"))
+	var t_sub := pulse.add_track(Animation.TYPE_VALUE)
+	pulse.track_set_path(t_sub, NodePath("Zone:modulate:r"))
+
+	var anim_cmd = AnimCmd.new()
+	var scene_cmd = SceneCmd.new()
+
+	# --- resolve_track_target -------------------------------------------------
+	var tgt: Dictionary = MCPUtils.resolve_track_target(player, pulse, t_mod)
+	_check("Zone:modulate resolves", tgt.get("found", false), true)
+	_check("Zone:modulate is a Color", tgt.get("type", -1), TYPE_COLOR)
+	var tgt_pos: Dictionary = MCPUtils.resolve_track_target(player, pulse, t_pos)
+	_check("position track resolves to the Node3D", tgt_pos.get("found", false) and tgt_pos["target"] == cube, true)
+	var tgt_sub: Dictionary = MCPUtils.resolve_track_target(player, pulse, t_sub)
+	_check("sub-property modulate:r resolves to a float", tgt_sub.get("type", -1), TYPE_FLOAT)
+
+	# --- _coerce_key_value (#363) --------------------------------------------
+	var c1: Dictionary = anim_cmd._coerce_key_value([1.6, 1.6, 1.6, 1], TYPE_COLOR)
+	_check("4-array coerces to Color", c1["ok"] and c1["value"] == Color(1.6, 1.6, 1.6, 1), true)
+	var c2: Dictionary = anim_cmd._coerce_key_value([1.4, 1.4], TYPE_VECTOR2)
+	_check("2-array coerces to Vector2", c2["ok"] and c2["value"] == Vector2(1.4, 1.4), true)
+	var c3: Dictionary = anim_cmd._coerce_key_value([1.6, 1.6], TYPE_COLOR)
+	_check("wrong-length array for Color is rejected", c3["ok"], false)
+	_check("rejection names the expected shape", str(c3.get("error", "")).contains("{r, g, b, a}"), true)
+	var c4: Dictionary = anim_cmd._coerce_key_value("red", TYPE_COLOR)
+	_check("String for Color is rejected", c4["ok"], false)
+	var c5: Dictionary = anim_cmd._coerce_key_value(3, TYPE_FLOAT)
+	_check("int widens to float", c5["ok"] and c5["value"] is float, true)
+	var c6: Dictionary = anim_cmd._coerce_key_value(Color.RED, TYPE_COLOR)
+	_check("already-typed value passes through", c6["ok"] and c6["value"] == Color.RED, true)
+	var c7: Dictionary = anim_cmd._coerce_key_value([1, 2], TYPE_NIL)
+	_check("unknown target type accepts anything", c7["ok"], true)
+	_check("expected type read off the live property", anim_cmd._expected_key_type(player, pulse, t_mod), TYPE_COLOR)
+	_check("expected type fixed by transform track", anim_cmd._expected_key_type(player, pulse, t_pos), TYPE_VECTOR3)
+
+	# --- _ensure_reset_key (#364) --------------------------------------------
+	_check("no RESET before", player.has_animation("RESET"), false)
+	var r1: Dictionary = anim_cmd._ensure_reset_key(player, pulse, t_mod)
+	_check("RESET key added for modulate", r1.get("added", false), true)
+	_check("RESET animation now exists", player.has_animation("RESET"), true)
+	var reset: Animation = player.get_animation("RESET")
+	_check("RESET holds the current modulate", reset.track_get_key_value(0, 0), Color(1, 1, 1, 1))
+	var r2: Dictionary = anim_cmd._ensure_reset_key(player, pulse, t_mod)
+	_check("second call does not duplicate the track", r2.get("added", true), false)
+	_check("still one RESET track", reset.get_track_count(), 1)
+	var r3: Dictionary = anim_cmd._ensure_reset_key(player, pulse, t_pos)
+	_check("RESET key added for the position track", r3.get("added", false), true)
+	_check("position RESET key holds the rest position", reset.position_track_interpolate(1, 0.0), Vector3(1, 2, 3))
+
+	# --- save-time reset round trip (#364) -----------------------------------
+	# Simulate a preview having left the first keyframe on the nodes.
+	zone.modulate = Color(1.6, 1.6, 1.6, 1)
+	cube.position = Vector3(9, 9, 9)
+	var backups: Array = scene_cmd._apply_reset_for_save(holder)
+	_check("one mixer reset for save", backups.size(), 1)
+	_check("modulate at rest value during the pack", zone.modulate, Color(1, 1, 1, 1))
+	_check("position at rest value during the pack", cube.position, Vector3(1, 2, 3))
+	var packed := PackedScene.new()
+	packed.pack(holder)
+	scene_cmd._restore_after_save(backups)
+	_check("preview modulate restored after the pack", zone.modulate, Color(1.6, 1.6, 1.6, 1))
+	_check("preview position restored after the pack", cube.position, Vector3(9, 9, 9))
+	var state := packed.get_state()
+	var saved_mod: Variant = null
+	for i in state.get_node_count():
+		if state.get_node_name(i) == "Zone":
+			for p in state.get_node_property_count(i):
+				if state.get_node_property_name(i, p) == "modulate":
+					saved_mod = state.get_node_property_value(i, p)
+	_check("packed scene carries the rest modulate (or default)", saved_mod == null or saved_mod == Color(1, 1, 1, 1), true)
+
+	player.reset_on_save = false
+	var none: Array = scene_cmd._apply_reset_for_save(holder)
+	_check("reset_on_save=false is honored", none.size(), 0)
+
+	print("1..%d" % _count)
+	if _failures == 0:
+		print("ALL PASS — %d checks" % _count)
+	else:
+		printerr("FAILED — %d/%d checks failed" % [_failures, _count])
+	quit(1 if _failures > 0 else 0)
+
+
+func _check(label: String, got: Variant, expected: Variant) -> void:
+	_count += 1
+	if got == expected:
+		print("ok %d - %s (= %s)" % [_count, label, str(got)])
+	else:
+		_failures += 1
+		printerr("not ok %d - %s: expected %s, got %s" % [_count, label, str(expected), str(got)])

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/core/__toolsnaps__/godot_animation_edit.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_animation_edit.json
@@ -19,7 +19,7 @@
           "remove_keyframe",
           "update_keyframe"
         ],
-        "description": "play: Play an animation\nstop: Stop playback\nseek: Seek to a position in the current animation\ncreate: Create an animation\ndelete: Delete an animation\nupdate_props: Update animation properties\nadd_track: Add a track to an animation\nremove_track: Remove a track\nadd_keyframe: Add a keyframe to a track\nremove_keyframe: Remove a keyframe\nupdate_keyframe: Update a keyframe"
+        "description": "play: Play an animation\nstop: Stop playback. Godot leaves the first keyframe values on the nodes unless the player has a RESET animation; the reply warns when it does not.\nseek: Seek to a position in the current animation\ncreate: Create an animation\ndelete: Delete an animation\nupdate_props: Update animation properties\nadd_track: Add a track to an animation\nremove_track: Remove a track\nadd_keyframe: Add a keyframe to a track\nremove_keyframe: Remove a keyframe\nupdate_keyframe: Update a keyframe"
       },
       "node_path": {
         "type": "string",
@@ -42,7 +42,7 @@
         "type": "boolean"
       },
       "keep_state": {
-        "description": "Keep current animation state (for: stop)",
+        "description": "Keep the current pose instead of seeking to the first keyframe (default false) (for: stop)",
         "type": "boolean"
       },
       "seconds": {
@@ -97,6 +97,10 @@
         "description": "Track index to insert at, -1 for end (for: add_track)",
         "type": "number"
       },
+      "create_reset": {
+        "description": "Also key the property's current value into the player's RESET animation (created if missing), as the editor's track panel does, so previews are undone by RESET and save writes the rest pose. Default true. (for: add_track)",
+        "type": "boolean"
+      },
       "track_index": {
         "type": "number",
         "description": "Track index (required for: remove_track, add_keyframe, remove_keyframe, update_keyframe)"
@@ -106,7 +110,7 @@
         "type": "number"
       },
       "value": {
-        "description": "Keyframe value (for: add_keyframe, update_keyframe)"
+        "description": "Keyframe value, typed to match the track's target property: numbers and strings as-is; Color as {r, g, b, a}; Vector2 as {x, y}; Vector3 as {x, y, z}; Quaternion/Vector4 as {x, y, z, w} (the same shape get_keyframes and get_properties emit). A bare numeric array of the right length is accepted for those types; any other mismatch is rejected with TYPE_MISMATCH rather than stored and coerced to black/zero at play time. (for: add_keyframe, update_keyframe)"
       },
       "transition": {
         "description": "Transition curve, 1.0 = linear (for: add_keyframe, update_keyframe)",

--- a/server/src/__tests__/core/__toolsnaps__/godot_scene.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_scene.json
@@ -11,7 +11,7 @@
           "save",
           "reload"
         ],
-        "description": "open: Open a scene file\nsave: Save the currently active scene to its own file\nreload: Reload an open scene from disk, discarding the editor's unsaved in-memory copy. Use after editing a .tscn file directly to refresh the editor without a full restart; the scene must already be open."
+        "description": "open: Open a scene file\nsave: Save the currently active scene to its own file. Honors reset_on_save: players with a RESET animation are written at their rest pose, not a previewed one.\nreload: Reload an open scene from disk, discarding the editor's unsaved in-memory copy. Use after editing a .tscn file directly to refresh the editor without a full restart; the scene must already be open."
       },
       "scene_path": {
         "description": "for open: Path to scene file to open; for save: Must match the active scene's file (defaults to it); a scene with no file yet may be saved to a new path. Naming a different scene is rejected (SCENE_MISMATCH) instead of overwriting it with the active tab's content; for reload: Path of the open scene to reload (defaults to the current scene) (required for: open; optional for: save, reload)",

--- a/server/src/__tests__/tools/animation.test.ts
+++ b/server/src/__tests__/tools/animation.test.ts
@@ -116,6 +116,14 @@ describe('animationEdit tool', () => {
       }, ctx)).toBe('Seeked to position: 1.5');
     });
 
+    it('stop surfaces the no-RESET warning (#364)', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({ stopped: true, warning: 'No RESET animation on this player: ...' });
+      const result = await animationEdit.execute({ action: 'stop', node_path: '/root/AnimPlayer' }, ctx);
+      expect(result).toContain('Animation stopped');
+      expect(result).toContain('WARNING: No RESET animation');
+    });
+
     it('play passes optional speed/blend/from_end params', async () => {
       mock.mockResponse({ playing: 'walk', from_position: 0 });
       const ctx = createToolContext(mock);
@@ -174,6 +182,19 @@ describe('animationEdit tool', () => {
         track_type: 'value',
         track_path: 'Sprite2D:frame',
       }, ctx)).toBe('Added track 0: value -> Sprite2D:frame');
+
+      mock.mockResponse({
+        track_index: 1, track_path: 'Zone:modulate', track_type: 'value',
+        reset_key_added: true, reset_value: { r: 1, g: 1, b: 1, a: 1 },
+      });
+      expect(await animationEdit.execute({
+        action: 'add_track',
+        node_path: '/root/AnimPlayer',
+        animation_name: 'pulse',
+        track_type: 'value',
+        track_path: 'Zone:modulate',
+      }, ctx)).toBe('Added track 1: value -> Zone:modulate (RESET key added: {"r":1,"g":1,"b":1,"a":1})');
+      expect(mock.calls[mock.calls.length - 1].params.create_reset).toBeUndefined();
 
       mock.mockResponse({ removed_track: 2 });
       expect(await animationEdit.execute({

--- a/server/src/__tests__/tools/scene.test.ts
+++ b/server/src/__tests__/tools/scene.test.ts
@@ -38,6 +38,14 @@ describe('scene tool', () => {
       expect(result).toBe('Opened scene: res://main.tscn');
     });
 
+    it('save mentions players whose RESET was applied for the write (#364)', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({ path: 'res://main.tscn', reset_applied: ['Player/AnimationPlayer'] });
+      const result = await scene.execute({ action: 'save' }, ctx);
+      expect(result).toContain('Saved scene: res://main.tscn');
+      expect(result).toContain('RESET applied for save on Player/AnimationPlayer');
+    });
+
     it('save returns path from Godot response and passes optional path', async () => {
       const ctx = createToolContext(mock);
 

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -53,9 +53,9 @@ const AnimationEditSchema = z.discriminatedUnion('action', [
     from_end: z.boolean().optional().describe('Play from end for reverse'),
   }),
   z.object({
-    action: z.literal('stop').describe('Stop playback'),
+    action: z.literal('stop').describe('Stop playback. Godot leaves the first keyframe values on the nodes unless the player has a RESET animation; the reply warns when it does not.'),
     node_path: nodePathField,
-    keep_state: z.boolean().optional().describe('Keep current animation state'),
+    keep_state: z.boolean().optional().describe('Keep the current pose instead of seeking to the first keyframe (default false)'),
   }),
   z.object({
     action: z.literal('seek').describe('Seek to a position in the current animation'),
@@ -93,6 +93,12 @@ const AnimationEditSchema = z.discriminatedUnion('action', [
     track_type: TrackTypeEnum.describe('Type of track'),
     track_path: z.string().describe('Node path and property, e.g. "Sprite2D:frame"'),
     insert_at: z.number().optional().describe('Track index to insert at, -1 for end'),
+    create_reset: z
+      .boolean()
+      .optional()
+      .describe(
+        'Also key the property\'s current value into the player\'s RESET animation (created if missing), as the editor\'s track panel does, so previews are undone by RESET and save writes the rest pose. Default true.'
+      ),
   }),
   z.object({
     action: z.literal('remove_track').describe('Remove a track'),
@@ -106,7 +112,7 @@ const AnimationEditSchema = z.discriminatedUnion('action', [
     animation_name: animNameField,
     track_index: trackIndexField,
     time: z.number().describe('Keyframe time in seconds'),
-    value: z.unknown().optional().describe('Keyframe value'),
+    value: z.unknown().optional().describe('Keyframe value, typed to match the track\'s target property: numbers and strings as-is; Color as {r, g, b, a}; Vector2 as {x, y}; Vector3 as {x, y, z}; Quaternion/Vector4 as {x, y, z, w} (the same shape get_keyframes and get_properties emit). A bare numeric array of the right length is accepted for those types; any other mismatch is rejected with TYPE_MISMATCH rather than stored and coerced to black/zero at play time.'),
     transition: z.number().optional().describe('Transition curve, 1.0 = linear'),
     method_name: z.string().optional().describe('Method name for method tracks'),
     args: z.array(z.unknown()).optional().describe('Method arguments'),
@@ -125,7 +131,7 @@ const AnimationEditSchema = z.discriminatedUnion('action', [
     track_index: trackIndexField,
     keyframe_index: keyframeIndexField,
     time: z.number().optional().describe('Keyframe time in seconds'),
-    value: z.unknown().optional().describe('Keyframe value'),
+    value: z.unknown().optional().describe('Keyframe value, typed to match the track\'s target property: numbers and strings as-is; Color as {r, g, b, a}; Vector2 as {x, y}; Vector3 as {x, y, z}; Quaternion/Vector4 as {x, y, z, w} (the same shape get_keyframes and get_properties emit). A bare numeric array of the right length is accepted for those types; any other mismatch is rejected with TYPE_MISMATCH rather than stored and coerced to black/zero at play time.'),
     transition: z.number().optional().describe('Transition curve, 1.0 = linear'),
   }),
 ]);
@@ -238,11 +244,11 @@ export const animationEdit = defineTool({
         return `Playing animation: ${result.playing}`;
       }
       case 'stop': {
-        await godot.sendCommand('stop_animation', {
+        const result = await godot.sendCommand<{ stopped: boolean; warning?: string }>('stop_animation', {
           node_path: args.node_path,
           keep_state: args.keep_state,
         });
-        return 'Animation stopped';
+        return result.warning ? `Animation stopped\nWARNING: ${result.warning}` : 'Animation stopped';
       }
       case 'seek': {
         const result = await godot.sendCommand<{ position: number }>('seek_animation', {
@@ -292,14 +298,23 @@ export const animationEdit = defineTool({
           track_index: number;
           track_path: string;
           track_type: string;
+          reset_key_added?: boolean;
+          reset_value?: unknown;
+          reset_skipped?: string;
         }>('add_animation_track', {
           node_path: args.node_path,
           animation_name: args.animation_name,
           track_type: args.track_type,
           track_path: args.track_path,
           insert_at: args.insert_at,
+          create_reset: args.create_reset,
         });
-        return `Added track ${result.track_index}: ${result.track_type} -> ${result.track_path}`;
+        const reset = result.reset_key_added
+          ? ` (RESET key added: ${JSON.stringify(result.reset_value)})`
+          : result.reset_skipped
+            ? ` (no RESET key: ${result.reset_skipped})`
+            : '';
+        return `Added track ${result.track_index}: ${result.track_type} -> ${result.track_path}${reset}`;
       }
       case 'remove_track': {
         const result = await godot.sendCommand<{ removed_track: number }>('remove_animation_track', {

--- a/server/src/tools/scene.ts
+++ b/server/src/tools/scene.ts
@@ -8,7 +8,7 @@ const SceneSchema = z.discriminatedUnion('action', [
     scene_path: z.string().describe('Path to scene file to open'),
   }),
   z.object({
-    action: z.literal('save').describe('Save the currently active scene to its own file'),
+    action: z.literal('save').describe('Save the currently active scene to its own file. Honors reset_on_save: players with a RESET animation are written at their rest pose, not a previewed one.'),
     scene_path: z
       .string()
       .optional()
@@ -46,10 +46,13 @@ export const scene = defineTool({
       }
 
       case 'save': {
-        const result = await godot.sendCommand<{ path: string }>('save_scene', {
+        const result = await godot.sendCommand<{ path: string; reset_applied?: string[] }>('save_scene', {
           path: args.scene_path,
         });
-        return `Saved scene: ${result.path}`;
+        const reset = result.reset_applied?.length
+          ? ` (RESET applied for save on ${result.reset_applied.join(', ')}; preview pose kept in the editor)`
+          : '';
+        return `Saved scene: ${result.path}${reset}`;
       }
 
       case 'reload': {


### PR DESCRIPTION
Neither fix takes the suggested shape as-is; both go through what the editor itself does.

**#363.** `add_keyframe` and `update_keyframe` now resolve what the track actually writes to — the node or resource and property named by the track path, from the player's `root_node` — and fit the value to that type. A bare numeric array of the right length becomes the Color / Vector2 / Vector3 / Quaternion the target holds (unambiguous once the target is known); any other mismatch is rejected with `TYPE_MISMATCH` and the expected shape (`expected Color as {r, g, b, a}, got String`). Transform, bezier and blend-shape tracks have a fixed key type and are checked the same way. When the target can't be resolved, the first existing key's type is used, and with nothing to go on the value passes through as before. The `value` description documents the object form.

**#364.** The root of this one is that tracks authored through the tool have no RESET keys, while the editor's track panel creates them by default, and our `save` packs the tree directly instead of going through EditorNode so `reset_on_save` never ran. So:
- `add_track` keys the property's current value into the player's RESET animation (created in the default library if missing), like the panel does. `create_reset: false` skips it. The reply says what was keyed.
- `godot_scene save` honors `reset_on_save`: for each mixer with a RESET animation it writes the rest values, packs, then puts the preview pose back — `AnimationMixer.apply_reset`/`make_backup` aren't scriptable, so this emulates them over RESET's tracks. The reply lists the players it reset.
- `stop` with `keep_state` false warns when the player has no RESET animation, since Godot's `stop()` leaves the first keyframe on the nodes.

`stop` itself keeps Godot's semantics rather than snapshotting and restoring on its own, so the editor view matches what the animation panel would show.

Tests: 615 vitest; new headless `animation_reset_headless_test.gd` (29 checks: resolver, coercion, RESET key creation, save-time reset round trip). Eleven addon scripts parse-checked. Dev version 4.1.4.

Worth a manual pass: the `Zone:modulate` array case from #363 (expect a Color, not black), a String value (expect TYPE_MISMATCH), then the #364 loop — `add_track`, keys, `play`/`seek`/`stop`, `save`, grep the .tscn for the rest value.

Closes #363
Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
