### PR TITLE
fix: step report, watch final sample, grouped tilemap cell reads (4.1.11)

### DIFF
--- a/docs/tools/game-time.md
+++ b/docs/tools/game-time.md
@@ -29,6 +29,7 @@ Advance a bounded slice of game time, then re-freeze. Freezes first if the game 
 | `duration_ms` | integer | No | Game time to advance in milliseconds (max 50000; loop steps for longer). Scaled by Engine.time_scale like normal play. Mutually exclusive with frames. |
 | `frames` | integer | No | Frames to advance instead of a duration (max 1200). frames: 1 is a single-frame advance. Mutually exclusive with duration_ms. |
 | `inputs` | array | No | Input timeline executed inside the window; start_ms is game time from window start. Entries share the godot_input sequence vocabulary: named actions (with analog strength), joypad buttons, axis holds, stick vectors, raw keys (with modifier combos), and relative mouse-look (look: [dx, dy], delivered as InputEventMouseMotion.relative inside the frozen step — the FPS-camera testing path). Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end. |
+| `report` | string[] | No | Optional GDScript expressions evaluated on the window's last frame and returned as a { expression: value } map, exactly as for step_until (same scope: autoloads by name, `tree`, `root`, engine singletons). Reads what the inputs did in the same call instead of a follow-up exec. |
 
 #### `step_until`
 

--- a/docs/tools/tilemap.md
+++ b/docs/tools/tilemap.md
@@ -43,7 +43,7 @@ Get the layer's TileSet info
 
 #### `get_used_cells`
 
-Get all used cells
+All used cells grouped by tile: tiles[] of {source_id, atlas_coords, alternative_tile, count, cells: [[x, y], ...]}. Answers "where is tile T" in one call; a few bytes per cell.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -60,7 +60,7 @@ Get a single cell
 
 #### `get_cells_in_region`
 
-Get cells within a rectangular region
+Cells within a rectangular region, grouped by tile exactly like get_used_cells.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -221,7 +221,7 @@ Get the GridMap's MeshLibrary info
 
 #### `get_used_cells`
 
-Get all used cells
+All used cells grouped by MeshLibrary item: items[] of {item, count, cells: [[x, y, z], ...]}. Orientation per cell is in get_cell / get_cells_by_item.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/godot/addons/godot_mcp/commands/tilemap_commands.gd
+++ b/godot/addons/godot_mcp/commands/tilemap_commands.gd
@@ -190,12 +190,33 @@ func get_used_cells(params: Dictionary) -> Dictionary:
 			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
 		return _error("NOT_TILEMAP_LAYER", "Node is not a TileMapLayer: %s" % node_path)
 
-	var cells := layer.get_used_cells()
-	var result := []
-	for cell in cells:
-		result.append(_serialize_vector2i(cell))
+	return _success(_group_cells_by_tile(layer, layer.get_used_cells()))
 
-	return _success({"cells": result, "count": result.size()})
+
+## Cells grouped by tile identity (#387): one entry per distinct
+## source/atlas/alternative, each with its cell list as [x, y] pairs. Answers
+## "where is tile T" directly and costs a few bytes a cell, where a flat
+## per-cell object list was ~90 bytes a cell and still had to be grouped by
+## the reader. Cell data is base64 in the .tscn, so this is the only read path.
+func _group_cells_by_tile(layer: TileMapLayer, cells: Array) -> Dictionary:
+	var groups: Dictionary = {}  # "src:ax,ay:alt" -> tile entry (insertion order kept)
+	for cell in cells:
+		var source_id := layer.get_cell_source_id(cell)
+		var atlas_coords := layer.get_cell_atlas_coords(cell)
+		var alt_tile := layer.get_cell_alternative_tile(cell)
+		var key := "%d:%d,%d:%d" % [source_id, atlas_coords.x, atlas_coords.y, alt_tile]
+		if not groups.has(key):
+			groups[key] = {
+				"source_id": source_id,
+				"atlas_coords": _serialize_vector2i(atlas_coords),
+				"alternative_tile": alt_tile,
+				"count": 0,
+				"cells": [],
+			}
+		var entry: Dictionary = groups[key]
+		entry["count"] += 1
+		(entry["cells"] as Array).append([cell.x, cell.y])
+	return {"count": cells.size(), "tiles": groups.values()}
 
 
 func get_cell(params: Dictionary) -> Dictionary:
