### PR TITLE
fix: watch honors hz; scene3d bounds include GridMap (4.1.8)

### DIFF
--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -336,6 +336,60 @@ func _can_resync() -> bool:
 evaluation at the end of the window, and false otherwise (including while
 frozen). The `has_node` guard keeps the game running without the addon.
 
+## Reading navigation state
+
+There is no `nav` action. `digest` and `watch` only see what a node exposes, and
+NavigationAgent state is a handful of getters plus a server with its own sync
+model, so read it with `godot_exec`. The recipe below returns everything that
+usually matters for "the agent isn't moving" in one call; adjust the paths.
+
+```gdscript
+var agent: NavigationAgent3D = get_node("/root/Main/Guard/NavigationAgent3D")
+var body: Node3D = agent.get_parent()
+var pos := body.global_position
+var next := agent.get_next_path_position()
+var to_next := pos.distance_to(next)
+var to_next_xz := Vector2(pos.x, pos.z).distance_to(Vector2(next.x, next.z))
+var map := agent.get_navigation_map()
+return JSON.stringify({
+    "target": agent.target_position,
+    "target_reachable": agent.is_target_reachable(),
+    "finished": agent.is_navigation_finished(),
+    "next": next,
+    "distance_to_next": to_next,
+    "distance_to_next_xz": to_next_xz,
+    "distance_to_target": agent.distance_to_target(),
+    "path_points": agent.get_current_navigation_path().size(),
+    "path_index": agent.get_current_navigation_path_index(),
+    # The classic stuck case: the next point is within path_desired_distance
+    # in 3D (usually straight below the agent) but not once flattened to XZ,
+    # so the agent never advances past it and its XZ move direction is zero.
+    "stuck_next_point_below": to_next <= agent.path_desired_distance and to_next_xz > 0.01,
+    "map_iteration": NavigationServer3D.map_get_iteration_id(map),
+    "map_regions": NavigationServer3D.map_get_regions(map).size(),
+    "closest_nav_point": NavigationServer3D.map_get_closest_point(map, pos),
+})
+```
+
+Things to know before trusting the numbers:
+
+- The NavigationServer syncs once per physics tick. A region you just baked
+  (`NavigationRegion3D.bake_navigation_mesh()` or a swapped `navigation_mesh`)
+  isn't queryable, and `map_get_iteration_id` doesn't change, until the next
+  tick. Under a freeze that means one `godot_game_time step` first.
+- `get_next_path_position()` is what the agent will steer toward. If it equals
+  the current position after flattening the Y axis, the agent is stuck on the
+  gotcha above; raise `path_desired_distance`, or project the target onto the
+  navmesh with `map_get_closest_point` before assigning it.
+- `map_get_closest_point` on top of a wall or pillar means the bake climbed
+  it: check the region's `agent_max_slope` / `cell_height` before blaming the
+  agent.
+- Route checks: `NavigationServer3D.map_get_path(map, from, to, true)` returns
+  the polyline the agent would follow; sum the segment lengths for total
+  distance. `NavigationRegion3D.get_bounds()` gives a region's AABB.
+- The 2D API is the same shape (`NavigationAgent2D`, `NavigationServer2D`,
+  `Vector2`); drop the XZ flattening.
+
 ## Quick checklist
 
 - Tag the entities that matter into the `mcp_watch` group.

