### PR TITLE
fix: add create_reset_keys to backfill RESET for existing animation tracks

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -33,7 +33,7 @@ Project information tools
 Animation query, playback, and editing tools
 
 - `godot_animation_read` - Inspect animation data on AnimationPlayer nodes in the editor: list players in the scene, read a player's state and libraries, get an animation's tracks and properties, and read a track's keyframes. Reach for it to verify what the editor actually loaded, including after editing animation resources by hand. It changes and previews nothing; use godot_animation_edit to create, modify, or play animations.
-- `godot_animation_edit` - Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.
+- `godot_animation_edit` - Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, backfill RESET keys for existing tracks (create_reset_keys), and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.
 
 ## [TileMapLayer/GridMap](tilemap.md)
 

--- a/docs/tools/animation.md
+++ b/docs/tools/animation.md
@@ -82,7 +82,7 @@ Get keyframes for a track
 
 ## godot_animation_edit
 
-Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.
+Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, backfill RESET keys for existing tracks (create_reset_keys), and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.
 
 ### Actions
 
@@ -165,6 +165,15 @@ Add a track to an animation
 | `insert_at` | number | No | Track index to insert at, -1 for end |
 | `create_reset` | boolean | No | Also key the property's current value into the player's RESET animation (created if missing), as the editor's track panel does, so previews are undone by RESET and save writes the rest pose. Default true. |
 