@@ -320,20 +341,12 @@ func get_cells_in_region(params: Dictionary) -> Dictionary:
 	var min_coords := _deserialize_vector2i(params["min_coords"])
 	var max_coords := _deserialize_vector2i(params["max_coords"])
 
-	var cells := []
+	var cells: Array = []
 	for cell in layer.get_used_cells():
 		if cell.x >= min_coords.x and cell.x <= max_coords.x and cell.y >= min_coords.y and cell.y <= max_coords.y:
-			var source_id := layer.get_cell_source_id(cell)
-			var atlas_coords := layer.get_cell_atlas_coords(cell)
-			var alt_tile := layer.get_cell_alternative_tile(cell)
-			cells.append({
-				"coords": _serialize_vector2i(cell),
-				"source_id": source_id,
-				"atlas_coords": _serialize_vector2i(atlas_coords),
-				"alternative_tile": alt_tile
-			})
+			cells.append(cell)
 
-	return _success({"cells": cells, "count": cells.size()})
+	return _success(_group_cells_by_tile(layer, cells))
 
 
 func set_cells_batch(params: Dictionary) -> Dictionary:
@@ -500,12 +513,19 @@ func get_gridmap_used_cells(params: Dictionary) -> Dictionary:
 			return _error("NODE_NOT_FOUND", "Node not found: %s" % node_path)
 		return _error("NOT_GRIDMAP", "Node is not a GridMap: %s" % node_path)
 
+	# Grouped by MeshLibrary item (#387), cells as [x, y, z]; orientation is a
+	# per-cell detail left to get_cell / get_cells_by_item.
 	var cells := gridmap.get_used_cells()
-	var result := []
+	var groups: Dictionary = {}
 	for cell in cells:
-		result.append(_serialize_vector3i(cell))
+		var item := gridmap.get_cell_item(cell)
+		if not groups.has(item):
+			groups[item] = {"item": item, "count": 0, "cells": []}
+		var entry: Dictionary = groups[item]
+		entry["count"] += 1
+		(entry["cells"] as Array).append([cell.x, cell.y, cell.z])
 
