### PR TITLE
fix: detect a stale server build instead of trusting package.json

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -26,7 +26,7 @@ Editor control, debugging, and screenshot tools
 
 Project information tools
 
-- `godot_project` - Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops. For scene contents or node properties, use godot_node_read instead.
+- `godot_project` - Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops; it also reports whether the running server build is stale relative to its source checkout. For scene contents or node properties, use godot_node_read instead.
 
 ## [Animation](animation.md)
 

--- a/docs/tools/project.md
+++ b/docs/tools/project.md
@@ -10,7 +10,7 @@ Project information tools
 
 ## godot_project
 
-Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops. For scene contents or node properties, use godot_node_read instead.
+Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops; it also reports whether the running server build is stale relative to its source checkout. For scene contents or node properties, use godot_node_read instead.
 
 ### Actions
 
@@ -31,7 +31,7 @@ Get project settings
 
 #### `addon_status`
 
-Check addon/server version compatibility
+Check addon/server version compatibility, and whether the running server build is stale (source edited after the last npm run build)
 
 *No parameters.*
 

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.6"
+version="4.1.7"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/satelliteoflove/godot-mcp#readme",
   "scripts": {
-    "build": "tsc && npm run copy-addon",
+    "build": "tsc && npm run build-info && npm run copy-addon",
+    "build-info": "tsx scripts/build-info.ts",
     "copy-addon": "tsx scripts/copy-addon.ts",
     "start": "node dist/index.js",
     "cli": "node dist/cli.js",

--- a/server/scripts/build-info.ts
+++ b/server/scripts/build-info.ts
@@ -1,0 +1,11 @@
+import { writeFileSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { writeBuildInfoObject } from '../src/utils/build-info.js';
+
+// Stamp dist with a hash of the source it was built from, so a server running
+// from an unbuilt checkout can say so (addon_status server_build).
+const root = process.cwd();
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf-8')) as { version: string };
+const info = writeBuildInfoObject(pkg.version, resolve(root, 'src'));
+writeFileSync(resolve(root, 'dist', 'build-info.json'), JSON.stringify(info, null, 2) + '\n');
+console.log(`build-info written: ${info.source_hash.slice(0, 12)} @ ${info.built_at}`);

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/core/__toolsnaps__/godot_project.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_project.json
@@ -1,6 +1,6 @@
 {
   "name": "godot_project",
-  "description": "Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops. For scene contents or node properties, use godot_node_read instead.",
+  "description": "Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops; it also reports whether the running server build is stale relative to its source checkout. For scene contents or node properties, use godot_node_read instead.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -12,7 +12,7 @@
           "addon_status",
           "check_stale"
         ],
-        "description": "get_info: Get project name, path, version, and main scene\nget_settings: Get project settings\naddon_status: Check addon/server version compatibility\ncheck_stale: Check whether project.godot was edited on disk after the editor loaded it, leaving the editor with stale autoloads / input map (and phantom \"Identifier not found\" errors in its log that do not exist at runtime). Returns the disk-vs-editor divergence; run godot_editor_edit restart to reload. Useful right after editing project.godot as a file."
+        "description": "get_info: Get project name, path, version, and main scene\nget_settings: Get project settings\naddon_status: Check addon/server version compatibility, and whether the running server build is stale (source edited after the last npm run build)\ncheck_stale: Check whether project.godot was edited on disk after the editor loaded it, leaving the editor with stale autoloads / input map (and phantom \"Identifier not found\" errors in its log that do not exist at runtime). Returns the disk-vs-editor divergence; run godot_editor_edit restart to reload. Useful right after editing project.godot as a file."
       },
       "category": {
         "description": "Settings category to filter by (use \"input\" for input mappings) (for: get_settings)",

--- a/server/src/__tests__/tools/project.test.ts
+++ b/server/src/__tests__/tools/project.test.ts
@@ -9,6 +9,21 @@ describe('project tool', () => {
     mock = createMockGodot();
   });
 
+  describe('addon_status', () => {
+    it('reports server_build beside the version comparison', async () => {
+      const ctx = createToolContext(mock);
+      Object.assign(ctx.godot, {
+        isConnected: true, addonVersion: '4.1.7', versionsMatch: true,
+        projectPath: '/p', projectName: 'demo',
+      });
+      const data = structuredOf(await project.execute({ action: 'addon_status' }, ctx));
+      expect(data.versions_match).toBe(true);
+      // Under vitest this module runs from src/, which is fresh by construction.
+      expect(data.server_build).toEqual({ mode: 'source', stale: false });
+      expect(data.recommendation).toBeNull();
+    });
+  });
+
   describe('check_stale (#245)', () => {
     it('queries get_project_staleness', async () => {
       mock.mockResponse({ stale: false });

--- a/server/src/__tests__/utils/build-info.test.ts
+++ b/server/src/__tests__/utils/build-info.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { computeSourceHash, hashSourceFiles, writeBuildInfoObject, checkBuildFreshness } from '../../utils/build-info.js';
+
+describe('build-info', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'godot-mcp-build-'));
+    mkdirSync(join(root, 'src', 'utils'), { recursive: true });
+    mkdirSync(join(root, 'src', '__tests__'), { recursive: true });
+    mkdirSync(join(root, 'dist', 'utils'), { recursive: true });
+    writeFileSync(join(root, 'src', 'a.ts'), 'export const a = 1;\n');
+    writeFileSync(join(root, 'src', 'utils', 'b.ts'), 'export const b = 2;\n');
+    writeFileSync(join(root, 'src', '__tests__', 'x.test.ts'), 'test\n');
+    writeFileSync(join(root, 'src', 'types.d.ts'), 'declare const q: number;\n');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('hashes source .ts files, skipping tests and declarations', () => {
+    const files = hashSourceFiles(join(root, 'src'));
+    expect(Object.keys(files).sort()).toEqual(['a.ts', 'utils/b.ts']);
+  });
+
+  it('changes the tree hash when a file changes', () => {
+    const before = computeSourceHash(join(root, 'src'));
+    writeFileSync(join(root, 'src', 'utils', 'b.ts'), 'export const b = 3;\n');
+    expect(computeSourceHash(join(root, 'src'))).not.toBe(before);
+  });
+
+  it('reports source mode when not running from dist', () => {
+    expect(checkBuildFreshness(join(root, 'src', 'utils') + '/')).toEqual({ mode: 'source', stale: false });
+  });
+
+  it('reports packaged when dist has no src beside it', () => {
+    rmSync(join(root, 'src'), { recursive: true });
+    expect(checkBuildFreshness(join(root, 'dist', 'utils') + '/').mode).toBe('packaged');
+  });
+
+  it('is stale when dist has no build stamp', () => {
+    const r = checkBuildFreshness(join(root, 'dist', 'utils') + '/');
+    expect(r.stale).toBe(true);
+    expect(r.reason).toContain('build-info.json is missing');
+  });
+
+  it('is fresh when the stamp matches src, stale with the changed files once src moves on', () => {
+    const info = writeBuildInfoObject('9.9.9', join(root, 'src'), new Date('2026-08-26T00:35:00Z'));
+    writeFileSync(join(root, 'dist', 'build-info.json'), JSON.stringify(info));
+    const fresh = checkBuildFreshness(join(root, 'dist', 'utils') + '/');
+    expect(fresh).toEqual({ mode: 'dist', built_at: '2026-08-26T00:35:00.000Z', stale: false });
+
+    writeFileSync(join(root, 'src', 'utils', 'b.ts'), 'export const b = 3;\n');
+    writeFileSync(join(root, 'src', 'c.ts'), 'export const c = 1;\n');
+    const stale = checkBuildFreshness(join(root, 'dist', 'utils') + '/');
+    expect(stale.stale).toBe(true);
+    expect(stale.changed).toEqual(['c.ts', 'utils/b.ts']);
+    expect(stale.reason).toContain('2 source file(s) changed since dist was built at 2026-08-26T00:35:00.000Z');
+    expect(stale.reason).toContain('npm run build');
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import { registerAllTools } from './tools/index.js';
 import { GodotCommandError } from './utils/errors.js';
 import { logger } from './utils/logger.js';
 import { getServerVersion } from './version.js';
+import { checkBuildFreshness } from './utils/build-info.js';
 
 function isReadOnlyMode(): boolean {
   const envValue = process.env.GODOT_MCP_READ_ONLY;
@@ -171,6 +172,13 @@ export async function main(deps: MainDeps = {}) {
   server.onclose = gracefulShutdown;
 
   logger.info('Server started');
+
+  // A source checkout whose dist predates its src: every tool reply would be
+  // from old code while addon_status says versions match. Say so once.
+  const build = checkBuildFreshness();
+  if (build.stale) {
+    logger.warning(`Server build is stale: ${build.reason}`);
+  }
 
   // Now reach for Godot, in the background. initializeConnection swallows its
   // own connect failures and schedules reconnects, so this never rejects and

--- a/server/src/tools/project.ts
+++ b/server/src/tools/project.ts
@@ -4,6 +4,7 @@ import { structured } from '../core/structured.js';
 import { staleAdvisory, type ProjectStaleness } from '../utils/project-staleness.js';
 import type { AnyToolDefinition } from '../core/types.js';
 import { getServerVersion } from '../version.js';
+import { checkBuildFreshness } from '../utils/build-info.js';
 
 const ProjectSchema = z.discriminatedUnion('action', [
   z.object({
@@ -21,7 +22,7 @@ const ProjectSchema = z.discriminatedUnion('action', [
       .describe('Include built-in ui_* actions (with category="input")'),
   }),
   z.object({
-    action: z.literal('addon_status').describe('Check addon/server version compatibility'),
+    action: z.literal('addon_status').describe('Check addon/server version compatibility, and whether the running server build is stale (source edited after the last npm run build)'),
   }),
   z.object({
     action: z
@@ -41,7 +42,7 @@ export const project = defineTool({
   name: 'godot_project',
   annotations: { title: 'Project Info', readOnlyHint: true, destructiveHint: false, openWorldHint: false },
   description:
-    'Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops. For scene contents or node properties, use godot_node_read instead.',
+    'Read project-level data from the editor: name, path, Godot version, and main scene (get_info), plus project settings including input mappings (get_settings). After editing project.godot as a file, use check_stale to detect whether the editor is still running stale autoloads or input map from before the edit; restart via godot_editor_edit to reload. Use addon_status to diagnose addon/server version skew when commands misbehave or the connection drops; it also reports whether the running server build is stale relative to its source checkout. For scene contents or node properties, use godot_node_read instead.',
   schema: ProjectSchema,
   async execute(args: ProjectArgs, { godot }) {
     switch (args.action) {
@@ -67,14 +68,21 @@ export const project = defineTool({
 
       case 'addon_status': {
         const serverVersion = getServerVersion();
+        // server_version comes from package.json, which a stale dist shares with
+        // fresh source; server_build compares the built source hash to src/.
+        const build = checkBuildFreshness();
+        const buildNote = build.stale ? `Server build is STALE: ${build.reason}` : null;
 
         if (!godot.isConnected) {
           return structured(
             {
               connected: false,
               server_version: serverVersion,
-              recommendation:
+              server_build: build,
+              recommendation: [
+                buildNote,
                 'Not connected to Godot. Ask user for their project path, then install with: npx @satelliteoflove/godot-mcp --install-addon <path>',
+              ].filter(Boolean).join(' '),
             }
           );
         }
@@ -82,19 +90,22 @@ export const project = defineTool({
         const addonVersion = godot.addonVersion;
         const projectPath = godot.projectPath;
         const versionsMatch = godot.versionsMatch;
+        const mismatchNote = versionsMatch
+          ? null
+          : `Version mismatch. Close Godot and run: npx @satelliteoflove/godot-mcp --install-addon "${projectPath}"`;
+        const notes = [buildNote, mismatchNote].filter(Boolean);
 
         return structured(
           {
             connected: true,
             server_version: serverVersion,
+            server_build: build,
             addon_version: addonVersion ?? 'unknown',
             versions_match: versionsMatch,
             project_path: projectPath,
             project_name: godot.projectName,
             godot_version: godot.godotVersion,
-            recommendation: versionsMatch
-              ? null
-              : `Version mismatch. Close Godot and run: npx @satelliteoflove/godot-mcp --install-addon "${projectPath}"`,
+            recommendation: notes.length > 0 ? notes.join(' ') : null,
           }
         );
       }

--- a/server/src/utils/build-info.ts
+++ b/server/src/utils/build-info.ts
@@ -1,0 +1,117 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// A stale `dist` looks exactly like a fresh one from the outside: package.json
+// carries the version, so addon_status reports versions_match: true while the
+// running code predates the last edit. The build writes a hash of the source
+// tree into dist/build-info.json; at runtime, when src/ sits beside dist/ (a
+// source checkout — npm installs don't ship src), the hash is recomputed and
+// compared. Nothing here is on the hot path: it runs once at startup and on
+// addon_status.
+
+export interface BuildInfo {
+  version: string;
+  built_at: string;
+  source_hash: string;
+}
+
+export interface BuildFreshness {
+  // 'dist' = running compiled output; 'source' = running .ts directly (tsx),
+  // which is fresh by construction; 'packaged' = dist without src beside it.
+  mode: 'dist' | 'source' | 'packaged';
+  built_at?: string;
+  stale: boolean;
+  // Files whose contents differ from what was built, when determinable.
+  changed?: string[];
+  reason?: string;
+}
+
+function walkTs(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walkTs(full, out);
+    else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) out.push(full);
+  }
+}
+
+// Per-file content hashes keyed by path relative to srcDir (posix separators).
+export function hashSourceFiles(srcDir: string): Record<string, string> {
+  const files: string[] = [];
+  walkTs(srcDir, files);
+  files.sort();
+  const out: Record<string, string> = {};
+  for (const f of files) {
+    const rel = relative(srcDir, f).split(sep).join('/');
+    out[rel] = createHash('sha1').update(readFileSync(f)).digest('hex');
+  }
+  return out;
+}
+
+export function computeSourceHash(srcDir: string): string {
+  const perFile = hashSourceFiles(srcDir);
+  const h = createHash('sha1');
+  for (const [rel, digest] of Object.entries(perFile)) h.update(`${rel}\0${digest}\n`);
+  return h.digest('hex');
+}
+
+export function writeBuildInfoObject(version: string, srcDir: string, now: Date = new Date()): BuildInfo & { files: Record<string, string> } {
+  return {
+    version,
+    built_at: now.toISOString(),
+    source_hash: computeSourceHash(srcDir),
+    files: hashSourceFiles(srcDir),
+  };
+}
+
+// Where this module lives at runtime: <root>/dist/utils or <root>/src/utils.
+function moduleDir(): string {
+  return fileURLToPath(new URL('.', import.meta.url));
+}
+
+export function checkBuildFreshness(here: string = moduleDir()): BuildFreshness {
+  const parent = dirname(here.replace(/[\\/]+$/, ''));
+  const parentName = basename(parent);
+  if (parentName !== 'dist') {
+    return { mode: 'source', stale: false };
+  }
+  const root = dirname(parent);
+  const srcDir = join(root, 'src');
+  const infoPath = join(parent, 'build-info.json');
+  if (!existsSync(srcDir) || !statSync(srcDir).isDirectory()) {
+    return { mode: 'packaged', stale: false, ...(existsSync(infoPath) ? { built_at: readInfo(infoPath)?.built_at } : {}) };
+  }
+  const info = existsSync(infoPath) ? readInfo(infoPath) : undefined;
+  if (!info) {
+    return { mode: 'dist', stale: true, reason: 'dist/build-info.json is missing — dist predates the build stamp; run `npm run build` in server/' };
+  }
+  const current = hashSourceFiles(srcDir);
+  const changed: string[] = [];
+  const built = info.files ?? {};
+  for (const [rel, digest] of Object.entries(current)) {
+    if (built[rel] !== digest) changed.push(rel);
+  }
+  for (const rel of Object.keys(built)) {
+    if (!(rel in current)) changed.push(`${rel} (removed)`);
+  }
+  if (changed.length === 0) {
+    return { mode: 'dist', built_at: info.built_at, stale: false };
+  }
+  return {
+    mode: 'dist',
+    built_at: info.built_at,
+    stale: true,
+    changed,
+    reason: `${changed.length} source file(s) changed since dist was built at ${info.built_at}; run \`npm run build\` in server/ and reconnect`,
+  };
+}
+
+function readInfo(path: string): (BuildInfo & { files?: Record<string, string> }) | undefined {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
From the 4.1.6 test round: `addon_status` said `server 4.1.6 / versions_match: true` while `dist` had been built before the last source edit, so the first `get_data` came back in the old shape. `server_version` comes from `package.json`, which a stale `dist` shares with fresh source, so a version comparison can't see this by construction.

- `npm run build` now writes `dist/build-info.json`: version, build time, and a per-file sha1 of `src/**/*.ts` (tests and `.d.ts` excluded).
- `checkBuildFreshness()` recomputes the hashes at runtime when `src/` sits beside `dist/` — a source checkout — and reports `mode: dist`, `built_at`, `stale`, the changed files, and a reason with the fix. An npm install has no `src/` and reads as `packaged`; running from `.ts` under tsx reads as `source` (fresh by construction). A `dist` with no stamp at all is reported stale, since it predates this.
- `addon_status` carries it as `server_build`, and the recommendation leads with "Server build is STALE: …" when it applies. Startup logs one warning to stderr.

Verified against a real build: fresh after `npm run build`; after touching `version.ts`, `stale: true, changed: ["version.ts"]` and the startup warning prints from `dist/cli.js`; fresh again after restoring. 629 vitest (7 new for the hashing and freshness states, 1 for `addon_status`). Dev version 4.1.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
