### PR TITLE
fix: numeric watch summaries say when min and max happened

### DIFF
--- a/docs/runtime-state-guide.md
+++ b/docs/runtime-state-guide.md
@@ -250,7 +250,8 @@ them in a digest (e.g. `/root/GameState`):
 ```
 
 then `{ "action": "watch_collect" }` returns a per-field summary
-(start/end/min/max/mean/slope plus events for numbers; transitions for strings). The raw
+(start/end/min/max/mean/slope for numbers, with `min_at`/`max_at` giving the `t_ms`
+of the first sample at each extreme, plus sign-change events; transitions for strings). The raw
 per-frame samples never reach the agent, so the cost is bounded by field count, not window
 length. See [Tools Reference -> Runtime State](tools/runtime-state.md) for the full surface.
 

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.9"
+version="4.1.10"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/tools/runtime-state.test.ts
+++ b/server/src/__tests__/tools/runtime-state.test.ts
@@ -528,6 +528,8 @@ describe('runtimeState tool', () => {
       expect(summary.samples).toBe(5);
       expect(summary.start).toBe(100);
       expect(summary.end).toBe(250);
+      expect(summary.min_at).toBe(0);
+      expect(summary.max_at).toBe(1000);
       expect(summary.min).toBe(100);
       expect(summary.max).toBe(250);
       expect(summary.slope).toBe(150); // (250-100) / 1.0s
@@ -774,7 +776,7 @@ describe('buildTimeline', () => {
   it('ignores numeric field summaries entirely', () => {
     const fields = {
       '/root/P:vel.x': {
-        samples: 2, start: 0, end: 5, min: 0, max: 5, mean: 2.5, slope: 5,
+        samples: 2, start: 0, end: 5, min: 0, max: 5, min_at: 0, max_at: 50, mean: 2.5, slope: 5,
         events: [{ t_ms: 50, from: 0, to: 5, kind: 'zero_cross' as const }],
       },
     };
@@ -787,7 +789,7 @@ describe('buildTimeline', () => {
 describe('summarizeNumericField', () => {
   it('returns zeros for empty input', () => {
     const r = summarizeNumericField([], 1000);
-    expect(r).toEqual({ samples: 0, start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] });
+    expect(r).toEqual({ samples: 0, start: 0, end: 0, min: 0, max: 0, min_at: 0, max_at: 0, mean: 0, slope: 0, events: [] });
   });
 
   it('handles single sample', () => {
@@ -842,6 +844,25 @@ describe('summarizeNumericField', () => {
 });
 
 // ── summarizeStringField unit tests ──────────────────────────────────────────
+
+describe('summarizeNumericField min_at/max_at', () => {
+  it('timestamps the first sample at min and max', () => {
+    const r = summarizeNumericField(
+      [
+        { t_ms: 0, value: 58 },
+        { t_ms: 50, value: 58 },
+        { t_ms: 100, value: 69 },
+        { t_ms: 150, value: 69 },
+        { t_ms: 200, value: 58 },
+      ],
+      200
+    );
+    expect(r.min).toBe(58);
+    expect(r.min_at).toBe(0);
+    expect(r.max).toBe(69);
+    expect(r.max_at).toBe(100);
+  });
+});
 
 describe('summarizeStringField', () => {
   it('returns empty result for empty input', () => {

--- a/server/src/tools/runtime-state.ts
+++ b/server/src/tools/runtime-state.ts
@@ -80,6 +80,10 @@ export interface NumericFieldSummary {
   end: number;
   min: number;
   max: number;
+  // t_ms of the FIRST sample at min/max: says when an excursion happened, which
+  // start/end/mean cannot (#384). A fact from the samples, not a change heuristic.
+  min_at: number;
+  max_at: number;
   mean: number;
   slope: number;
   events: Array<{ t_ms: number; from: number; to: number; kind: 'sign_change' | 'zero_cross' }>;
@@ -102,7 +106,7 @@ export function summarizeNumericField(
   windowMs: number
 ): NumericFieldSummary {
   if (samples.length === 0) {
-    return { samples: 0, start: 0, end: 0, min: 0, max: 0, mean: 0, slope: 0, events: [] };
+    return { samples: 0, start: 0, end: 0, min: 0, max: 0, min_at: 0, max_at: 0, mean: 0, slope: 0, events: [] };
   }
 
   const values = samples.map((s) => s.value as number);
@@ -110,6 +114,8 @@ export function summarizeNumericField(
   const last = values[values.length - 1];
   const min = Math.min(...values);
   const max = Math.max(...values);
+  const minAt = samples[values.indexOf(min)].t_ms;
+  const maxAt = samples[values.indexOf(max)].t_ms;
   const mean = Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 100) / 100;
   const slope = windowMs > 0 ? Math.round(((last - first) / (windowMs / 1000)) * 100) / 100 : 0;
 
@@ -124,7 +130,7 @@ export function summarizeNumericField(
     }
   }
 
-  return { samples: samples.length, start: first, end: last, min, max, mean, slope, events };
+  return { samples: samples.length, start: first, end: last, min, max, min_at: minAt, max_at: maxAt, mean, slope, events };
 }
 
 export function summarizeStringField(samples: WatchRawSample[]): StringFieldSummary {


### PR DESCRIPTION
Partial for #384: numeric field summaries from `watch_collect`/`watch_stop` now carry `min_at` and `max_at`, the `t_ms` of the first sample at each extreme. That answers the question in the issue (when did the bar go to 69) with a fact read from the samples rather than a change-detection rule.

The step-event / `field_change` part of the proposal is not implemented; reasoning on the issue.

Server-side only, no addon change. Dev version bumped to 4.1.10.

Refs #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjW4wsS6DoBKNf5jEWPT3J