-	return _success({"cells": result, "count": result.size()})
+	return _success({"count": cells.size(), "items": groups.values()})
 
 
 func get_gridmap_cell(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_game_bridge.gd
@@ -1598,7 +1598,8 @@ var _step_last_tree_paused := false
 # fixed-budget step, set for step_until; _step_response_type routes _finish_step's
 # reply to the matching command (the relay correlates by message type). _step_report
 # is the optional readings the agent wants back at stop time (in one round-trip,
-# instead of a separate observation call) — each is [{src: String, expr: Expression}].
+# instead of a separate observation call), for both step kinds — each is
+# [{src: String, expr: Expression}]; _step_predicate_inputs is their context.
 var _step_predicate: Expression = null
 var _step_predicate_inputs: Array = []
 var _step_predicate_met := false
@@ -1734,6 +1735,19 @@ func _handle_game_time_step(data: Array) -> void:
 		return
 	_step_input_kinds = compiled["kinds"]
 
+	# Optional readings at stop time, same contract as step_until's report (#388):
+	# parsed up front in the predicate context, evaluated on the window's last frame.
+	var report_compiled: Array = []
+	var report_inputs: Array = []
+	if not (params.get("report", []) as Array).is_empty():
+		var ctx := _build_predicate_context()
+		var report_result := _compile_report(params.get("report", []), ctx["names"], ctx["inputs"])
+		if report_result.has("error"):
+			_send_game_time_response("game_time_step", {"error": report_result["error"]})
+			return
+		report_compiled = report_result["report"]
+		report_inputs = ctx["inputs"]
+
 	# Step from a running game is allowed — it freezes first, so "advance
 	# 500ms then wait for me" is a single atomic call.
 	_engage_freeze()
@@ -1753,6 +1767,8 @@ func _handle_game_time_step(data: Array) -> void:
 	_step_wall_start = Time.get_ticks_msec()
 	_step_wall_budget_ms = int(params.get("wall_budget_ms", STEP_WALL_BUDGET_MS))
 	_step_predicate = null
+	_step_predicate_inputs = report_inputs
+	_step_report = report_compiled
 	_step_response_type = "game_time_step"
 	_step_active = true
 
@@ -2309,7 +2325,7 @@ func _finish_step() -> void:
 	# gates wall-clock resyncs on it must see the same answer during the last
 	# processed frame and at report time.
 	var report_values: Dictionary = {}
-	if _step_predicate != null and not _step_report.is_empty():
+	if not _step_report.is_empty():
 		report_values = _evaluate_report(_step_report, _step_predicate_inputs)
 
 	_step_active = false
@@ -2337,13 +2353,14 @@ func _finish_step() -> void:
 		result["pause_transitions"] = _step_transitions
 	if _step_wall_exceeded:
 		result["wall_budget_exceeded"] = true
+	# report carries the readings the agent asked for (the "what advanced" hint,
+	# so it need not re-observe), for step and step_until alike (#388).
+	if not _step_report.is_empty():
+		result["report"] = report_values
 	if _step_predicate != null:
-		# step_until: predicate_met is the headline. report carries the readings the
-		# agent asked for (the "what advanced" hint, so it need not re-observe). A
-		# non-met return means the cap or wall budget ran out first.
+		# step_until: predicate_met is the headline. A non-met return means the
+		# cap or wall budget ran out first.
 		result["predicate_met"] = _step_predicate_met
-		if not _step_report.is_empty():
-			result["report"] = report_values
 		if not _step_predicate_error.is_empty():
 			result["predicate_error"] = _step_predicate_error
 

--- a/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
+++ b/godot/addons/godot_mcp/game_bridge/mcp_runtime_state_sampler.gd
@@ -23,6 +23,9 @@ var _elapsed_ms: float = 0.0
 # differs from it -- launched frozen the reading is 0, after a long freeze it is
 # stale -- and the window then fills 2-4x faster or slower than asked (#378).
 var _next_sample_ms: float = 0.0
+# True once game time has advanced past the last recorded sample, so stop() and
+# collect() know the recorded `end` is stale and take one more (#389).
+var _advanced_since_sample: bool = false
 var _samples: Dictionary = {}  # field_key -> Array of {t_ms, value}
 var _events: Array = []        # [{t_ms, source, signal, args?}] -- signal emissions this window
 var _events_truncated: bool = false
@@ -32,6 +35,14 @@ var _signal_counts: Dictionary = {}    # "source:signal" -> kept count (enforces
 var _signal_dropped: Dictionary = {}   # "source:signal" -> dropped count (reported to the agent)
 var _field_truncated: Dictionary = {}  # full_key -> true once MAX_SAMPLES_PER_FIELD was hit
 var _connections: Array = []   # [{node, sig_name, callable}] -- live connections to tear down
+
+
+func _ready() -> void:
+	# Autoloads (and their children) are processed BEFORE scene nodes, so a
+	# sample taken at default priority reflects the state from before this
+	# frame's game logic ran and every reading is one frame stale. Run late in
+	# the frame so a sample stamped at frame N shows what frame N did (#389).
+	process_priority = 1000
 
 
 func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) -> Dictionary:
@@ -49,6 +60,7 @@ func start(specs: Array, hz: int, duration_ms: int, signal_specs: Array = []) ->
 	_duration_ms = clampi(duration_ms, 100, 5000)
 	_elapsed_ms = 0.0
 	_next_sample_ms = 0.0  # first unpaused frame samples immediately (t ~= one delta)
+	_advanced_since_sample = false
 
 	# resolved_fields counts fields that are READABLE at start (node found and a
 	# probe read returned a value), not node lookups. Every field that isn't is
@@ -261,6 +273,7 @@ func _process(delta: float) -> void:
 		return
 
 	if _elapsed_ms < _next_sample_ms:
+		_advanced_since_sample = true
 		return
 	var interval_ms := 1000.0 / float(_hz)
 	_next_sample_ms += interval_ms
@@ -268,7 +281,16 @@ func _process(delta: float) -> void:
 		# A frame longer than the interval (stall, or a big single step): take one
 		# sample now and resync rather than bursting to make up the missed ticks.
 		_next_sample_ms = _elapsed_ms + interval_ms
+	_sample_fields()
 