+#### `create_reset_keys`
+
+Backfill RESET keys for existing tracks: every track on one animation (or all of the player's animations) gets a RESET key holding the property's current value where RESET lacks one. Use it on tracks authored by hand or before add_track keyed RESET automatically, and call it BEFORE previewing, while the nodes still hold their rest pose.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `node_path` | string | Yes | Path to the AnimationPlayer |
+| `animation_name` | string | No | Animation to cover (default: all animations on the player except RESET) |
+
 #### `remove_track`
 
 Remove a track
@@ -243,7 +252,7 @@ Update a keyframe
 }
 ```
 
-*8 more actions available: `create`, `delete`, `update_props`, `add_track`, `remove_track`, `add_keyframe`, `remove_keyframe`, `update_keyframe`*
+*9 more actions available: `create`, `delete`, `update_props`, `add_track`, `create_reset_keys`, `remove_track`, `add_keyframe`, `remove_keyframe`, `update_keyframe`*
 
 ---
 

--- a/godot/addons/godot_mcp/commands/animation_commands.gd
+++ b/godot/addons/godot_mcp/commands/animation_commands.gd
@@ -57,6 +57,7 @@ func get_commands() -> Dictionary:
 		"add_animation_track": add_animation_track,
 		"remove_animation_track": remove_animation_track,
 		"add_keyframe": add_keyframe,
+		"create_reset_keys": create_reset_keys,
 		"remove_keyframe": remove_keyframe,
 		"update_keyframe": update_keyframe
 	}
@@ -592,6 +593,57 @@ func add_animation_track(params: Dictionary) -> Dictionary:
 		if reset.has("reason"):
 			result["reset_skipped"] = reset["reason"]
 	return _success(result)
+
+
+# Backfill RESET keys for tracks authored before add_track keyed them (or by
+# hand): every track on the named animation, or on all of the player's
+# animations, gets a RESET key holding the property's CURRENT value where the
+# RESET animation lacks one. Call it before previewing, while the nodes still
+# hold their rest pose.
+func create_reset_keys(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var anim_name: String = params.get("animation_name", "")
+
+	if node_path.is_empty():
+		return _error("INVALID_PARAMS", "node_path is required")
+
+	var player := _get_animation_player(node_path)
+	if not player:
+		var node := _get_node(node_path)
+		if not node:
+			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
+		return _error("NOT_ANIMATION_PLAYER", "Node is not an AnimationPlayer")
+
+	var names: Array = []
+	if anim_name.is_empty():
+		for n in player.get_animation_list():
+			if n != "RESET":
+				names.append(n)
+	else:
+		if not player.has_animation(anim_name):
+			return _error("ANIMATION_NOT_FOUND", "Animation not found: %s" % anim_name)
+		names.append(anim_name)
+
+	var added: Array = []
+	var skipped: Array = []
+	for n in names:
+		var anim := player.get_animation(n)
+		for t in anim.get_track_count():
+			var r := _ensure_reset_key(player, anim, t)
+			var entry := {"animation": n, "track_index": t, "track_path": str(anim.track_get_path(t))}
+			if r.get("added", false):
+				entry["value"] = r.get("value")
+				added.append(entry)
+			else:
+				entry["reason"] = r.get("reason", "track type has no rest value")
+				skipped.append(entry)
+
+	return _success({
+		"animations": names,
+		"added": added,
+		"skipped": skipped,
+		"has_reset": player.has_animation("RESET"),
+	})
 
 
 func remove_animation_track(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.4"
+version="4.1.5"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/godot/addons/godot_mcp/test/animation_reset_headless_test.gd
+++ b/godot/addons/godot_mcp/test/animation_reset_headless_test.gd
@@ -92,6 +92,20 @@ func _initialize() -> void:
 	_check("RESET key added for the position track", r3.get("added", false), true)
 	_check("position RESET key holds the rest position", reset.position_track_interpolate(1, 0.0), Vector3(1, 2, 3))
 
+	# --- backfill over an animation authored without RESET keys ---------------
+	var legacy := Animation.new()
+	lib.add_animation("legacy", legacy)
+	var l_scale := legacy.add_track(Animation.TYPE_SCALE_3D)
+	legacy.track_set_path(l_scale, NodePath("Cube"))
+	var l_missing := legacy.add_track(Animation.TYPE_VALUE)
+	legacy.track_set_path(l_missing, NodePath("Nope:modulate"))
+	var before_tracks := reset.get_track_count()
+	var b1: Dictionary = anim_cmd._ensure_reset_key(player, legacy, l_scale)
+	_check("backfill keys an unkeyed scale track", b1.get("added", false), true)
+	var b2: Dictionary = anim_cmd._ensure_reset_key(player, legacy, l_missing)
+	_check("unresolvable target is skipped with a reason", not b2.get("added", true) and b2.has("reason"), true)
+	_check("backfill added exactly one RESET track", reset.get_track_count(), before_tracks + 1)
+
 	# --- save-time reset round trip (#364) -----------------------------------
 	# Simulate a preview having left the first keyframe on the nodes.
 	zone.modulate = Color(1.6, 1.6, 1.6, 1)

--- a/godot/addons/godot_mcp/test/animation_reset_headless_test.gd.uid
+++ b/godot/addons/godot_mcp/test/animation_reset_headless_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bjdgh6ivfbw6x

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/core/__toolsnaps__/godot_animation_edit.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_animation_edit.json
@@ -1,6 +1,6 @@
 {
   "name": "godot_animation_edit",
-  "description": "Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.",
+  "description": "Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, backfill RESET keys for existing tracks (create_reset_keys), and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -14,12 +14,13 @@
           "delete",
           "update_props",
           "add_track",
+          "create_reset_keys",
           "remove_track",
           "add_keyframe",
           "remove_keyframe",
           "update_keyframe"
         ],
-        "description": "play: Play an animation\nstop: Stop playback. Godot leaves the first keyframe values on the nodes unless the player has a RESET animation; the reply warns when it does not.\nseek: Seek to a position in the current animation\ncreate: Create an animation\ndelete: Delete an animation\nupdate_props: Update animation properties\nadd_track: Add a track to an animation\nremove_track: Remove a track\nadd_keyframe: Add a keyframe to a track\nremove_keyframe: Remove a keyframe\nupdate_keyframe: Update a keyframe"
+        "description": "play: Play an animation\nstop: Stop playback. Godot leaves the first keyframe values on the nodes unless the player has a RESET animation; the reply warns when it does not.\nseek: Seek to a position in the current animation\ncreate: Create an animation\ndelete: Delete an animation\nupdate_props: Update animation properties\nadd_track: Add a track to an animation\ncreate_reset_keys: Backfill RESET keys for existing tracks: every track on one animation (or all of the player's animations) gets a RESET key holding the property's current value where RESET lacks one. Use it on tracks authored by hand or before add_track keyed RESET automatically, and call it BEFORE previewing, while the nodes still hold their rest pose.\nremove_track: Remove a track\nadd_keyframe: Add a keyframe to a track\nremove_keyframe: Remove a keyframe\nupdate_keyframe: Update a keyframe"
       },
       "node_path": {
         "type": "string",
@@ -27,7 +28,7 @@
       },
       "animation_name": {
         "type": "string",
-        "description": "Animation name (required for: play, create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe)"
+        "description": "for play: Animation name; for create: Animation name; for delete: Animation name; for update_props: Animation name; for add_track: Animation name; for create_reset_keys: Animation to cover (default: all animations on the player except RESET); for remove_track: Animation name; for add_keyframe: Animation name; for remove_keyframe: Animation name; for update_keyframe: Animation name (required for: play, create, delete, update_props, add_track, remove_track, add_keyframe, remove_keyframe, update_keyframe; optional for: create_reset_keys)"
       },
       "custom_blend": {
         "description": "Custom blend time, -1 for default (for: play)",

--- a/server/src/__tests__/tools/animation.test.ts
+++ b/server/src/__tests__/tools/animation.test.ts
@@ -205,6 +205,25 @@ describe('animationEdit tool', () => {
       }, ctx)).toBe('Removed track: 2');
     });
 
+    it('create_reset_keys lists what was keyed and what was skipped', async () => {
+      const ctx = createToolContext(mock);
+      mock.mockResponse({
+        animations: ['beat_pulse'],
+        added: [{ animation: 'beat_pulse', track_index: 0, track_path: 'Zone:modulate', value: { r: 1, g: 1, b: 1, a: 1 } }],
+        skipped: [{ animation: 'beat_pulse', track_index: 1, track_path: 'Zone:modulate', reason: 'RESET already has this track' }],
+        has_reset: true,
+      });
+      const result = await animationEdit.execute({
+        action: 'create_reset_keys',
+        node_path: '/root/AnimPlayer',
+        animation_name: 'beat_pulse',
+      }, ctx);
+      expect(mock.calls[0].command).toBe('create_reset_keys');
+      expect(result).toContain('1 added, 1 skipped across 1 animation(s)');
+      expect(result).toContain('+ beat_pulse[0] Zone:modulate = {"r":1,"g":1,"b":1,"a":1}');
+      expect(result).toContain('- beat_pulse[1] Zone:modulate: RESET already has this track');
+    });
+
     it('keyframe operations return formatted confirmations', async () => {
       const ctx = createToolContext(mock);
 

--- a/server/src/tools/animation.ts
+++ b/server/src/tools/animation.ts
@@ -101,6 +101,15 @@ const AnimationEditSchema = z.discriminatedUnion('action', [
       ),
   }),
   z.object({
+    action: z
+      .literal('create_reset_keys')
+      .describe(
+        'Backfill RESET keys for existing tracks: every track on one animation (or all of the player\'s animations) gets a RESET key holding the property\'s current value where RESET lacks one. Use it on tracks authored by hand or before add_track keyed RESET automatically, and call it BEFORE previewing, while the nodes still hold their rest pose.'
+      ),
+    node_path: nodePathField,
+    animation_name: z.string().optional().describe('Animation to cover (default: all animations on the player except RESET)'),
+  }),
+  z.object({
     action: z.literal('remove_track').describe('Remove a track'),
     node_path: nodePathField,
     animation_name: animNameField,
@@ -226,7 +235,7 @@ export const animationEdit = defineTool({
     openWorldHint: false,
   },
   description:
-    "Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.",
+    "Create and modify animations on an AnimationPlayer and preview them in the editor: create, delete, or update animations, add and remove tracks and keyframes, backfill RESET keys for existing tracks (create_reset_keys), and play, stop, or seek the editor's preview (playback controls the editor, not the running game). Pair each change with an immediate play or seek to check the result; this is the only way to verify animation feel without running the whole game. To inspect animation data without changing it, use godot_animation_read.",
   schema: AnimationEditSchema,
   async execute(args: AnimationEditArgs, { godot }) {
     switch (args.action) {
@@ -315,6 +324,27 @@ export const animationEdit = defineTool({
             ? ` (no RESET key: ${result.reset_skipped})`
             : '';
         return `Added track ${result.track_index}: ${result.track_type} -> ${result.track_path}${reset}`;
+      }
+      case 'create_reset_keys': {
+        const result = await godot.sendCommand<{
+          animations: string[];
+          added: Array<{ animation: string; track_index: number; track_path: string; value: unknown }>;
+          skipped: Array<{ animation: string; track_index: number; track_path: string; reason: string }>;
+          has_reset: boolean;
+        }>('create_reset_keys', {
+          node_path: args.node_path,
+          animation_name: args.animation_name,
+        });
+        const lines = [
+          `RESET keys: ${result.added.length} added, ${result.skipped.length} skipped across ${result.animations.length} animation(s)`,
+        ];
+        for (const a of result.added) {
+          lines.push(`  + ${a.animation}[${a.track_index}] ${a.track_path} = ${JSON.stringify(a.value)}`);
+        }
+        for (const sk of result.skipped) {
+          lines.push(`  - ${sk.animation}[${sk.track_index}] ${sk.track_path}: ${sk.reason}`);
+        }
+        return lines.join('\n');
       }
       case 'remove_track': {
         const result = await godot.sendCommand<{ removed_track: number }>('remove_animation_track', {


### PR DESCRIPTION
Follow-up to #364. Tracks authored before 4.1.4, or by hand, have no RESET keys, so `save` still writes their preview values and only the `stop` warning catches it.

`godot_animation_edit create_reset_keys` keys the current value of every track on one animation (or all of the player's animations, RESET excluded) into the RESET animation where it lacks one, reusing the same helper `add_track` uses. Call it before previewing, while the nodes still hold their rest pose. The reply lists what was keyed and what was skipped with a reason.

Tests: 618 vitest; headless `animation_reset_headless_test.gd` now 32 checks (backfill over an unkeyed scale track, an unresolvable target skipped with a reason). Dev version 4.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