--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -344,7 +344,7 @@ model, so read it with `godot_exec`. The recipe below returns everything that
 usually matters for "the agent isn't moving" in one call; adjust the paths.
 
 ```gdscript
-var agent: NavigationAgent3D = get_node("/root/Main/Guard/NavigationAgent3D")
+var agent: NavigationAgent3D = root.get_node("/root/Main/Guard/NavigationAgent3D")
 var body: Node3D = agent.get_parent()
 var pos := body.global_position
 var next := agent.get_next_path_position()
@@ -361,10 +361,11 @@ return JSON.stringify({
     "distance_to_target": agent.distance_to_target(),
     "path_points": agent.get_current_navigation_path().size(),
     "path_index": agent.get_current_navigation_path_index(),
-    # The classic stuck case: the next point is within path_desired_distance
-    # in 3D (usually straight below the agent) but not once flattened to XZ,
-    # so the agent never advances past it and its XZ move direction is zero.
-    "stuck_next_point_below": to_next <= agent.path_desired_distance and to_next_xz > 0.01,
+    # The classic stuck case: the next point sits straight below (or above)
+    # the agent, so the XZ distance is ~0 and the flattened move direction is
+    # zero, while the 3D distance is still at or past path_desired_distance,
+    # so the agent never counts the point as reached and never advances.
+    "stuck_next_point_below": to_next_xz < 0.01 and to_next >= agent.path_desired_distance,
     "map_iteration": NavigationServer3D.map_get_iteration_id(map),
     "map_regions": NavigationServer3D.map_get_regions(map).size(),
     "closest_nav_point": NavigationServer3D.map_get_closest_point(map, pos),
@@ -378,9 +379,11 @@ Things to know before trusting the numbers:
   isn't queryable, and `map_get_iteration_id` doesn't change, until the next
   tick. Under a freeze that means one `godot_game_time step` first.
 - `get_next_path_position()` is what the agent will steer toward. If it equals
-  the current position after flattening the Y axis, the agent is stuck on the
-  gotcha above; raise `path_desired_distance`, or project the target onto the
-  navmesh with `map_get_closest_point` before assigning it.
+  the current position after flattening the Y axis but is still
+  `path_desired_distance` or more away in 3D, the agent is stuck on the gotcha
+  above; raise `path_desired_distance` past the vertical gap, or keep the
+  agent's Y on the navmesh (`map_get_closest_point`) so the path points aren't
+  below it.
 - `map_get_closest_point` on top of a wall or pillar means the bake climbed
   it: check the region's `agent_max_slope` / `cell_height` before blaming the
   agent.

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -54,7 +54,7 @@ Resource inspection tools for SpriteFrames, TileSet, Materials, etc.
 
 3D spatial information and bounding box tools
 
-- `godot_scene3d` - Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs, combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.
+- `godot_scene3d` - Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs (VisualInstance3D, and GridMap folded from its placed cells), combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.
 
 ## [Documentation](docs.md)
 
@@ -78,7 +78,7 @@ Performance profiling: snapshots, per-frame time series with spike detection, ac
 
 Observe live game entity state as structured JSON — positions, velocities, animation state, and custom _mcp_state() data. Works out of the box for both 2D and 3D scenes (the auto fallback surfaces visible 3D world nodes — meshes, gridmaps, cameras, lights, physics bodies and areas — not just UI). Much cheaper than screenshots.
 
-- `godot_runtime_state` - Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
+- `godot_runtime_state` - Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup. Navigation (NavigationAgent path state, NavigationServer map sync, find-path) is not exposed here; use godot_exec with the recipe in docs/runtime-state-guide.md "Reading navigation state".
 
 ## [Game Time Control](game-time.md)
 

--- a/docs/tools/runtime-state.md
+++ b/docs/tools/runtime-state.md
@@ -10,7 +10,7 @@ Observe live game entity state as structured JSON — positions, velocities, ani
 
 ## godot_runtime_state
 
-Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.
+Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup. Navigation (NavigationAgent path state, NavigationServer map sync, find-path) is not exposed here; use godot_exec with the recipe in docs/runtime-state-guide.md "Reading navigation state".
 
 ### Actions
 

--- a/docs/tools/scene3d.md
+++ b/docs/tools/scene3d.md
@@ -10,7 +10,7 @@
 
 ## godot_scene3d
 
-Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs, combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.
+Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs (VisualInstance3D, and GridMap folded from its placed cells), combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.
 
 ### Actions
 
@@ -28,7 +28,7 @@ Get spatial data for a Node3D and optionally its children
 
 #### `get_bounds`
 
-Get the combined AABB of a subtree
+Get the combined AABB of a subtree (VisualInstance3D and GridMap nodes)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/godot/addons/godot_mcp/commands/scene3d_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene3d_commands.gd
@@ -106,7 +106,8 @@ func _get_node3d_info(node: Node3D) -> Dictionary:
 
 
 ## Local-space bounds of a node that draws something, or {} when it draws
-## nothing we can measure. VisualInstance3D reports its own AABB. GridMap is a
+## nothing we can measure (no mesh, or a GridMap with no cells). VisualInstance3D
+## reports its own AABB. GridMap is a
 ## plain Node3D that renders through its own RenderingServer instances, so its
 ## bounds are folded from the placed cells: each cell contributes its library
 ## mesh's AABB (through the item mesh transform, cell orientation and
@@ -114,7 +115,13 @@ func _get_node3d_info(node: Node3D) -> Dictionary:
 ## has no mesh -- so it covers what is actually drawn, not just the grid (#379).
 func _local_bounds(node: Node) -> Dictionary:
 	if node is VisualInstance3D:
-		return {"aabb": (node as VisualInstance3D).get_aabb()}
+		var aabb := (node as VisualInstance3D).get_aabb()
+		# A MeshInstance3D with no mesh (assigned at runtime, null in the editor)
+		# reports a zero-size AABB at its origin. That is not geometry: counting it
+		# would merge a point into the subtree bounds and report a bogus zero box.
+		if aabb.size == Vector3.ZERO:
+			return {}
+		return {"aabb": aabb}
 	if node is GridMap:
 		var grid := node as GridMap
 		var cells := grid.get_used_cells()

--- a/godot/addons/godot_mcp/commands/scene3d_commands.gd
+++ b/godot/addons/godot_mcp/commands/scene3d_commands.gd
@@ -96,13 +96,53 @@ func _get_node3d_info(node: Node3D) -> Dictionary:
 		"visible": node.visible,
 	}
 
-	if node is VisualInstance3D:
-		var aabb := (node as VisualInstance3D).get_aabb()
-		var global_aabb := node.global_transform * aabb
+	var bounds := _local_bounds(node)
+	if bounds.has("aabb"):
+		var aabb: AABB = bounds.aabb
 		info["aabb"] = _serialize_aabb(aabb)
-		info["global_aabb"] = _serialize_aabb(global_aabb)
+		info["global_aabb"] = _serialize_aabb(node.global_transform * aabb)
 
 	return info
+
+
+## Local-space bounds of a node that draws something, or {} when it draws
+## nothing we can measure. VisualInstance3D reports its own AABB. GridMap is a
+## plain Node3D that renders through its own RenderingServer instances, so its
+## bounds are folded from the placed cells: each cell contributes its library
+## mesh's AABB (through the item mesh transform, cell orientation and
+## cell_scale, at the cell's local origin), or a cell_size box when the item
+## has no mesh -- so it covers what is actually drawn, not just the grid (#379).
+func _local_bounds(node: Node) -> Dictionary:
+	if node is VisualInstance3D:
+		return {"aabb": (node as VisualInstance3D).get_aabb()}
+	if node is GridMap:
+		var grid := node as GridMap
+		var cells := grid.get_used_cells()
+		if cells.is_empty():
+			return {}
+		var library: MeshLibrary = grid.mesh_library
+		var cell_box := AABB(-grid.cell_size / 2.0, grid.cell_size)
+		var scale_basis := Basis().scaled(Vector3.ONE * grid.cell_scale)
+		var total := AABB()
+		var first := true
+		for cell in cells:
+			var item := grid.get_cell_item(cell)
+			var origin: Vector3 = grid.map_to_local(cell)
+			var cell_aabb: AABB
+			var mesh: Mesh = library.get_item_mesh(item) if library != null and library.get_item_list().has(item) else null
+			if mesh != null:
+				var orientation := grid.get_basis_with_orthogonal_index(grid.get_cell_item_orientation(cell))
+				var xform := Transform3D(orientation * scale_basis, origin) * library.get_item_mesh_transform(item)
+				cell_aabb = xform * mesh.get_aabb()
+			else:
+				cell_aabb = AABB(cell_box.position + origin, cell_box.size)
+			if first:
+				total = cell_aabb
+				first = false
+			else:
+				total = total.merge(cell_aabb)
+		return {"aabb": total}
+	return {}
 
 
 func _serialize_aabb(aabb: AABB) -> Dictionary:
@@ -131,7 +171,7 @@ func get_scene_bounds(params: Dictionary) -> Dictionary:
 	_collect_bounds(search_root, state)
 
 	if state.count == 0:
-		return _error("NO_GEOMETRY", "No VisualInstance3D nodes found under: %s" % (root_path if not root_path.is_empty() else "scene root"))
+		return _error("NO_GEOMETRY", "No VisualInstance3D or populated GridMap nodes found under: %s" % (root_path if not root_path.is_empty() else "scene root"))
 
 	var usable_path := "/root/" + scene_root.name
 	if search_root != scene_root:
@@ -146,10 +186,9 @@ func get_scene_bounds(params: Dictionary) -> Dictionary:
 
 
 func _collect_bounds(node: Node, state: Dictionary) -> void:
-	if node is VisualInstance3D:
-		var visual := node as VisualInstance3D
-		var local_aabb := visual.get_aabb()
-		var global_aabb := visual.global_transform * local_aabb
+	var bounds := _local_bounds(node)
+	if bounds.has("aabb"):
+		var global_aabb: AABB = (node as Node3D).global_transform * bounds.aabb
 
 		if state.first:
 			state.aabb = global_aabb

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -17,8 +17,12 @@ var _duration_ms: int = 1000
 # godot_game_time freeze the tree is paused between steps, and counting wall time
 # there would run the window down / log stale samples before the step that moves.
 var _elapsed_ms: float = 0.0
-var _frame_index: int = 0
-var _sample_interval: int = 1  # sample every N frames
+# Next sample is due when _elapsed_ms reaches this. Sampling is scheduled in GAME
+# time (1000 / hz ms apart), never as a frame stride: a stride derived from one
+# fps reading at start() is wrong whenever the frame rate during the window
+# differs from it -- launched frozen the reading is 0, after a long freeze it is
+# stale -- and the window then fills 2-4x faster or slower than asked (#378).
+var _next_sample_ms: float = 0.0
 var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
 var _events: Array = []        # [{t_ms, source, signal, args?}] -- signal emissions this window
 var _events_truncated: bool = false
@@ -44,8 +48,7 @@ func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) ->
 	_hz = clampi(hz, 1, 60)
 	_duration_ms = clampi(duration_ms, 100, 5000)
 	_elapsed_ms = 0.0
-	_frame_index = 0
-	_sample_interval = max(1, int(Engine.get_frames_per_second() / _hz)) if Engine.get_frames_per_second() > 0 else max(1, int(60.0 / _hz))
+	_next_sample_ms = 0.0  # first unpaused frame samples immediately (t ~= one delta)
 
 	var field_count := 0
 	for spec in specs:
@@ -242,9 +245,14 @@ func _process(delta: float) -> void:
 		_disconnect_all()
 		return
 
-	_frame_index += 1
-	if _frame_index % _sample_interval != 0:
+	if _elapsed_ms < _next_sample_ms:
 		return
+	var interval_ms := 1000.0 / float(_hz)
+	_next_sample_ms += interval_ms
+	if _next_sample_ms <= _elapsed_ms:
+		# A frame longer than the interval (stall, or a big single step): take one
+		# sample now and resync rather than bursting to make up the missed ticks.
+		_next_sample_ms = _elapsed_ms + interval_ms
 
 	for spec in _specs:
 		# Untyped: a typed assignment of a freed instance is a script error that

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.7"
+version="4.1.8"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/godot/addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd
+++ b/godot/addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd
@@ -82,6 +82,16 @@ func _process(_delta: float) -> bool:
 	_approx("collect: merged min", state.aabb.position, Vector3(-10.5, 0.5, -0.5))
 	_approx("collect: merged max", state.aabb.end, Vector3(20.5, 5.5, 16.5))
 
+	# A MeshInstance3D with no mesh (runtime-assigned) has no bounds and is not counted.
+	var bare := MeshInstance3D.new()
+	bare.position = Vector3(50, 50, 50)
+	parent.add_child(bare)
+	_check("mesh-less MeshInstance3D has no bounds", cmds._local_bounds(bare).has("aabb"), false)
+	state = {"aabb": AABB(), "count": 0, "first": true}
+	cmds._collect_bounds(parent, state)
+	_check("collect: mesh-less instance not counted", state.count, 2)
+	_approx("collect: mesh-less instance does not stretch the box", state.aabb.end, Vector3(20.5, 5.5, 16.5))
+
 	print("1..%d" % _n)
 	if _fail == 0:
 		print("ALL PASS - %d checks" % _n)

--- a/godot/addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd
+++ b/godot/addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd
@@ -1,0 +1,91 @@
+extends SceneTree
+## Headless check for #379: godot_scene3d bounds include GridMap cells.
+## Exercises MCPScene3DCommands._local_bounds directly (no editor needed).
+##
+##   godot --headless --path <project> --script res://addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd
+
+var _n := 0
+var _fail := 0
+
+
+func _check(label: String, got, want) -> void:
+	_n += 1
+	if got == want:
+		print("ok %d - %s" % [_n, label])
+	else:
+		_fail += 1
+		print("not ok %d - %s (got %s, want %s)" % [_n, label, got, want])
+
+
+func _approx(label: String, got: Vector3, want: Vector3) -> void:
+	_check(label, got.is_equal_approx(want), true)
+
+
+var _ran := false
+
+
+func _process(_delta: float) -> bool:
+	if _ran:
+		return false
+	_ran = true
+	print("===================== SCENE3D GRIDMAP BOUNDS TEST =====================")
+	var script := load("res://addons/godot_mcp/commands/scene3d_commands.gd")
+	var cmds = script.new()
+
+	# Empty GridMap: no bounds at all (must not appear as a zero box at origin).
+	var grid := GridMap.new()
+	grid.cell_size = Vector3(2, 2, 2)
+	root.add_child(grid)
+	_check("empty GridMap has no bounds", cmds._local_bounds(grid).has("aabb"), false)
+
+	# No mesh library: cells fall back to cell_size boxes. Cells (0,0,0) and (9,0,7)
+	# with centered cells -> 0..20 x 0..2 x 0..16.
+	grid.set_cell_item(Vector3i(0, 0, 0), 0)
+	grid.set_cell_item(Vector3i(9, 0, 7), 0)
+	var b: AABB = cmds._local_bounds(grid).get("aabb")
+	_approx("cell boxes: min", b.position, Vector3(0, 0, 0))
+	_approx("cell boxes: max", b.end, Vector3(20, 2, 16))
+
+	# With a library mesh larger than the cell, the mesh AABB wins over the cell box.
+	var lib := MeshLibrary.new()
+	lib.create_item(0)
+	var box := BoxMesh.new()
+	box.size = Vector3(3, 1, 3)  # wider than the 2-unit cell, shorter
+	lib.set_item_mesh(0, box)
+	grid.mesh_library = lib
+	b = cmds._local_bounds(grid).get("aabb")
+	_approx("mesh aabb: min", b.position, Vector3(-0.5, 0.5, -0.5))
+	_approx("mesh aabb: max", b.end, Vector3(20.5, 1.5, 16.5))
+
+	# Item mesh transform offsets and cell_scale scales the drawn mesh.
+	lib.set_item_mesh_transform(0, Transform3D(Basis(), Vector3(0, 1, 0)))
+	grid.cell_scale = 2.0
+	b = cmds._local_bounds(grid).get("aabb")
+	_approx("mesh_transform + cell_scale: min", b.position, Vector3(-2, 2, -2))
+	_approx("mesh_transform + cell_scale: max", b.end, Vector3(22, 4, 18))
+
+	# Sibling mesh instance and the GridMap merge in _collect_bounds under a parent.
+	grid.cell_scale = 1.0
+	lib.set_item_mesh_transform(0, Transform3D())
+	var parent := Node3D.new()
+	root.add_child(parent)
+	grid.reparent(parent)
+	var mi := MeshInstance3D.new()
+	var far := BoxMesh.new()
+	far.size = Vector3(1, 1, 1)
+	mi.mesh = far
+	mi.position = Vector3(-10, 5, 0)
+	parent.add_child(mi)
+	var state := {"aabb": AABB(), "count": 0, "first": true}
+	cmds._collect_bounds(parent, state)
+	_check("collect: GridMap counts as a visual node", state.count, 2)
+	_approx("collect: merged min", state.aabb.position, Vector3(-10.5, 0.5, -0.5))
+	_approx("collect: merged max", state.aabb.end, Vector3(20.5, 5.5, 16.5))
+
+	print("1..%d" % _n)
+	if _fail == 0:
+		print("ALL PASS - %d checks" % _n)
+	else:
+		print("FAILED - %d of %d" % [_fail, _n])
+	quit(0 if _fail == 0 else 1)
+	return true

--- a/godot/addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd.uid
+++ b/godot/addons/godot_mcp/test/scene3d_gridmap_bounds_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bqrqmhhlbb0iw

--- a/godot/addons/godot_mcp/test/watch_contract_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_contract_headless_test.gd
@@ -99,11 +99,11 @@ func _run() -> void:
 	emitter.fired.emit()
 	emitter.hit.emit(3)
 
-	# Drive a few field samples deterministically (interval forced to 1, as in the
-	# timeline test) so `fields` is non-empty and field_sample keys can be checked.
-	sampler._sample_interval = 1
+	# Drive a few field samples deterministically (each frame advances game time
+	# past the 60 Hz interval, as in the timeline test) so `fields` is non-empty
+	# and field_sample keys can be checked.
 	for i in 3:
-		sampler._process(0.0)
+		sampler._process(0.02)
 
 	var result: Dictionary = sampler.collect()
 

--- a/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
@@ -50,6 +50,7 @@ func _run() -> void:
 	_test_fairness_three(sampler, emitter)
 	_test_field_samples_truncated(sampler, emitter)
 	_test_freeze_pauses_sampling(sampler, emitter)
+	_test_hz_is_game_time(sampler)
 	_test_arg_caps(sampler, emitter)
 	await _test_window_semantics(sampler, emitter)
 	await _test_auto_stop(sampler, emitter)
@@ -193,16 +194,15 @@ func _test_fairness_three(sampler: MCPRuntimeStateSampler, emitter: _Emitter) ->
 
 func _test_field_samples_truncated(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:
 	# Sampled-field history caps at MAX_SAMPLES_PER_FIELD; overflow must be FLAGGED,
-	# not silently dropped (#285 #4). Drive _process directly with the interval forced
-	# to 1 so the sample count is deterministic and independent of the headless frame
-	# rate (which makes the fps-derived _sample_interval unpredictable).
+	# not silently dropped (#285 #4). Drive _process directly with a 20 ms delta
+	# (past the 60 Hz interval) so every frame samples and the count is
+	# deterministic, independent of the headless frame rate.
 	# Watch a real field ("score", saturates) alongside a never-readable "ghost" field
 	# (_read_field returns null, so it never appends and must never appear in
 	# fields_truncated) — proving the flag is genuinely per-field, not blanket.
 	sampler.start([{"path": "/root/FakeAutoload", "fields": ["score", "ghost"]}], 60, 5000, [])
-	sampler._sample_interval = 1
 	for i in MCPRuntimeStateSampler.MAX_SAMPLES_PER_FIELD + 25:
-		sampler._process(0.0)
+		sampler._process(0.02)
 	var result: Dictionary = sampler.stop()
 	var ft: Dictionary = result.get("fields_truncated", {})
 	_check("field saturation: overflow flagged for the saturated field",
@@ -220,9 +220,8 @@ func _test_freeze_pauses_sampling(sampler: MCPRuntimeStateSampler, _emitter: _Em
 	# but the sampler inherits PROCESS_MODE_ALWAYS so _process keeps firing. Those
 	# paused frames must NOT advance the window or record samples — otherwise the
 	# window (formerly wall-clock) ran down during frozen idle and stepped tests
-	# came back flat. Drive _process directly with the interval forced to 1.
+	# came back flat. Drive _process directly; 500 ms deltas exceed any interval.
 	sampler.start([{"path": "/root/FakeAutoload", "fields": ["score"]}], 60, 5000, [])
-	sampler._sample_interval = 1
 	paused = true
 	for i in 5:
 		sampler._process(0.5)  # 5 frames @ 500ms each — would be 2500ms of WALL time
@@ -240,6 +239,24 @@ func _test_freeze_pauses_sampling(sampler: MCPRuntimeStateSampler, _emitter: _Em
 	_check("freeze: sampling resumes once unpaused (step)", live_samples > 0, true)
 	_check("freeze: window advances in GAME time once unpaused (~1500ms)",
 		int(live.get("window_ms")) >= 1400, true)
+	sampler.stop()
+
+
+func _test_hz_is_game_time(sampler: MCPRuntimeStateSampler) -> void:
+	# #378: hz is a rate in game time, not a frame stride. 1 s of game time must
+	# yield ~hz samples regardless of the frame rate it is delivered at.
+	sampler.start([{"path": "/root/FakeAutoload", "fields": ["score"]}], 10, 5000, [])
+	for i in 240:
+		sampler._process(1.0 / 240.0)  # 240 fps for 1 s
+	var fast: int = ((sampler.collect().get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", []) as Array).size()
+	_check("hz: 1 s at 240 fps gives ~10 samples at 10 Hz (not 40)", fast >= 10 and fast <= 11, true)
+	for i in 30:
+		sampler._process(1.0 / 30.0)  # then 30 fps for 1 s -- same rate expected
+	var total: int = ((sampler.collect().get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", []) as Array).size()
+	_check("hz: a frame-rate change mid-window keeps the same sample rate", total - fast >= 9 and total - fast <= 11, true)
+	sampler._process(0.5)  # one 500 ms stall: exactly one sample, no burst
+	var after_stall: int = ((sampler.collect().get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", []) as Array).size()
+	_check("hz: a long frame takes one sample, no catch-up burst", after_stall - total, 1)
 	sampler.stop()
 
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/core/__toolsnaps__/godot_runtime_state.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_runtime_state.json
@@ -1,6 +1,6 @@
 {
   "name": "godot_runtime_state",
-  "description": "Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup.",
+  "description": "Observe live game state as structured data. Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). Use watch_start → watch_collect for state-over-time without context blowup. Navigation (NavigationAgent path state, NavigationServer map sync, find-path) is not exposed here; use godot_exec with the recipe in docs/runtime-state-guide.md \"Reading navigation state\".",
   "inputSchema": {
     "type": "object",
     "properties": {

--- a/server/src/__tests__/core/__toolsnaps__/godot_scene3d.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_scene3d.json
@@ -1,6 +1,6 @@
 {
   "name": "godot_scene3d",
-  "description": "Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs, combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.",
+  "description": "Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs (VisualInstance3D, and GridMap folded from its placed cells), combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -10,7 +10,7 @@
           "get_spatial_info",
           "get_bounds"
         ],
-        "description": "get_spatial_info: Get spatial data for a Node3D and optionally its children\nget_bounds: Get the combined AABB of a subtree"
+        "description": "get_spatial_info: Get spatial data for a Node3D and optionally its children\nget_bounds: Get the combined AABB of a subtree (VisualInstance3D and GridMap nodes)"
       },
       "node_path": {
         "type": "string",

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -490,7 +490,9 @@ describe('runtimeState tool', () => {
 
       expect(data.window_ms).toBe(1000);
       expect(data.sample_count).toBe(5);
+      expect(data.samples_per_field).toBe(5);
       const summary = data.fields['/root/Player:pos.x'];
+      expect(summary.samples).toBe(5);
       expect(summary.start).toBe(100);
       expect(summary.end).toBe(250);
       expect(summary.min).toBe(100);

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -704,7 +704,7 @@ describe('buildTimeline', () => {
 
   it('splits field keys on the LAST colon (paths may contain colons)', () => {
     const fields = {
-      '/root/Player:anim': { start: 'a', end: 'b', changes: [{ t_ms: 10, from: 'a', to: 'b' }] },
+      '/root/Player:anim': { samples: 2, start: 'a', end: 'b', changes: [{ t_ms: 10, from: 'a', to: 'b' }] },
     };
     const [entry] = buildTimeline([], fields);
     expect(entry).toEqual({ t_ms: 10, kind: 'anim_transition', source: '/root/Player', from: 'a', to: 'b' });
@@ -712,8 +712,8 @@ describe('buildTimeline', () => {
 
   it('orders t_ms ties deterministically: signal < anim_transition < field_change', () => {
     const fields = {
-      '/root/P:state': { start: 'x', end: 'y', changes: [{ t_ms: 100, from: 'x', to: 'y' }] },
-      '/root/P:anim': { start: 'a', end: 'b', changes: [{ t_ms: 100, from: 'a', to: 'b' }] },
+      '/root/P:state': { samples: 2, start: 'x', end: 'y', changes: [{ t_ms: 100, from: 'x', to: 'y' }] },
+      '/root/P:anim': { samples: 2, start: 'a', end: 'b', changes: [{ t_ms: 100, from: 'a', to: 'b' }] },
     };
     const events = [{ t_ms: 100, source: '/root/P', signal: 'tick' }];
     expect(buildTimeline(events, fields).map((e) => e.kind)).toEqual([
@@ -741,7 +741,7 @@ describe('buildTimeline', () => {
   it('ignores numeric field summaries entirely', () => {
     const fields = {
       '/root/P:vel.x': {
-        start: 0, end: 5, min: 0, max: 5, mean: 2.5, slope: 5,
+        samples: 2, start: 0, end: 5, min: 0, max: 5, mean: 2.5, slope: 5,
         events: [{ t_ms: 50, from: 0, to: 5, kind: 'zero_cross' as const }],
       },
     };
@@ -754,7 +754,7 @@ describe('buildTimeline', () => {
 describe('summarizeNumericField', () => {
   it('returns zeros for empty input', () => {
     const r = summarizeNumericField([], 1000);
-    expect(r).toEqual({ start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] });
+    expect(r).toEqual({ samples: 0, start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] });
   });
 
   it('handles single sample', () => {
@@ -813,7 +813,7 @@ describe('summarizeNumericField', () => {
 describe('summarizeStringField', () => {
   it('returns empty result for empty input', () => {
     const r = summarizeStringField([]);
-    expect(r).toEqual({ start: '', end: '', changes: [] });
+    expect(r).toEqual({ samples: 0, start: '', end: '', changes: [] });
   });
 
   it('returns no changes for constant value', () => {

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -75,6 +75,7 @@ interface WatchRawResponse {
 // ── Server-side summarization helpers ───────────────────────────────────────
 
 export interface NumericFieldSummary {
+  samples: number;
   start: number;
   end: number;
   min: number;
@@ -88,6 +89,7 @@ export interface NumericFieldSummary {
 }
 
 export interface StringFieldSummary {
+  samples: number;
   start: string;
   end: string;
   changes: Array<{ t_ms: number; from: string; to: string }>;
@@ -100,7 +102,7 @@ export function summarizeNumericField(
   windowMs: number
 ): NumericFieldSummary {
   if (samples.length === 0) {
-    return { start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] };
+    return { samples: 0, start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] };
   }
 
   const values = samples.map((s) => s.value as number);
@@ -122,12 +124,12 @@ export function summarizeNumericField(
     }
   }
 
-  return { start: first, end: last, min, max, mean, slope, events };
+  return { samples: samples.length, start: first, end: last, min, max, mean, slope, events };
 }
 
 export function summarizeStringField(samples: WatchRawSample[]): StringFieldSummary {
   if (samples.length === 0) {
-    return { start: '', end: '', changes: [] };
+    return { samples: 0, start: '', end: '', changes: [] };
   }
 
   const first = samples[0].value as string;
@@ -142,7 +144,7 @@ export function summarizeStringField(samples: WatchRawSample[]): StringFieldSumm
     }
   }
 
-  return { start: first, end: last, changes };
+  return { samples: samples.length, start: first, end: last, changes };
 }
 
 function summarizeWatchRaw(raw: WatchRawResponse): Record<string, NumericFieldSummary | StringFieldSummary> {
@@ -237,9 +239,13 @@ function summarizeWatchResponse(raw: WatchRawResponse) {
   const stringFieldTruncated = Object.values(fields).some(
     (f) => 'changes' in f && f.samples_truncated === true
   );
+  // sample_count is the SUM over fields (two fields at 10 Hz for 1 s read 20), so
+  // it is not a rate; samples_per_field (the longest field) is, against window_ms.
+  const samplesPerField = Math.max(0, ...Object.values(raw.fields).map((f) => f.length));
   return structured({
     window_ms: raw.window_ms,
     sample_count: raw.sample_count,
+    samples_per_field: samplesPerField,
     fields,
     timeline,
     // Honest headline: the timeline omits entries for ANY reason — the signal-event

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -423,7 +423,10 @@ export const runtimeState = defineTool({
   description:
     'Observe live game state as structured data. ' +
     'Use digest for a one-shot entity snapshot (replaces most godot_editor_read screenshot_game calls). ' +
-    'Use watch_start → watch_collect for state-over-time without context blowup.',
+    'Use watch_start → watch_collect for state-over-time without context blowup. ' +
+    'Navigation (NavigationAgent path state, NavigationServer map sync, find-path) is not ' +
+    'exposed here; use godot_exec with the recipe in docs/runtime-state-guide.md ' +
+    '"Reading navigation state".',
   schema: RuntimeStateSchema,
 
   async execute(args: RuntimeStateArgs, { godot }) {

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -54,7 +54,7 @@ const Scene3DSchema = z.discriminatedUnion('action', [
     ),
   }),
   z.object({
-    action: z.literal('get_bounds').describe('Get the combined AABB of a subtree'),
+    action: z.literal('get_bounds').describe('Get the combined AABB of a subtree (VisualInstance3D and GridMap nodes)'),
     root_path: z
       .string()
       .optional()
@@ -76,7 +76,7 @@ export const scene3d = defineTool({
   name: 'godot_scene3d',
   annotations: { title: '3D Scene Info', readOnlyHint: true, destructiveHint: false, openWorldHint: false },
   description:
-    'Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs, combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.',
+    'Read engine-computed 3D spatial data that cannot be derived from .tscn text: global transforms resolved through the parent chain, mesh AABBs (VisualInstance3D, and GridMap folded from its placed cells), combined subtree bounds, and visibility. Use get_spatial_info for one Node3D or a filtered set of its children (by type or world-space region); use get_bounds for the combined AABB of a subtree. Read-only: to change transforms or other properties, use godot_node_edit.',
   schema: Scene3DSchema,
   async execute(args: Scene3DArgs, { godot }) {
     switch (args.action) {

--- a/server/src/tools/scene3d.ts
+++ b/server/src/tools/scene3d.ts
@@ -110,6 +110,9 @@ export const scene3d = defineTool({
           line += `  rotation: ${formatVector3(n.global_rotation)} rad\n`;
           line += `  scale: ${formatVector3(n.global_scale)}\n`;
           line += `  visible: ${n.visible}`;
+          if (n.aabb) {
+            line += `\n  aabb: ${formatAABB(n.aabb)}`;
+          }
           if (n.global_aabb) {
             line += `\n  global_aabb: ${formatAABB(n.global_aabb)}`;
           }


### PR DESCRIPTION
Fixes the sampler in `mcp_runtime_state_sampler.gd` so `watch_start` honors `hz`.

The rate was converted to a frame stride from one `Engine.get_frames_per_second()` reading at `start()`. That reading is 0 when the game is launched frozen (so the fallback assumed 60 fps, giving ~40 Hz at 240 fps) and stale after a long freeze. Sampling is now scheduled on the game-time clock the window already uses: a sample is due every `1000 / hz` ms of unpaused, time-scaled time, independent of frame rate. A frame longer than the interval takes one sample and resyncs instead of bursting to catch up.

Headless tests: the two watch tests no longer pin `_sample_interval`; a new check feeds 1 s at 240 fps and 1 s at 30 fps at 10 Hz and expects ~10 samples from each, plus one sample (no burst) from a 500 ms stall.

Also in this round:

- **#379** `godot_scene3d` get_bounds / get_spatial_info now include GridMap. GridMap is a plain Node3D drawing through its own RenderingServer instances, so `_collect_bounds` never saw it. A new `_local_bounds()` helper folds the placed cells: each cell contributes its library mesh AABB (item mesh transform, cell orientation, cell_scale, at `map_to_local`), or a cell_size box when the item has no mesh, so it covers what is actually drawn rather than just the grid. New headless test `scene3d_gridmap_bounds_test.gd` (10 checks).
- **#380** not implemented as an action. Everything in the proposal is reachable through `godot_exec` and the value is in the API knowledge, so that is written down once: a "Reading navigation state" section in `docs/runtime-state-guide.md` with a one-call recipe (including the next-point-below-agent stuck flag and the physics-tick sync rule), and the `godot_runtime_state` description points at it.

Dev version bumped to 4.1.8.

Closes #378
Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjW4wsS6DoBKNf5jEWPT3J