+
+# One sample of every field at the current game time. Called on schedule from
+# _process, and once more by stop()/collect() when frames ran after the last
+# scheduled sample, so `end` is the value at the moment of the read (under a
+# freeze, the exact frame the game is sitting on) and not the last thing the
+# schedule happened to catch.
+func _sample_fields() -> void:
+	_advanced_since_sample = false
 	for spec in _specs:
 		# Untyped: a typed assignment of a freed instance is a script error that
 		# would abort the whole sampling pass (same hazard as _disconnect_all).
@@ -295,6 +317,8 @@ func _process(delta: float) -> void:
 
 
 func collect() -> Dictionary:
+	if _active and _advanced_since_sample:
+		_sample_fields()
 	var elapsed := int(_elapsed_ms)
 	var total_samples := 0
 	for key in _samples:
@@ -316,6 +340,8 @@ func collect() -> Dictionary:
 func stop() -> Dictionary:
 	# _elapsed_ms already holds the game-time window and freezes once _active is
 	# false, so a late manual stop can't inflate window_ms past the real window end.
+	if _active and _advanced_since_sample:
+		_sample_fields()  # `end` is the frame the game is sitting on (#389)
 	_active = false
 	set_process(false)
 	_disconnect_all()

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Model Context Protocol server for AI assistant integration"
 author="godot-mcp"
-version="4.1.10"
+version="4.1.11"
 script="plugin.gd"
 godot_version_min="4.5"

--- a/godot/addons/godot_mcp/test/tilemap_grouped_cells_test.gd
+++ b/godot/addons/godot_mcp/test/tilemap_grouped_cells_test.gd
@@ -1,0 +1,76 @@
+extends SceneTree
+## Headless check for #387: tilemap/gridmap used-cell reads are grouped by tile.
+##   godot --headless --path <project> --script res://addons/godot_mcp/test/tilemap_grouped_cells_test.gd
+
+var _n := 0
+var _fail := 0
+var _ran := false
+
+
+func _check(label: String, got, want) -> void:
+	_n += 1
+	if got == want:
+		print("ok %d - %s" % [_n, label])
+	else:
+		_fail += 1
+		print("not ok %d - %s (got %s, want %s)" % [_n, label, got, want])
+
+
+func _process(_delta: float) -> bool:
+	if _ran:
+		return false
+	_ran = true
+	print("===================== TILEMAP GROUPED CELLS TEST =====================")
+	var cmds = load("res://addons/godot_mcp/commands/tilemap_commands.gd").new()
+
+	var tileset := TileSet.new()
+	var src := TileSetAtlasSource.new()
+	var tex := PlaceholderTexture2D.new()
+	tex.size = Vector2(64, 64)
+	src.texture = tex
+	src.texture_region_size = Vector2i(16, 16)
+	src.create_tile(Vector2i(0, 0))
+	src.create_tile(Vector2i(2, 0))
+	tileset.add_source(src, 0)
+	var layer := TileMapLayer.new()
+	layer.tile_set = tileset
+	root.add_child(layer)
+	# 4x3 floor of tile (0,0) with two hazards (2,0) at (1,1) and (3,2).
+	for y in 3:
+		for x in 4:
+			var is_hazard := (x == 1 and y == 1) or (x == 3 and y == 2)
+			layer.set_cell(Vector2i(x, y), 0, Vector2i(2, 0) if is_hazard else Vector2i(0, 0))
+
+	var res: Dictionary = cmds._group_cells_by_tile(layer, layer.get_used_cells())
+	_check("count is the total cell count", res.get("count"), 12)
+	var tiles: Array = res.get("tiles", [])
+	_check("one group per distinct tile", tiles.size(), 2)
+	var by_atlas := {}
+	for t in tiles:
+		by_atlas["%d,%d" % [t.atlas_coords.x, t.atlas_coords.y]] = t
+	_check("floor group has 10 cells", by_atlas["0,0"].count, 10)
+	_check("hazard group has 2 cells", by_atlas["2,0"].count, 2)
+	_check("hazard cells are [x, y] pairs", by_atlas["2,0"].cells, [[1, 1], [3, 2]])
+	_check("group carries source_id", by_atlas["2,0"].source_id, 0)
+	_check("group carries alternative_tile", by_atlas["2,0"].alternative_tile, 0)
+	_check("group cells sum to count", by_atlas["0,0"].cells.size() + by_atlas["2,0"].cells.size(), 12)
+
+	var region: Array = []
+	for c in layer.get_used_cells():
+		if c.x >= 2 and c.y >= 1:
+			region.append(c)
+	var reg: Dictionary = cmds._group_cells_by_tile(layer, region)
+	_check("region subset: count", reg.get("count"), 4)
+	var reg_hazard := 0
+	for t in reg.get("tiles", []):
+		if t.atlas_coords.x == 2:
+			reg_hazard = t.count
+	_check("region subset: hazard inside region", reg_hazard, 1)
+
+	var empty: Dictionary = cmds._group_cells_by_tile(layer, [])
+	_check("empty: count 0 and no groups", empty.get("count") == 0 and (empty.get("tiles") as Array).is_empty(), true)
+
+	print("1..%d" % _n)
+	print("ALL PASS - %d checks" % _n if _fail == 0 else "FAILED - %d of %d" % [_fail, _n])
+	quit(0 if _fail == 0 else 1)
+	return true

--- a/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
+++ b/godot/addons/godot_mcp/test/watch_timeline_headless_test.gd
@@ -52,6 +52,7 @@ func _run() -> void:
 	_test_freeze_pauses_sampling(sampler, emitter)
 	_test_hz_is_game_time(sampler)
 	_test_field_reporting(sampler)
+	_test_final_sample_on_stop(sampler)
 	_test_arg_caps(sampler, emitter)
 	await _test_window_semantics(sampler, emitter)
 	await _test_auto_stop(sampler, emitter)
@@ -290,6 +291,29 @@ func _test_field_reporting(sampler: MCPRuntimeStateSampler) -> void:
 	var w: Array = fields.get("/root/Bar:size.x", [])
 	_check("fields: Control size.x sampled", w.size() == 1 and w[0].value == 100.0, true)
 	ctl.queue_free()
+
+
+func _test_final_sample_on_stop(sampler: MCPRuntimeStateSampler) -> void:
+	# #389: a value that flips on a frame with no scheduled sample must still be
+	# the `end` of the window when stop()/collect() read it.
+	var fake: Node = root.get_node("/root/FakeAutoload")
+	var before = fake.score
+	fake.score = 1
+	sampler.start([{"path": "/root/FakeAutoload", "fields": ["score"]}], 10, 5000, [])
+	sampler._process(0.01)  # first frame samples (score 1)
+	fake.score = 2
+	sampler._process(0.01)  # 20 ms in, next sample not due until 100 ms
+	var mid: Array = (sampler.collect().get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", [])
+	_check("final sample: collect sees the flip the schedule missed", mid.back().value, 2.0)
+	_check("final sample: collect took exactly one extra sample", mid.size(), 2)
+	var again: Array = (sampler.collect().get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", [])
+	_check("final sample: a second collect with no new frames adds nothing", again.size(), 2)
+	fake.score = 3
+	sampler._process(0.01)
+	var fin: Array = (sampler.stop().get("fields", {}) as Dictionary).get("/root/FakeAutoload:score", [])
+	_check("final sample: stop ends on the current value", fin.back().value, 3.0)
+	_check("final sample: sampler runs late in the frame", sampler.process_priority > 0, true)
+	fake.score = before
 
 
 func _test_arg_caps(sampler: MCPRuntimeStateSampler, emitter: _Emitter) -> void:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satelliteoflove/godot-mcp",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satelliteoflove/godot-mcp",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "MCP server that gives AI assistants eyes and hands in the Godot editor: scene editing, input injection, deterministic game-time control, and live runtime state for agent-driven playtesting",
   "type": "module",
   "main": "dist/index.js",

--- a/server/server.json
+++ b/server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.satelliteoflove/godot-mcp",
   "title": "Godot MCP",
   "description": "Agent-driven Godot playtesting: editor control, input injection, game-time stepping, live state.",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "repository": {
     "url": "https://github.com/satelliteoflove/godot-mcp",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@satelliteoflove/godot-mcp",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/server/src/__tests__/core/__toolsnaps__/godot_game_time.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_game_time.json
@@ -291,6 +291,14 @@
           ]
         }
       },
+      "report": {
+        "description": "for step: Optional GDScript expressions evaluated on the window's last frame and returned as a { expression: value } map, exactly as for step_until (same scope: autoloads by name, `tree`, `root`, engine singletons). Reads what the inputs did in the same call instead of a follow-up exec.; for step_until: Optional GDScript expressions (same scope as `until`) evaluated when stepping stops and returned as a { expression: value } map — e.g. [\"G.wave\", \"tree.get_nodes_in_group(\\\"enemies\\\").size()\"]. Use this to read the state you care about in the same call instead of a separate observation round-trip. Each must parse up front, but is only evaluated when stepping stops, so it may read state the step itself creates (a spawned node); an expression that fails then comes back as { error: message } in the map without failing the call. Game code can tell it is inside a step window via `get_node(\"/root/MCPGameBridge\").is_stepping()`. (for: step, step_until)",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
       "until": {
         "type": "string",
         "minLength": 1,
@@ -301,14 +309,6 @@
         "type": "integer",
         "minimum": 1,
         "maximum": 50000
-      },
-      "report": {
-        "description": "Optional GDScript expressions (same scope as `until`) evaluated when stepping stops and returned as a { expression: value } map — e.g. [\"G.wave\", \"tree.get_nodes_in_group(\\\"enemies\\\").size()\"]. Use this to read the state you care about in the same call instead of a separate observation round-trip. Each must parse up front, but is only evaluated when stepping stops, so it may read state the step itself creates (a spawned node); an expression that fails then comes back as { error: message } in the map without failing the call. Game code can tell it is inside a step window via `get_node(\"/root/MCPGameBridge\").is_stepping()`. (for: step_until)",
-        "type": "array",
-        "items": {
-          "type": "string",
-          "minLength": 1
-        }
       }
     },
     "required": [

--- a/server/src/__tests__/core/__toolsnaps__/godot_gridmap_read.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_gridmap_read.json
@@ -14,7 +14,7 @@
           "get_cell",
           "get_cells_by_item"
         ],
-        "description": "list: List GridMap nodes in the scene\nget_info: Get GridMap info\nget_meshlib_info: Get the GridMap's MeshLibrary info\nget_used_cells: Get all used cells\nget_cell: Get a single cell\nget_cells_by_item: Get all cells using a given MeshLibrary item"
+        "description": "list: List GridMap nodes in the scene\nget_info: Get GridMap info\nget_meshlib_info: Get the GridMap's MeshLibrary info\nget_used_cells: All used cells grouped by MeshLibrary item: items[] of {item, count, cells: [[x, y, z], ...]}. Orientation per cell is in get_cell / get_cells_by_item.\nget_cell: Get a single cell\nget_cells_by_item: Get all cells using a given MeshLibrary item"
       },
       "root_path": {
         "description": "Starting node path (defaults to scene root) (for: list)",

--- a/server/src/__tests__/core/__toolsnaps__/godot_tilemap_read.json
+++ b/server/src/__tests__/core/__toolsnaps__/godot_tilemap_read.json
@@ -15,7 +15,7 @@
           "get_cells_in_region",
           "convert_coords"
         ],
-        "description": "list_layers: List TileMapLayer nodes in the scene\nget_info: Get TileMapLayer info\nget_tileset_info: Get the layer's TileSet info\nget_used_cells: Get all used cells\nget_cell: Get a single cell\nget_cells_in_region: Get cells within a rectangular region\nconvert_coords: Convert between local position and map coordinates"
+        "description": "list_layers: List TileMapLayer nodes in the scene\nget_info: Get TileMapLayer info\nget_tileset_info: Get the layer's TileSet info\nget_used_cells: All used cells grouped by tile: tiles[] of {source_id, atlas_coords, alternative_tile, count, cells: [[x, y], ...]}. Answers \"where is tile T\" in one call; a few bytes per cell.\nget_cell: Get a single cell\nget_cells_in_region: Cells within a rectangular region, grouped by tile exactly like get_used_cells.\nconvert_coords: Convert between local position and map coordinates"
       },
       "root_path": {
         "description": "Starting node path (defaults to scene root) (for: list_layers)",

--- a/server/src/__tests__/tools/game-time.test.ts
+++ b/server/src/__tests__/tools/game-time.test.ts
@@ -46,6 +46,8 @@ describe('game_time tool', () => {
       expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', max_ms: 0 }).success).toBe(false);
       expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', report: ['G.wave', 'G.score'] }).success).toBe(true);
       expect(gameTime.schema.safeParse({ action: 'step_until', until: 'true', report: [''] }).success).toBe(false);
+      expect(gameTime.schema.safeParse({ action: 'step', frames: 1, report: ['G.wave'] }).success).toBe(true);
+      expect(gameTime.schema.safeParse({ action: 'step', frames: 1, report: [''] }).success).toBe(false);
       expect(gameTime.schema.safeParse({
         action: 'step_until',
         until: 'true',
@@ -304,6 +306,31 @@ describe('game_time tool', () => {
       expect(data.predicate_met).toBe(true);
       expect(data.report).toEqual({ 'G.wave': 1 });
       expect(data.elapsed_ms).toBe(4317);
+    });
+
+    it('step forwards report and surfaces its readings (#388)', async () => {
+      mock.mockResponse({
+        completed: true,
+        frozen: true,
+        elapsed_ms: 560,
+        gameplay_ms: 560,
+        frames: 34,
+        physics_ticks: 34,
+        game_paused: false,
+        input_kinds: { action: 1, joy_button: 0, axis: 0, key: 0, look: 0 },
+        report: { 'Conductor.last_input_judgment': 'perfect' },
+      });
+      const ctx = createToolContext(mock);
+      const data = structuredOf(
+        await gameTime.execute(
+          { action: 'step', duration_ms: 560, report: ['Conductor.last_input_judgment'] },
+          ctx
+        )
+      );
+      expect(mock.calls[0].command).toBe('game_time_step');
+      expect(mock.calls[0].params.report).toEqual(['Conductor.last_input_judgment']);
+      expect(data.report).toEqual({ 'Conductor.last_input_judgment': 'perfect' });
+      expect(data.predicate_met).toBeUndefined();
     });
 
     it('reports predicate_met false when the cap is hit first', async () => {

--- a/server/src/__tests__/tools/tilemap.test.ts
+++ b/server/src/__tests__/tools/tilemap.test.ts
@@ -41,7 +41,7 @@ describe('tilemap read tool', () => {
       node_path: '/root/Ground',
     }, ctx) as string)).toHaveProperty('tile_size');
 
-    mock.mockResponse({ cells: [{ x: 0, y: 0 }], count: 1 });
+    mock.mockResponse({ count: 1, tiles: [{ source_id: 0, atlas_coords: { x: 0, y: 0 }, alternative_tile: 0, count: 1, cells: [[0, 0]] }] });
     expect(structuredOf(await tilemapRead.execute({
       action: 'get_used_cells',
       node_path: '/root/Ground',
@@ -59,7 +59,7 @@ describe('tilemap read tool', () => {
     }, ctx);
     expect(mock.calls[0].params.coords).toEqual({ x: 5, y: 10 });
 
-    mock.mockResponse({ cells: [], count: 0 });
+    mock.mockResponse({ count: 0, tiles: [] });
     await tilemapRead.execute({
       action: 'get_cells_in_region',
       node_path: '/root/Ground',

--- a/server/src/tools/game-time.ts
+++ b/server/src/tools/game-time.ts
@@ -58,6 +58,10 @@ const GameTimeSchema = z
         .array(InputEntrySchema)
         .optional()
         .describe('Input timeline executed inside the window; start_ms is game time from window start. Entries share the godot_input sequence vocabulary: named actions (with analog strength), joypad buttons, axis holds, stick vectors, raw keys (with modifier combos), and relative mouse-look (look: [dx, dy], delivered as InputEventMouseMotion.relative inside the frozen step — the FPS-camera testing path). Inputs must ride inside the step — events injected while frozen miss their is_action_just_pressed edge. Holds are always released by window end.'),
+      report: z
+        .array(z.string().min(1))
+        .optional()
+        .describe('Optional GDScript expressions evaluated on the window\'s last frame and returned as a { expression: value } map, exactly as for step_until (same scope: autoloads by name, `tree`, `root`, engine singletons). Reads what the inputs did in the same call instead of a follow-up exec.'),
     }),
     z.object({
       action: z
@@ -115,9 +119,9 @@ interface StepResult {
   pause_transitions?: Array<{ at_ms: number; paused: boolean }>;
   wall_budget_exceeded?: boolean;
   input_kinds?: Record<string, number>;
+  report?: Record<string, unknown>;
   // step_until only:
   predicate_met?: boolean;
-  report?: Record<string, unknown>;
   predicate_error?: string;
 }
 
@@ -145,6 +149,7 @@ export const gameTime = defineTool({
         const result = await godot.sendCommand<StepResult>('game_time_step', {
           duration_ms: args.duration_ms,
           frames: args.frames,
+          report: args.report,
           inputs: compileInputEntries(args.inputs ?? []),
           relay_timeout_ms: t.relayMs,
           wall_budget_ms: t.bridgeWallMs,

--- a/server/src/tools/tilemap.ts
+++ b/server/src/tools/tilemap.ts
@@ -23,14 +23,14 @@ const TilemapReadSchema = z.discriminatedUnion('action', [
   }),
   z.object({ action: z.literal('get_info').describe('Get TileMapLayer info'), node_path: tilemapNodePath }),
   z.object({ action: z.literal('get_tileset_info').describe("Get the layer's TileSet info"), node_path: tilemapNodePath }),
-  z.object({ action: z.literal('get_used_cells').describe('Get all used cells'), node_path: tilemapNodePath }),
+  z.object({ action: z.literal('get_used_cells').describe('All used cells grouped by tile: tiles[] of {source_id, atlas_coords, alternative_tile, count, cells: [[x, y], ...]}. Answers "where is tile T" in one call; a few bytes per cell.'), node_path: tilemapNodePath }),
   z.object({
     action: z.literal('get_cell').describe('Get a single cell'),
     node_path: tilemapNodePath,
     coords: Vector2iSchema.describe('Cell coordinates'),
   }),
   z.object({
-    action: z.literal('get_cells_in_region').describe('Get cells within a rectangular region'),
+    action: z.literal('get_cells_in_region').describe('Cells within a rectangular region, grouped by tile exactly like get_used_cells.'),
     node_path: tilemapNodePath,
     min_coords: Vector2iSchema.describe('Minimum corner of region'),
     max_coords: Vector2iSchema.describe('Maximum corner of region'),
@@ -197,7 +197,7 @@ const GridmapReadSchema = z.discriminatedUnion('action', [
   }),
   z.object({ action: z.literal('get_info').describe('Get GridMap info'), node_path: gridmapNodePath }),
   z.object({ action: z.literal('get_meshlib_info').describe("Get the GridMap's MeshLibrary info"), node_path: gridmapNodePath }),
-  z.object({ action: z.literal('get_used_cells').describe('Get all used cells'), node_path: gridmapNodePath }),
+  z.object({ action: z.literal('get_used_cells').describe('All used cells grouped by MeshLibrary item: items[] of {item, count, cells: [[x, y, z], ...]}. Orientation per cell is in get_cell / get_cells_by_item.'), node_path: gridmapNodePath }),
   z.object({
     action: z.literal('get_cell').describe('Get a single cell'),
     node_path: gridmapNodePath,


### PR DESCRIPTION
Three issues, each root-caused past the report.

**#389** `watch_stop`/`watch_collect` `end` could contradict the timeline in the same reply. Two causes: autoloads process before scene nodes, so every sample reflected the state from before that frame's game logic (one frame stale, always), and `stop()` summarized whatever the schedule last caught. The sampler now runs late in the frame (`process_priority`), and stop/collect take one extra sample only when frames ran after the last scheduled one, so the count is not inflated by mid-window collects. Headless test: flip on an unscheduled frame is the `end`; a second collect with no new frames adds nothing.

**#388** `step` takes `report`, same scope and semantics as `step_until`. The evaluation was already in `_finish_step`, gated on a predicate for no reason. Schema, relay and result plumbing on the server; unit test.

**#387** `get_used_cells` had no tile identity and `get_cells_in_region` cost ~90 bytes a cell. Rather than a format switch or a skip rule, both now return the same grouped shape: `tiles[]` of `{source_id, atlas_coords, alternative_tile, count, cells: [[x, y], ...]}`, with region as a filter. GridMap `get_used_cells` is grouped by item (`items[]` of `{item, count, cells: [[x, y, z], ...]}`). No new actions or parameters; the reply shape of those three read actions changes. New headless test `tilemap_grouped_cells_test.gd` (11 checks).

Dev version bumped to 4.1.11. Note: #390 (4.1.10) is still open and touches the same version lines; merge that first and I'll rebase, or the two can go in either order with a trivial conflict.

Closes #387
Closes #388
Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjW4wsS6DoBKNf5jEWPT3J